### PR TITLE
feat: Dashboard layout transformation

### DIFF
--- a/src/components/cards/CardGrid.tsx
+++ b/src/components/cards/CardGrid.tsx
@@ -1,0 +1,71 @@
+/**
+ * Auto-fill grid container for CellCards.
+ * Reads from multiCellResults and renders a card for each selected cell.
+ * Only scrollable area in the dashboard.
+ *
+ * Uses selectedCells() (stable number primitives) as the <For> source
+ * so that SolidJS can match items by value across solver updates,
+ * keeping CellCard instances alive and preserving their zoom state.
+ */
+
+import { For, Show, createMemo } from 'solid-js';
+import { CellCard } from './CellCard';
+import {
+  selectedCells,
+  multiCellResults,
+  solvingCells,
+  activelySolvingCell,
+  gridColumns,
+} from '../../lib/multi-cell-store';
+import { samplingRate } from '../../lib/data-store';
+import { selectedCell } from '../../lib/viz-store';
+import '../../styles/cards.css';
+
+export interface CardGridProps {
+  onCellClick: (cellIndex: number) => void;
+}
+
+export function CardGrid(props: CardGridProps) {
+  const cells = createMemo(() => selectedCells());
+
+  return (
+    <div class="card-grid-container">
+      <Show
+        when={cells().length > 0}
+        fallback={
+          <div class="card-grid__empty">
+            No cell results yet. Adjust parameters to solve.
+          </div>
+        }
+      >
+        <div class="card-grid" style={{ '--grid-cols': gridColumns() }}>
+          <For each={cells()}>
+            {(cellIndex) => {
+              const traces = createMemo(() => multiCellResults().get(cellIndex));
+              return (
+                <Show when={traces()}>
+                  {(t) => (
+                    <CellCard
+                      cellIndex={cellIndex}
+                      rawTrace={t().raw}
+                      deconvolvedTrace={t().deconvolved}
+                      reconvolutionTrace={t().reconvolution}
+                      samplingRate={samplingRate() ?? 30}
+                      isActive={selectedCell() === cellIndex}
+                      solverStatus={
+                        activelySolvingCell() === cellIndex ? 'solving'
+                          : solvingCells().has(cellIndex) ? 'stale'
+                          : 'fresh'
+                      }
+                      onClick={() => props.onCellClick(cellIndex)}
+                    />
+                  )}
+                </Show>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/cards/CellCard.tsx
+++ b/src/components/cards/CellCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * Individual cell card with overview (minimap) + zoom window.
+ * Self-contained visualization for one cell in the card grid.
+ */
+
+import { createSignal, createMemo, createEffect, Show } from 'solid-js';
+import { TraceOverview } from './TraceOverview';
+import { ZoomWindow } from './ZoomWindow';
+import { QualityBadge } from '../metrics/QualityBadge';
+import type { SolverStatus } from '../metrics/QualityBadge';
+import { computePeakSNR, snrToQuality } from '../../lib/metrics/snr';
+
+export interface CellCardProps {
+  cellIndex: number;
+  rawTrace: Float64Array;
+  deconvolvedTrace?: Float64Array;
+  reconvolutionTrace?: Float64Array;
+  samplingRate: number;
+  isActive?: boolean;
+  solverStatus?: SolverStatus;
+  onClick?: () => void;
+}
+
+const DEFAULT_ZOOM_WINDOW_S = 60; // 60 seconds default zoom window
+const ZOOM_SYNC_KEY = 'catune-card-zoom';
+
+export function CellCard(props: CellCardProps) {
+  const totalDuration = createMemo(() => props.rawTrace.length / props.samplingRate);
+
+  // Quality badge
+  const snr = createMemo(() => computePeakSNR(props.rawTrace));
+  const quality = createMemo(() => snrToQuality(snr()));
+
+  // Per-card independent zoom window
+  const initialEnd = () => Math.min(DEFAULT_ZOOM_WINDOW_S, totalDuration());
+  const [zoomStart, setZoomStart] = createSignal(0);
+  const [zoomEnd, setZoomEnd] = createSignal(initialEnd());
+
+  // Sync zoom end when trace changes
+  createEffect(() => {
+    const dur = totalDuration();
+    if (zoomEnd() > dur) setZoomEnd(dur);
+    if (zoomEnd() <= zoomStart()) setZoomEnd(Math.min(zoomStart() + DEFAULT_ZOOM_WINDOW_S, dur));
+  });
+
+  const handleZoomChange = (start: number, end: number) => {
+    setZoomStart(start);
+    setZoomEnd(end);
+  };
+
+  return (
+    <div
+      class={`cell-card${props.isActive ? ' cell-card--active' : ''}`}
+      onClick={() => props.onClick?.()}
+    >
+      <div class="cell-card__header">
+        <span class="cell-card__title">
+          <QualityBadge quality={quality()} snr={snr()} solverStatus={props.solverStatus} />
+          {' '}Cell {props.cellIndex + 1}
+        </span>
+      </div>
+
+      <Show when={props.rawTrace.length > 0}>
+        <div class="cell-card__overview">
+          <TraceOverview
+            trace={props.rawTrace}
+            samplingRate={props.samplingRate}
+            zoomStart={zoomStart()}
+            zoomEnd={zoomEnd()}
+            onZoomChange={handleZoomChange}
+          />
+        </div>
+
+        <div class="cell-card__zoom">
+          <ZoomWindow
+            rawTrace={props.rawTrace}
+            deconvolvedTrace={props.deconvolvedTrace}
+            reconvolutionTrace={props.reconvolutionTrace}
+            samplingRate={props.samplingRate}
+            startTime={zoomStart()}
+            endTime={zoomEnd()}
+            syncKey={`${ZOOM_SYNC_KEY}-${props.cellIndex}`}
+            onZoomChange={handleZoomChange}
+          />
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/cards/TraceOverview.tsx
+++ b/src/components/cards/TraceOverview.tsx
@@ -1,0 +1,239 @@
+/**
+ * Multi-row full-trace overview with interactive minimap.
+ * Draws the entire recording as a thin canvas, split into rows of ~20min.
+ * Highlighted region shows the current zoom window position.
+ * Click/drag to reposition the zoom window.
+ */
+
+import { createEffect, createMemo, onCleanup, onMount } from 'solid-js';
+import { downsampleMinMax } from '../../lib/chart/downsample';
+import { makeTimeAxis } from '../../lib/chart/time-axis';
+
+export interface TraceOverviewProps {
+  trace: Float64Array;
+  samplingRate: number;
+  /** Zoom window start time (seconds) */
+  zoomStart: number;
+  /** Zoom window end time (seconds) */
+  zoomEnd: number;
+  /** Called when the user clicks/drags to reposition the zoom window */
+  onZoomChange: (startTime: number, endTime: number) => void;
+}
+
+const ROW_HEIGHT = 24;
+const ROW_DURATION_S = 20 * 60; // 20 minutes per row
+const PIXELS_PER_ROW = 600; // target downsample width per row
+
+export function TraceOverview(props: TraceOverviewProps) {
+  let canvasRef: HTMLCanvasElement | undefined;
+  let containerRef: HTMLDivElement | undefined;
+
+  const totalDuration = createMemo(() => props.trace.length / props.samplingRate);
+  const numRows = createMemo(() => Math.max(1, Math.ceil(totalDuration() / ROW_DURATION_S)));
+
+  const canvasHeight = createMemo(() => numRows() * ROW_HEIGHT);
+
+  // Compute row data once when trace changes
+  const rowData = createMemo(() => {
+    const trace = props.trace;
+    const fs = props.samplingRate;
+    const rows = numRows();
+    const samplesPerRow = Math.floor(ROW_DURATION_S * fs);
+    const result: { dsX: number[]; dsY: number[]; timeOffset: number }[] = [];
+
+    for (let r = 0; r < rows; r++) {
+      const start = r * samplesPerRow;
+      const end = Math.min(start + samplesPerRow, trace.length);
+      if (start >= trace.length) break;
+
+      const segment = trace.subarray(start, end);
+      const x = makeTimeAxis(segment.length, fs);
+      const [dsX, dsY] = downsampleMinMax(x, segment, PIXELS_PER_ROW);
+      result.push({ dsX, dsY, timeOffset: start / fs });
+    }
+    return result;
+  });
+
+  // Draw the overview canvas
+  function draw() {
+    const canvas = canvasRef;
+    if (!canvas) return;
+    const container = containerRef;
+    if (!container) return;
+
+    const dpr = devicePixelRatio;
+    const width = container.clientWidth;
+    if (width <= 0) return;
+
+    canvas.width = width * dpr;
+    canvas.height = canvasHeight() * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${canvasHeight()}px`;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, canvasHeight());
+
+    const rows = rowData();
+    const duration = totalDuration();
+
+    // Find global min/max for consistent y-scaling
+    let globalMin = Infinity;
+    let globalMax = -Infinity;
+    for (const row of rows) {
+      for (const v of row.dsY) {
+        if (v < globalMin) globalMin = v;
+        if (v > globalMax) globalMax = v;
+      }
+    }
+    const yRange = globalMax - globalMin || 1;
+
+    for (let r = 0; r < rows.length; r++) {
+      const row = rows[r];
+      const rowY = r * ROW_HEIGHT;
+      const rowDuration = r < rows.length - 1
+        ? ROW_DURATION_S
+        : duration - r * ROW_DURATION_S;
+
+      // Draw zoom window highlight for this row
+      const zoomStart = props.zoomStart;
+      const zoomEnd = props.zoomEnd;
+      const rowStartTime = row.timeOffset;
+      const rowEndTime = rowStartTime + rowDuration;
+
+      if (zoomEnd > rowStartTime && zoomStart < rowEndTime) {
+        const hlStart = Math.max(0, (zoomStart - rowStartTime) / rowDuration) * width;
+        const hlEnd = Math.min(1, (zoomEnd - rowStartTime) / rowDuration) * width;
+        ctx.fillStyle = 'rgba(83, 199, 240, 0.15)';
+        ctx.fillRect(hlStart, rowY, hlEnd - hlStart, ROW_HEIGHT);
+
+        // Border lines for highlight
+        ctx.strokeStyle = 'rgba(83, 199, 240, 0.4)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(hlStart, rowY, hlEnd - hlStart, ROW_HEIGHT);
+      }
+
+      // Draw trace line
+      ctx.strokeStyle = 'hsl(200, 60%, 50%)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+
+      for (let i = 0; i < row.dsX.length; i++) {
+        const xPos = (row.dsX[i] / rowDuration) * width;
+        const yPos = rowY + ROW_HEIGHT - ((row.dsY[i] - globalMin) / yRange) * (ROW_HEIGHT - 4) - 2;
+
+        if (i === 0) ctx.moveTo(xPos, yPos);
+        else ctx.lineTo(xPos, yPos);
+      }
+      ctx.stroke();
+    }
+  }
+
+  createEffect(() => {
+    // Track reactive dependencies
+    props.trace;
+    props.zoomStart;
+    props.zoomEnd;
+    draw();
+  });
+
+  // ResizeObserver for container width changes
+  let resizeRaf: number | undefined;
+  const resizeObserver = new ResizeObserver(() => {
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(draw);
+  });
+
+  onMount(() => {
+    if (containerRef) resizeObserver.observe(containerRef);
+  });
+
+  onCleanup(() => {
+    resizeObserver.disconnect();
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
+  });
+
+  // Convert pixel coordinates to time position
+  const pixelToTime = (x: number, y: number): number | null => {
+    if (!containerRef) return null;
+    const width = containerRef.clientWidth;
+    if (width <= 0) return null;
+
+    const rowIndex = Math.floor(y / ROW_HEIGHT);
+    const rows = rowData();
+    if (rowIndex < 0 || rowIndex >= rows.length) return null;
+
+    const row = rows[rowIndex];
+    const duration = totalDuration();
+    const rowDuration = rowIndex < rows.length - 1
+      ? ROW_DURATION_S
+      : duration - rowIndex * ROW_DURATION_S;
+
+    const tFraction = Math.max(0, Math.min(1, x / width));
+    return row.timeOffset + tFraction * rowDuration;
+  };
+
+  // Clamp and emit a zoom window centered on a time position
+  const emitCentered = (centerTime: number, windowDuration: number) => {
+    const duration = totalDuration();
+    let newStart = centerTime - windowDuration / 2;
+    let newEnd = newStart + windowDuration;
+
+    if (newStart < 0) { newStart = 0; newEnd = windowDuration; }
+    if (newEnd > duration) { newEnd = duration; newStart = Math.max(0, duration - windowDuration); }
+
+    props.onZoomChange(newStart, newEnd);
+  };
+
+  // Click + drag handler for repositioning zoom window
+  const handleMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!containerRef) return;
+    const rect = containerRef.getBoundingClientRect();
+    const startX = e.clientX - rect.left;
+    const startY = e.clientY - rect.top;
+    const windowDuration = props.zoomEnd - props.zoomStart;
+    let dragged = false;
+
+    const onMove = (ev: MouseEvent) => {
+      ev.preventDefault();
+      dragged = true;
+      const mx = ev.clientX - rect.left;
+      const my = ev.clientY - rect.top;
+      const time = pixelToTime(mx, my);
+      if (time != null) emitCentered(time, windowDuration);
+    };
+
+    const onUp = (ev: MouseEvent) => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+
+      if (!dragged) {
+        // No drag — treat as click: center on position
+        const cx = ev.clientX - rect.left;
+        const cy = ev.clientY - rect.top;
+        const time = pixelToTime(cx, cy);
+        if (time != null) emitCentered(time, windowDuration);
+      }
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      class="trace-overview"
+      onMouseDown={handleMouseDown}
+      style={{ cursor: 'grab' }}
+    >
+      <canvas ref={canvasRef} class="trace-overview__canvas" />
+    </div>
+  );
+}

--- a/src/components/cards/ZoomWindow.tsx
+++ b/src/components/cards/ZoomWindow.tsx
@@ -1,0 +1,209 @@
+/**
+ * Zoomed analysis window showing raw + deconvolved + reconvolved traces
+ * for a configurable time window. Uses uPlot via TracePanel.
+ */
+
+import { createMemo, createSignal, Show } from 'solid-js';
+import type uPlot from 'uplot';
+import { TracePanel } from '../traces/TracePanel';
+import { downsampleMinMax } from '../../lib/chart/downsample';
+import { createRawSeries, createFitSeries, createDeconvolvedSeries } from '../../lib/chart/series-config';
+
+export interface ZoomWindowProps {
+  rawTrace: Float64Array;
+  deconvolvedTrace?: Float64Array;
+  reconvolutionTrace?: Float64Array;
+  samplingRate: number;
+  /** Zoom window start time (seconds) */
+  startTime: number;
+  /** Zoom window end time (seconds) */
+  endTime: number;
+  height?: number;
+  syncKey: string;
+  /** Called when the user scrolls to zoom in/out in time */
+  onZoomChange?: (startTime: number, endTime: number) => void;
+}
+
+const ZOOM_BUCKET_WIDTH = 800;
+const DECONV_GAP = -2; // z-score offset: negative = deconv peaks overlap raw range
+const DECONV_SCALE = 0.35; // scale deconvolved to this fraction of raw z-range
+
+export function ZoomWindow(props: ZoomWindowProps) {
+  const height = () => props.height ?? 150;
+
+  // Z-score stats from full raw trace — consistent across zoom levels
+  const rawStats = createMemo(() => {
+    const raw = props.rawTrace;
+    if (!raw || raw.length === 0) return { mean: 0, std: 1 };
+    let sum = 0;
+    for (let i = 0; i < raw.length; i++) sum += raw[i];
+    const mean = sum / raw.length;
+    let ssq = 0;
+    for (let i = 0; i < raw.length; i++) ssq += (raw[i] - mean) ** 2;
+    const std = Math.sqrt(ssq / raw.length) || 1;
+    return { mean, std };
+  });
+
+  // Global y-range in z-score space, with room for deconv offset below
+  const globalYRange = createMemo<[number, number]>(() => {
+    const raw = props.rawTrace;
+    const { mean, std } = rawStats();
+    if (!raw || raw.length === 0) return [-4, 6];
+
+    // Find z-scored min/max of raw trace
+    let zMin = Infinity;
+    let zMax = -Infinity;
+    for (let i = 0; i < raw.length; i++) {
+      const z = (raw[i] - mean) / std;
+      if (z < zMin) zMin = z;
+      if (z > zMax) zMax = z;
+    }
+
+    // Deconv sits below raw: baseline at deconvBottom, peaks up to deconvTop
+    const deconvHeight = (zMax - zMin) * DECONV_SCALE;
+    const deconvBottom = zMin - DECONV_GAP - deconvHeight;
+    return [deconvBottom, zMax + (zMax - zMin) * 0.02];
+  });
+
+  const zoomData = createMemo<[number[], ...number[][]]>(() => {
+    const raw = props.rawTrace;
+    const fs = props.samplingRate;
+    if (!raw || raw.length === 0) return [[], [], [], []];
+
+    const startSample = Math.max(0, Math.floor(props.startTime * fs));
+    const endSample = Math.min(raw.length, Math.ceil(props.endTime * fs));
+    if (startSample >= endSample) return [[], [], [], []];
+
+    const len = endSample - startSample;
+    const { mean, std } = rawStats();
+
+    // Build time axis for the window
+    const x = new Float64Array(len);
+    const dt = 1 / fs;
+    for (let i = 0; i < len; i++) {
+      x[i] = (startSample + i) * dt;
+    }
+
+    // Raw trace — z-score normalized
+    const rawSlice = raw.subarray(startSample, endSample);
+    const [dsX, dsRawRaw] = downsampleMinMax(x, rawSlice, ZOOM_BUCKET_WIDTH);
+    const dsRaw = dsRawRaw.map(v => (v - mean) / std);
+
+    // Reconvolution trace — same z-score as raw (it approximates the raw)
+    const reconv = props.reconvolutionTrace;
+    let dsReconv: number[];
+    if (reconv && reconv.length === raw.length) {
+      const reconvSlice = reconv.subarray(startSample, endSample);
+      let dsReconvRaw: number[];
+      [, dsReconvRaw] = downsampleMinMax(x, reconvSlice, ZOOM_BUCKET_WIDTH);
+      dsReconv = dsReconvRaw.map(v => (v - mean) / std);
+    } else {
+      dsReconv = new Array(dsX.length).fill(null) as number[];
+    }
+
+    // Deconvolved trace — normalize to [0,1] then scale + offset below raw
+    const deconv = props.deconvolvedTrace;
+    let dsDeconv: number[];
+    if (deconv && deconv.length === raw.length) {
+      const deconvSlice = deconv.subarray(startSample, endSample);
+      let dsDeconvRaw: number[];
+      [, dsDeconvRaw] = downsampleMinMax(x, deconvSlice, ZOOM_BUCKET_WIDTH);
+
+      // Find global deconv min/max for consistent normalization
+      let dMin = Infinity;
+      let dMax = -Infinity;
+      for (let i = 0; i < deconv.length; i++) {
+        if (deconv[i] < dMin) dMin = deconv[i];
+        if (deconv[i] > dMax) dMax = deconv[i];
+      }
+      const dRange = dMax - dMin || 1;
+
+      // Find raw z-range for proportional scaling
+      let zMin = Infinity;
+      let zMax = -Infinity;
+      for (let i = 0; i < raw.length; i++) {
+        const z = (raw[i] - mean) / std;
+        if (z < zMin) zMin = z;
+        if (z > zMax) zMax = z;
+      }
+
+      // Deconv peaks point UP from a baseline below the raw trace
+      const deconvHeight = (zMax - zMin) * DECONV_SCALE;
+      const deconvTop = zMin - DECONV_GAP;           // top of deconv peaks
+      const deconvBottom = deconvTop - deconvHeight;  // baseline of deconv
+      dsDeconv = dsDeconvRaw.map(v => {
+        const norm = (v - dMin) / dRange; // [0, 1]
+        return deconvBottom + norm * deconvHeight;    // peaks go up
+      });
+    } else {
+      dsDeconv = new Array(dsX.length).fill(null) as number[];
+    }
+
+    return [dsX, dsRaw, dsDeconv, dsReconv];
+  });
+
+  const seriesConfig = createMemo<uPlot.Series[]>(() => {
+    return [{}, createRawSeries(), createDeconvolvedSeries(), createFitSeries()];
+  });
+
+  const ZOOM_FACTOR = 0.75;
+  const MIN_WINDOW_S = 1; // minimum 1 second zoom window
+
+  const [showHint, setShowHint] = createSignal(false);
+  let hintTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const handleWheel = (e: WheelEvent) => {
+    if (!props.onZoomChange) return;
+
+    // Require Ctrl (or Cmd on Mac) for zoom — bare scroll passes through for page scrolling
+    if (!e.ctrlKey && !e.metaKey) {
+      // Show hint briefly
+      setShowHint(true);
+      clearTimeout(hintTimer);
+      hintTimer = setTimeout(() => setShowHint(false), 1500);
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const totalDuration = props.rawTrace.length / props.samplingRate;
+    const currentRange = props.endTime - props.startTime;
+
+    // Zoom in (scroll up) or out (scroll down)
+    const newRange = e.deltaY < 0
+      ? Math.max(MIN_WINDOW_S, currentRange * ZOOM_FACTOR)
+      : Math.min(totalDuration, currentRange / ZOOM_FACTOR);
+
+    // Center zoom on cursor horizontal position
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const cursorFraction = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    const cursorTime = props.startTime + cursorFraction * currentRange;
+
+    let newStart = cursorTime - cursorFraction * newRange;
+    let newEnd = newStart + newRange;
+
+    // Clamp to data bounds
+    if (newStart < 0) { newStart = 0; newEnd = newRange; }
+    if (newEnd > totalDuration) { newEnd = totalDuration; newStart = Math.max(0, totalDuration - newRange); }
+
+    props.onZoomChange(newStart, newEnd);
+  };
+
+  return (
+    <div class="zoom-window" onWheel={handleWheel} style={{ position: 'relative' }}>
+      <TracePanel
+        data={() => zoomData()}
+        series={seriesConfig()}
+        height={height()}
+        syncKey={props.syncKey}
+        disableWheelZoom={!!props.onZoomChange}
+        yRange={globalYRange()}
+        hideYValues
+      />
+      <Show when={showHint()}>
+        <div class="zoom-hint">Hold Ctrl to zoom</div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/community/CommunityBrowser.tsx
+++ b/src/components/community/CommunityBrowser.tsx
@@ -39,7 +39,7 @@ export function CommunityBrowser() {
     brainRegion: null,
   });
   const [loading, setLoading] = createSignal(false);
-  const [collapsed, setCollapsed] = createSignal(true);
+  const [collapsed, setCollapsed] = createSignal(false);
   const [compareMyParams, setCompareMyParams] = createSignal(false);
   const [lastFetched, setLastFetched] = createSignal<number | null>(null);
   const [error, setError] = createSignal<string | null>(null);

--- a/src/components/community/ScatterPlot.tsx
+++ b/src/components/community/ScatterPlot.tsx
@@ -216,7 +216,25 @@ export function ScatterPlot(props: ScatterPlotProps) {
     uplotInstance = new uPlot(opts, data, containerRef);
   });
 
+  // ResizeObserver: resize chart when sidebar opens/closes
+  let resizeRaf: number | undefined;
+  const resizeObserver = new ResizeObserver(() => {
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(() => {
+      if (uplotInstance && containerRef) {
+        const w = containerRef.clientWidth;
+        if (w > 0) uplotInstance.setSize({ width: w, height: 340 });
+      }
+    });
+  });
+
+  createEffect(() => {
+    if (containerRef) resizeObserver.observe(containerRef);
+  });
+
   onCleanup(() => {
+    resizeObserver.disconnect();
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
     if (uplotInstance) {
       uplotInstance.destroy();
       uplotInstance = undefined;

--- a/src/components/controls/CellSelector.tsx
+++ b/src/components/controls/CellSelector.tsx
@@ -13,6 +13,8 @@ import {
   selectedCells,
   setSelectedCells,
   updateCellSelection,
+  gridColumns,
+  setGridColumns,
 } from '../../lib/multi-cell-store';
 import { numCells } from '../../lib/data-store';
 import '../../styles/multi-trace.css';
@@ -54,6 +56,13 @@ export function CellSelector(props: CellSelectorProps) {
     props.onSelectionChange();
   };
 
+  const handleGridColumnsChange = (e: Event) => {
+    const value = parseInt((e.target as HTMLInputElement).value, 10);
+    if (!isNaN(value) && value >= 1 && value <= 6) {
+      setGridColumns(value);
+    }
+  };
+
   const handleReshuffle = () => {
     updateCellSelection();
     props.onSelectionChange();
@@ -89,6 +98,15 @@ export function CellSelector(props: CellSelectorProps) {
           />
         </div>
       </Show>
+
+      <div class="cell-selector__group">
+        <label class="cell-selector__label">Grid columns</label>
+        <div class="cell-selector__stepper">
+          <button class="cell-selector__step-btn" onClick={() => gridColumns() > 1 && setGridColumns(gridColumns() - 1)}>−</button>
+          <span class="cell-selector__step-value">{gridColumns()}</span>
+          <button class="cell-selector__step-btn" onClick={() => gridColumns() < 6 && setGridColumns(gridColumns() + 1)}>+</button>
+        </div>
+      </div>
 
       <Show when={selectionMode() === 'random'}>
         <button class="btn-secondary btn-small" onClick={handleReshuffle}>

--- a/src/components/controls/ParameterSlider.tsx
+++ b/src/components/controls/ParameterSlider.tsx
@@ -39,7 +39,7 @@ export function ParameterSlider(props: ParameterSliderProps) {
     const raw = parseFloat((e.target as HTMLInputElement).value);
     if (isNaN(raw)) return;
     const val = props.fromSlider ? props.fromSlider(raw) : raw;
-    props.setValue(() => val);
+    props.setValue(val);
   };
 
   // Range input: commit on mouse release (pushes to undo history)
@@ -55,7 +55,7 @@ export function ParameterSlider(props: ParameterSliderProps) {
     const raw = parseFloat((e.target as HTMLInputElement).value);
     if (isNaN(raw)) return;
     const clamped = Math.max(props.min, Math.min(props.max, raw));
-    props.setValue(() => clamped);
+    props.setValue(clamped);
   };
 
   // Numeric input: commit on blur/enter
@@ -68,30 +68,32 @@ export function ParameterSlider(props: ParameterSliderProps) {
 
   return (
     <div class="param-slider" data-tutorial={props['data-tutorial']}>
-      <label class="param-slider__label">{props.label}</label>
-      <div class="param-slider__controls">
-        <input
-          type="range"
-          class="param-slider__range"
-          min={props.toSlider ? 0 : props.min}
-          max={props.toSlider ? 1 : props.max}
-          step={props.toSlider ? 0.001 : props.step}
-          value={sliderValue()}
-          onInput={handleRangeInput}
-          onChange={handleRangeChange}
-        />
-        <input
-          type="number"
-          class="param-slider__number"
-          value={displayValue()}
-          min={props.min}
-          max={props.max}
-          step={props.step}
-          onInput={handleNumericInput}
-          onChange={handleNumericChange}
-        />
-        {props.unit && <span class="param-slider__unit">{props.unit}</span>}
+      <div class="param-slider__header">
+        <label class="param-slider__label">{props.label}</label>
+        <span class="param-slider__inline-value">
+          <input
+            type="number"
+            class="param-slider__number"
+            value={displayValue()}
+            min={props.min}
+            max={props.max}
+            step={props.step}
+            onInput={handleNumericInput}
+            onChange={handleNumericChange}
+          />
+          {props.unit && <span class="param-slider__unit">{props.unit}</span>}
+        </span>
       </div>
+      <input
+        type="range"
+        class="param-slider__range"
+        min={props.toSlider ? 0 : props.min}
+        max={props.toSlider ? 1 : props.max}
+        step={props.toSlider ? 0.001 : props.step}
+        value={sliderValue()}
+        onInput={handleRangeInput}
+        onChange={handleRangeChange}
+      />
     </div>
   );
 }

--- a/src/components/layout/CompactHeader.tsx
+++ b/src/components/layout/CompactHeader.tsx
@@ -1,0 +1,73 @@
+import { Show, type Accessor } from 'solid-js';
+import { rawFile, effectiveShape, samplingRate, durationSeconds, resetImport } from '../../lib/data-store';
+import { clearMultiCellState } from '../../lib/multi-cell-store';
+import { supabaseEnabled } from '../../lib/supabase';
+import { sidebarOpen, setSidebarOpen } from './DashboardShell';
+import { TutorialLauncher } from '../tutorial/TutorialLauncher';
+import '../../styles/compact-header.css';
+
+export interface CompactHeaderProps {
+  tutorialOpen: Accessor<boolean>;
+  onTutorialToggle: () => void;
+}
+
+export function CompactHeader(props: CompactHeaderProps) {
+  const handleChangeData = () => {
+    clearMultiCellState();
+    resetImport();
+  };
+
+  const durationDisplay = () => {
+    const d = durationSeconds();
+    if (d === null) return null;
+    const minutes = d / 60;
+    if (minutes >= 1) return `${minutes.toFixed(1)} min`;
+    return `${d.toFixed(1)}s`;
+  };
+
+  return (
+    <header class="compact-header">
+      <div class="compact-header__brand">
+        <span class="compact-header__title">CaTune</span>
+        <span class="compact-header__version">{import.meta.env.VITE_APP_VERSION || 'dev'}</span>
+      </div>
+
+      <div class="compact-header__info">
+        <Show when={rawFile()}>
+          {(file) => (
+            <span class="compact-header__file">{file().name}</span>
+          )}
+        </Show>
+        <Show when={effectiveShape()}>
+          {(shape) => (<>
+            <span class="compact-header__sep">&middot;</span>
+            <span>{shape()[0]} cells</span>
+            <span class="compact-header__sep">&middot;</span>
+            <span>{shape()[1].toLocaleString()} tp</span>
+          </>)}
+        </Show>
+        <Show when={samplingRate()}>
+          <span class="compact-header__sep">&middot;</span>
+          <span>{samplingRate()} Hz</span>
+        </Show>
+        <Show when={durationDisplay()}>
+          <span class="compact-header__sep">&middot;</span>
+          <span>{durationDisplay()}</span>
+        </Show>
+      </div>
+
+      <div class="compact-header__actions">
+        <TutorialLauncher isOpen={props.tutorialOpen} onToggle={props.onTutorialToggle} />
+        <button
+          class={`btn-secondary btn-small${sidebarOpen() ? ' btn-active' : ''}`}
+          onClick={() => setSidebarOpen(prev => !prev)}
+        >
+          Sidebar
+        </button>
+        <button class="btn-secondary btn-small" onClick={handleChangeData}>
+          Change Data
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -1,0 +1,27 @@
+import { createSignal, type JSX, type ParentComponent } from 'solid-js';
+
+export interface DashboardShellProps {
+  header: JSX.Element;
+  sidebar?: JSX.Element;
+  children: JSX.Element;
+}
+
+// Sidebar state — exported so CompactHeader can toggle it
+const [sidebarOpen, setSidebarOpen] = createSignal(false);
+export { sidebarOpen, setSidebarOpen };
+
+export const DashboardShell: ParentComponent<DashboardShellProps> = (props) => {
+  return (
+    <div class={`dashboard-shell${sidebarOpen() ? ' dashboard-shell--sidebar-open' : ''}`}>
+      <div class="dashboard-shell__header">
+        {props.header}
+      </div>
+      <div class="dashboard-shell__main">
+        {props.children}
+      </div>
+      <div class="dashboard-shell__sidebar">
+        {props.sidebar}
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/ImportOverlay.tsx
+++ b/src/components/layout/ImportOverlay.tsx
@@ -1,0 +1,175 @@
+import { Show, type JSX } from 'solid-js';
+import { FileDropZone } from '../FileDropZone';
+import { NpzArraySelector } from '../NpzArraySelector';
+import { DimensionConfirmation } from '../DimensionConfirmation';
+import { SamplingRateInput } from '../SamplingRateInput';
+import { DataValidationReport } from '../DataValidationReport';
+import { TracePreview } from '../TracePreview';
+import {
+  importStep,
+  rawFile,
+  effectiveShape,
+  samplingRate,
+  durationSeconds,
+  validationResult,
+  npzArrays,
+} from '../../lib/data-store';
+
+const STEP_LABELS: Record<string, { num: number; label: string }> = {
+  'drop':          { num: 1, label: 'Load Data' },
+  'confirm-dims':  { num: 2, label: 'Confirm Dimensions' },
+  'sampling-rate': { num: 3, label: 'Set Sampling Rate' },
+  'validation':    { num: 4, label: 'Validate Data' },
+  'ready':         { num: 4, label: 'Ready' },
+};
+
+const TOTAL_STEPS = 4;
+
+export interface ImportOverlayProps {
+  hasFile: boolean;
+  onReset: () => void;
+  onLoadDemo: () => void;
+}
+
+export function ImportOverlay(props: ImportOverlayProps): JSX.Element {
+  const step = () => importStep();
+  const stepInfo = () => STEP_LABELS[step()] ?? { num: 1, label: 'Load Data' };
+
+  const durationDisplay = () => {
+    const d = durationSeconds();
+    if (d === null) return null;
+    const minutes = d / 60;
+    if (minutes >= 1) return `${d.toFixed(1)}s (${minutes.toFixed(1)} min)`;
+    return `${d.toFixed(1)}s`;
+  };
+
+  return (
+    <main class="import-container">
+      {/* Header */}
+      <header class="app-header" data-tutorial="app-header">
+        <h1 class="app-header__title">CaTune <span class="app-header__version">{import.meta.env.VITE_APP_VERSION || 'dev'}</span></h1>
+        <p class="app-header__subtitle">
+          Calcium Deconvolution Parameter Tuning
+        </p>
+      </header>
+
+      {/* Step indicator */}
+      <div class="step-indicator">
+        <div class="step-indicator__bar">
+          {[1, 2, 3, 4].map((n) => (
+            <div class={`step-dot ${n <= stepInfo().num ? 'step-dot--active' : ''} ${n === stepInfo().num ? 'step-dot--current' : ''}`}>
+              {n}
+            </div>
+          ))}
+        </div>
+        <p class="step-indicator__label">
+          Step {stepInfo().num} of {TOTAL_STEPS}: {stepInfo().label}
+        </p>
+      </div>
+
+      {/* Start Over button */}
+      <Show when={props.hasFile}>
+        <div class="start-over-row">
+          <button class="btn-secondary btn-small" onClick={props.onReset}>
+            Start Over
+          </button>
+        </div>
+      </Show>
+
+      {/* Step 1: File Drop */}
+      <Show when={step() === 'drop'}>
+        <FileDropZone />
+        <Show when={npzArrays()}>
+          <NpzArraySelector />
+        </Show>
+        <div class="demo-data-row">
+          <span class="demo-data-row__divider">or</span>
+          <button class="btn-secondary" onClick={props.onLoadDemo}>
+            Load Demo Data
+          </button>
+          <p class="demo-data-row__hint">
+            20 synthetic cells, 5 min at 30 Hz
+          </p>
+        </div>
+      </Show>
+
+      {/* Step 2: Confirm Dimensions */}
+      <Show when={step() === 'confirm-dims'}>
+        <div class="file-info-dimmed">
+          <FileDropZone />
+        </div>
+        <DimensionConfirmation />
+      </Show>
+
+      {/* Step 3: Sampling Rate */}
+      <Show when={step() === 'sampling-rate'}>
+        <Show when={effectiveShape()}>
+          {(shape) => (
+            <div class="info-summary">
+              <span>{shape()[0].toLocaleString()} cells</span>
+              <span class="info-summary__sep">&middot;</span>
+              <span>{shape()[1].toLocaleString()} timepoints</span>
+            </div>
+          )}
+        </Show>
+        <SamplingRateInput />
+      </Show>
+
+      {/* Step 4: Validation */}
+      <Show when={step() === 'validation'}>
+        <Show when={effectiveShape()}>
+          {(shape) => (
+            <div class="info-summary">
+              <span>{shape()[0].toLocaleString()} cells</span>
+              <span class="info-summary__sep">&middot;</span>
+              <span>{shape()[1].toLocaleString()} timepoints</span>
+              <span class="info-summary__sep">&middot;</span>
+              <span>{samplingRate()} Hz</span>
+            </div>
+          )}
+        </Show>
+        <DataValidationReport />
+      </Show>
+
+      {/* Step 5 (ready): shown briefly before dashboard transition */}
+      <Show when={step() === 'ready'}>
+        <div class="info-summary">
+          <Show when={rawFile()}>
+            {(file) => (<>
+              <span>{file().name}</span>
+              <span class="info-summary__sep">&middot;</span>
+            </>)}
+          </Show>
+          <Show when={effectiveShape()}>
+            {(shape) => (<>
+              <span>{shape()[0].toLocaleString()} cells</span>
+              <span class="info-summary__sep">&middot;</span>
+              <span>{shape()[1].toLocaleString()} timepoints</span>
+              <span class="info-summary__sep">&middot;</span>
+            </>)}
+          </Show>
+          <span>{samplingRate()} Hz</span>
+          <Show when={durationDisplay()}>
+            <span class="info-summary__sep">&middot;</span>
+            <span>{durationDisplay()}</span>
+          </Show>
+        </div>
+        <Show when={validationResult()}>
+          {(result) => (
+            <Show when={result().warnings.length > 0}>
+              <p class="text-warning" style="text-align: center; margin-bottom: 12px;">
+                {result().warnings.length} warning{result().warnings.length > 1 ? 's' : ''}
+              </p>
+            </Show>
+          )}
+        </Show>
+        <TracePreview />
+        <div class="card ready-card">
+          <p class="text-success" style="font-weight: 600; text-align: center;">
+            Data loaded and validated. Ready for parameter tuning.
+          </p>
+        </div>
+      </Show>
+    </main>
+  );
+}

--- a/src/components/layout/SidebarTabs.tsx
+++ b/src/components/layout/SidebarTabs.tsx
@@ -1,0 +1,44 @@
+/**
+ * Sidebar tab switcher: Community | Metrics
+ * Preserves component state by rendering both, hiding the inactive one.
+ */
+
+import { createSignal, type JSX } from 'solid-js';
+
+export type SidebarTab = 'community' | 'metrics';
+
+export interface SidebarTabsProps {
+  communityContent: JSX.Element;
+  metricsContent: JSX.Element;
+}
+
+export function SidebarTabs(props: SidebarTabsProps) {
+  const [activeTab, setActiveTab] = createSignal<SidebarTab>('community');
+
+  return (
+    <div class="sidebar-tabs">
+      <div class="sidebar-tabs__bar">
+        <button
+          class={`sidebar-tabs__tab${activeTab() === 'community' ? ' sidebar-tabs__tab--active' : ''}`}
+          onClick={() => setActiveTab('community')}
+        >
+          Community
+        </button>
+        <button
+          class={`sidebar-tabs__tab${activeTab() === 'metrics' ? ' sidebar-tabs__tab--active' : ''}`}
+          onClick={() => setActiveTab('metrics')}
+        >
+          Metrics
+        </button>
+      </div>
+      <div class="sidebar-tabs__content">
+        <div style={{ display: activeTab() === 'community' ? 'block' : 'none' }}>
+          {props.communityContent}
+        </div>
+        <div style={{ display: activeTab() === 'metrics' ? 'block' : 'none' }}>
+          {props.metricsContent}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/VizLayout.tsx
+++ b/src/components/layout/VizLayout.tsx
@@ -1,12 +1,25 @@
-import type { ParentComponent, JSX } from 'solid-js';
+import { type ParentComponent, type JSX, onMount, onCleanup } from 'solid-js';
 
 interface VizLayoutProps {
+  mode?: 'scroll' | 'dashboard';
   children: JSX.Element;
 }
 
 export const VizLayout: ParentComponent<VizLayoutProps> = (props) => {
+  const mode = () => props.mode ?? 'dashboard';
+
+  onMount(() => {
+    if (mode() === 'dashboard') {
+      document.documentElement.classList.add('dashboard-mode');
+    }
+  });
+
+  onCleanup(() => {
+    document.documentElement.classList.remove('dashboard-mode');
+  });
+
   return (
-    <div class="viz-layout viz-layout--scroll">
+    <div class={`viz-layout viz-layout--${mode()}`}>
       {props.children}
     </div>
   );

--- a/src/components/metrics/MetricsPanel.tsx
+++ b/src/components/metrics/MetricsPanel.tsx
@@ -1,0 +1,114 @@
+/**
+ * Aggregate metrics dashboard shown in the sidebar metrics tab.
+ * Displays signal quality and solver output metrics across all selected cells.
+ */
+
+import { createMemo, For, Show } from 'solid-js';
+import { multiCellResults } from '../../lib/multi-cell-store';
+import { computePeakSNR, snrToQuality } from '../../lib/metrics/snr';
+import { computeSparsityRatio, computeResidualRMS, computeRSquared } from '../../lib/metrics/solver-metrics';
+
+interface CellMetrics {
+  cellIndex: number;
+  snr: number;
+  quality: 'good' | 'fair' | 'poor';
+  sparsity: number;
+  residualRms: number;
+  rSquared: number;
+}
+
+export function MetricsPanel() {
+  const cellMetrics = createMemo<CellMetrics[]>(() => {
+    const results = multiCellResults();
+    const metrics: CellMetrics[] = [];
+
+    for (const [cellIndex, traces] of results.entries()) {
+      const snr = computePeakSNR(traces.raw);
+      metrics.push({
+        cellIndex,
+        snr,
+        quality: snrToQuality(snr),
+        sparsity: computeSparsityRatio(traces.deconvolved),
+        residualRms: computeResidualRMS(traces.raw, traces.reconvolution),
+        rSquared: computeRSquared(traces.raw, traces.reconvolution),
+      });
+    }
+
+    return metrics.sort((a, b) => b.snr - a.snr);
+  });
+
+  const avgSNR = createMemo(() => {
+    const m = cellMetrics();
+    if (m.length === 0) return 0;
+    return m.reduce((sum, c) => sum + c.snr, 0) / m.length;
+  });
+
+  const avgRSquared = createMemo(() => {
+    const m = cellMetrics();
+    if (m.length === 0) return 0;
+    return m.reduce((sum, c) => sum + c.rSquared, 0) / m.length;
+  });
+
+  const qualityColor = (q: string) => {
+    if (q === 'good') return 'var(--success)';
+    if (q === 'fair') return 'var(--warning)';
+    return 'var(--error)';
+  };
+
+  return (
+    <div class="metrics-panel">
+      <h3 class="metrics-panel__title">Metrics</h3>
+
+      <Show
+        when={cellMetrics().length > 0}
+        fallback={
+          <div class="metrics-panel__empty">
+            No cell results yet. Solve cells to see metrics.
+          </div>
+        }
+      >
+        {/* Aggregate stats */}
+        <div class="metrics-panel__summary">
+          <div class="metrics-panel__stat">
+            <span class="metrics-panel__stat-label">Avg SNR</span>
+            <span class="metrics-panel__stat-value">{avgSNR().toFixed(1)}</span>
+          </div>
+          <div class="metrics-panel__stat">
+            <span class="metrics-panel__stat-label">Avg R²</span>
+            <span class="metrics-panel__stat-value">{avgRSquared().toFixed(3)}</span>
+          </div>
+          <div class="metrics-panel__stat">
+            <span class="metrics-panel__stat-label">Cells</span>
+            <span class="metrics-panel__stat-value">{cellMetrics().length}</span>
+          </div>
+        </div>
+
+        {/* Per-cell table */}
+        <div class="metrics-panel__table">
+          <div class="metrics-panel__row metrics-panel__row--header">
+            <span>Cell</span>
+            <span>SNR</span>
+            <span>R²</span>
+            <span>Sparsity</span>
+          </div>
+          <For each={cellMetrics()}>
+            {(cell) => (
+              <div class="metrics-panel__row">
+                <span>
+                  <span
+                    class="metrics-panel__dot"
+                    style={{ background: qualityColor(cell.quality) }}
+                  />
+                  {cell.cellIndex + 1}
+                </span>
+                <span>{cell.snr.toFixed(1)}</span>
+                <span>{cell.rSquared.toFixed(3)}</span>
+                <span>{(cell.sparsity * 100).toFixed(0)}%</span>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/metrics/QualityBadge.tsx
+++ b/src/components/metrics/QualityBadge.tsx
@@ -1,0 +1,51 @@
+/**
+ * Per-card quality indicator badge.
+ * Small colored dot reflecting solver state:
+ *   - fresh: SNR-based color (green/yellow/red)
+ *   - solving: yellow pulse (actively running)
+ *   - stale: red (queued, results outdated)
+ */
+
+import type { QualityTier } from '../../lib/metrics/snr';
+
+export type SolverStatus = 'fresh' | 'solving' | 'stale';
+
+export interface QualityBadgeProps {
+  quality: QualityTier;
+  snr?: number;
+  solverStatus?: SolverStatus;
+}
+
+const COLORS: Record<QualityTier, string> = {
+  good: 'var(--success)',
+  fair: 'var(--warning)',
+  poor: 'var(--error)',
+};
+
+export function QualityBadge(props: QualityBadgeProps) {
+  const status = () => props.solverStatus ?? 'fresh';
+
+  const color = () => {
+    switch (status()) {
+      case 'solving': return 'var(--warning)';
+      case 'stale': return 'var(--error)';
+      default: return COLORS[props.quality];
+    }
+  };
+
+  const title = () => {
+    switch (status()) {
+      case 'solving': return 'Solving...';
+      case 'stale': return 'Stale — awaiting solver';
+      default: return props.snr != null ? `SNR: ${props.snr.toFixed(1)}` : undefined;
+    }
+  };
+
+  return (
+    <span
+      class={`quality-badge${status() === 'solving' ? ' quality-badge--solving' : ''}`}
+      title={title()}
+      style={{ background: color() }}
+    />
+  );
+}

--- a/src/components/traces/KernelDisplay.tsx
+++ b/src/components/traces/KernelDisplay.tsx
@@ -33,17 +33,13 @@ export function KernelDisplay() {
 
   return (
     <div class="kernel-section" data-tutorial="kernel-display">
-      <div class="kernel-section__header">
-        <h4 class="panel-label">Calcium Kernel</h4>
-        <p class="kernel-section__params">
-          tau_rise = {tauRise().toFixed(3)}s, tau_decay = {tauDecay().toFixed(2)}s
-        </p>
-      </div>
+      <h4 class="panel-label">Calcium Kernel</h4>
       <TracePanel
         data={() => kernelData()}
         series={kernelSeries}
-        height={100}
+        height={140}
         syncKey={KERNEL_SYNC_KEY}
+        xLabel="Time (s)"
       />
     </div>
   );

--- a/src/components/traces/MultiTraceView.tsx
+++ b/src/components/traces/MultiTraceView.tsx
@@ -11,11 +11,7 @@ import { TracePanel } from './TracePanel';
 import { downsampleMinMax } from '../../lib/chart/downsample';
 import { makeTimeAxis } from '../../lib/chart/time-axis';
 import { createRawSeries, createFitSeries } from '../../lib/chart/series-config';
-import {
-  multiCellResults,
-  multiCellSolving,
-  multiCellProgress,
-} from '../../lib/multi-cell-store';
+import { multiCellResults } from '../../lib/multi-cell-store';
 import { samplingRate } from '../../lib/data-store';
 import { selectedCell } from '../../lib/viz-store';
 
@@ -41,13 +37,6 @@ export function MultiTraceView(props: MultiTraceViewProps) {
             {multiCellResults().size} cells
           </span>
         </div>
-
-        <Show when={multiCellSolving()}>
-          <div class="solving-progress">
-            Solving cell {multiCellProgress()?.current ?? 0} of{' '}
-            {multiCellProgress()?.total ?? 0}...
-          </div>
-        </Show>
 
         <div class="multi-trace-grid">
           <For each={entries()}>

--- a/src/components/traces/TracePanel.tsx
+++ b/src/components/traces/TracePanel.tsx
@@ -21,17 +21,80 @@ export interface TracePanelProps {
   syncKey: string;
   /** Additional plugins (zoom sync injected externally) */
   plugins?: uPlot.Plugin[];
+  /** Disable built-in wheel zoom plugin (when parent handles zoom) */
+  disableWheelZoom?: boolean;
+  /** Lock y-axis to a fixed [min, max] range (prevents auto-ranging on zoom) */
+  yRange?: [number, number];
+  /** Hide y-axis tick labels (keep gridlines for visual reference) */
+  hideYValues?: boolean;
+  /** X-axis label (e.g., "Time (s)") */
+  xLabel?: string;
+}
+
+/** Format x-axis tick values, adapting decimal places to the visible range */
+function formatTimeValues(_u: uPlot, splits: number[]): string[] {
+  if (splits.length < 2) return splits.map(v => String(v));
+  const range = splits[splits.length - 1] - splits[0];
+  const decimals = range < 1 ? 2 : range < 10 ? 1 : 0;
+  return splits.map(v => v.toFixed(decimals));
 }
 
 export function TracePanel(props: TracePanelProps) {
   const height = () => props.height ?? 150;
 
   const plugins = (): uPlot.Plugin[] => {
-    const base = [wheelZoomPlugin()];
+    const base = props.disableWheelZoom ? [] : [wheelZoomPlugin()];
     if (props.plugins) {
       return [...base, ...props.plugins];
     }
     return base;
+  };
+
+  const scales = (): uPlot.Scales => {
+    const s: uPlot.Scales = { x: { time: false } };
+    if (props.yRange) {
+      const [yMin, yMax] = props.yRange;
+      s.y = { range: () => [yMin, yMax] };
+    }
+    return s;
+  };
+
+  // Build axes config once — stable references prevent SolidUplot from
+  // recreating the chart on every data update
+  // Use resolved hex colors (not CSS variables) — uPlot draws axis labels
+  // on canvas via fillText, and CSS variable resolution can fail during
+  // setData redraws, causing tick labels to vanish.
+  const AXIS_TEXT = '#8b92a8';
+  const AXIS_GRID = 'rgba(160, 160, 160, 0.15)';
+  const AXIS_TICK = 'rgba(160, 160, 160, 0.3)';
+
+  const xAxis: uPlot.Axis = {
+    stroke: AXIS_TEXT,
+    grid: { stroke: AXIS_GRID },
+    ticks: { stroke: AXIS_TICK },
+    values: formatTimeValues,
+    ...(props.xLabel ? { label: props.xLabel, labelSize: 14, labelGap: 2, labelFont: '11px sans-serif' } : {}),
+  };
+
+  const yAxisBase: uPlot.Axis = {
+    stroke: AXIS_TEXT,
+    grid: { stroke: AXIS_GRID },
+    ticks: { stroke: AXIS_TICK },
+  };
+
+  const yAxisHidden: uPlot.Axis = {
+    ...yAxisBase,
+    values: () => '' as any,
+    size: 20,
+  };
+
+  const yAxis = () => props.hideYValues ? yAxisHidden : yAxisBase;
+
+  const cursorConfig = {
+    sync: {
+      key: props.syncKey,
+      setSeries: true,
+    },
   };
 
   return (
@@ -39,25 +102,9 @@ export function TracePanel(props: TracePanelProps) {
       <SolidUplot
         data={props.data()}
         series={props.series}
-        scales={{ x: { time: false } }}
-        cursor={{
-          sync: {
-            key: props.syncKey,
-            setSeries: true,
-          },
-        }}
-        axes={[
-          {
-            stroke: 'var(--text-secondary)',
-            grid: { stroke: 'rgba(160, 160, 160, 0.15)' },
-            ticks: { stroke: 'rgba(160, 160, 160, 0.3)' },
-          },
-          {
-            stroke: 'var(--text-secondary)',
-            grid: { stroke: 'rgba(160, 160, 160, 0.15)' },
-            ticks: { stroke: 'rgba(160, 160, 160, 0.3)' },
-          },
-        ]}
+        scales={scales()}
+        cursor={cursorConfig}
+        axes={[xAxis, yAxis()]}
         plugins={plugins()}
         height={height()}
         autoResize={true}

--- a/src/lib/chart/chart-theme.css
+++ b/src/lib/chart/chart-theme.css
@@ -18,7 +18,7 @@
 
 /* Axis tick labels — mono font */
 .u-axis .u-label {
-  color: var(--text-secondary);
+  color: #8b92a8;
   font-size: 11px;
   font-family: var(--font-mono);
 }

--- a/src/lib/metrics/snr.ts
+++ b/src/lib/metrics/snr.ts
@@ -1,0 +1,98 @@
+/**
+ * Signal-to-noise ratio computation for calcium traces.
+ * Uses peak-based SNR: ratio of signal range to baseline noise (RMS of residual).
+ */
+
+/**
+ * Compute peak SNR for a calcium trace.
+ * SNR = (max - baseline_mean) / baseline_std
+ *
+ * Baseline is estimated from the lower 25th percentile of the trace.
+ * This is appropriate for calcium traces where most of the trace
+ * is at baseline with occasional transient peaks.
+ *
+ * @returns SNR value (higher = better signal quality)
+ */
+export function computePeakSNR(trace: Float64Array): number {
+  if (trace.length < 10) return 0;
+
+  // Sort a copy to find percentiles
+  const sorted = Float64Array.from(trace).sort();
+  const n = sorted.length;
+
+  // Baseline: lower 25th percentile
+  const q25Idx = Math.floor(n * 0.25);
+  let baselineSum = 0;
+  let baselineSumSq = 0;
+  for (let i = 0; i < q25Idx; i++) {
+    baselineSum += sorted[i];
+    baselineSumSq += sorted[i] * sorted[i];
+  }
+  const baselineMean = baselineSum / q25Idx;
+  const baselineVar = baselineSumSq / q25Idx - baselineMean * baselineMean;
+  const baselineStd = Math.sqrt(Math.max(0, baselineVar));
+
+  if (baselineStd === 0) return Infinity;
+
+  // Peak: 95th percentile to be robust against outliers
+  const q95Idx = Math.floor(n * 0.95);
+  const peak = sorted[q95Idx];
+
+  return (peak - baselineMean) / baselineStd;
+}
+
+/**
+ * Compute RMS SNR (signal power / noise power).
+ * Uses residual trace if available, otherwise estimates noise
+ * from high-frequency component (diff filter).
+ *
+ * @param raw - Raw fluorescence trace
+ * @param residual - Optional residual trace (raw - fit)
+ * @returns SNR in dB-like scale (10 * log10(signal_var / noise_var))
+ */
+export function computeRmsSNR(raw: Float64Array, residual?: Float64Array): number {
+  if (raw.length < 10) return 0;
+
+  // Signal variance
+  let sum = 0;
+  let sumSq = 0;
+  for (let i = 0; i < raw.length; i++) {
+    sum += raw[i];
+    sumSq += raw[i] * raw[i];
+  }
+  const signalMean = sum / raw.length;
+  const signalVar = sumSq / raw.length - signalMean * signalMean;
+
+  // Noise variance
+  let noiseVar: number;
+  if (residual && residual.length === raw.length) {
+    let nSum = 0;
+    let nSumSq = 0;
+    for (let i = 0; i < residual.length; i++) {
+      nSum += residual[i];
+      nSumSq += residual[i] * residual[i];
+    }
+    const nMean = nSum / residual.length;
+    noiseVar = nSumSq / residual.length - nMean * nMean;
+  } else {
+    // Estimate noise from first-order differences
+    let diffSumSq = 0;
+    for (let i = 1; i < raw.length; i++) {
+      const d = raw[i] - raw[i - 1];
+      diffSumSq += d * d;
+    }
+    noiseVar = diffSumSq / (2 * (raw.length - 1));
+  }
+
+  if (noiseVar === 0) return Infinity;
+  return 10 * Math.log10(signalVar / noiseVar);
+}
+
+/** Quality tier based on peak SNR */
+export type QualityTier = 'good' | 'fair' | 'poor';
+
+export function snrToQuality(snr: number): QualityTier {
+  if (snr >= 5) return 'good';
+  if (snr >= 2) return 'fair';
+  return 'poor';
+}

--- a/src/lib/metrics/solver-metrics.ts
+++ b/src/lib/metrics/solver-metrics.ts
@@ -1,0 +1,64 @@
+/**
+ * Solver output quality metrics.
+ * Measures how well the deconvolution solution fits the data.
+ */
+
+/**
+ * Compute the sparsity ratio of the deconvolved trace.
+ * Fraction of values that are effectively zero (below threshold).
+ */
+export function computeSparsityRatio(
+  deconvolved: Float64Array,
+  threshold: number = 1e-6,
+): number {
+  if (deconvolved.length === 0) return 0;
+  let zeroCount = 0;
+  for (let i = 0; i < deconvolved.length; i++) {
+    if (Math.abs(deconvolved[i]) < threshold) zeroCount++;
+  }
+  return zeroCount / deconvolved.length;
+}
+
+/**
+ * Compute the RMS of the residual (raw - reconvolution).
+ * Lower = better fit.
+ */
+export function computeResidualRMS(
+  raw: Float64Array,
+  reconvolution: Float64Array,
+): number {
+  if (raw.length === 0 || raw.length !== reconvolution.length) return 0;
+  let sumSq = 0;
+  for (let i = 0; i < raw.length; i++) {
+    const d = raw[i] - reconvolution[i];
+    sumSq += d * d;
+  }
+  return Math.sqrt(sumSq / raw.length);
+}
+
+/**
+ * Compute R-squared (coefficient of determination).
+ * 1.0 = perfect fit, 0 = no better than mean, negative = worse than mean.
+ */
+export function computeRSquared(
+  raw: Float64Array,
+  reconvolution: Float64Array,
+): number {
+  if (raw.length === 0 || raw.length !== reconvolution.length) return 0;
+
+  let sum = 0;
+  for (let i = 0; i < raw.length; i++) sum += raw[i];
+  const mean = sum / raw.length;
+
+  let ssTot = 0;
+  let ssRes = 0;
+  for (let i = 0; i < raw.length; i++) {
+    const d = raw[i] - mean;
+    ssTot += d * d;
+    const r = raw[i] - reconvolution[i];
+    ssRes += r * r;
+  }
+
+  if (ssTot === 0) return 1;
+  return 1 - ssRes / ssTot;
+}

--- a/src/lib/multi-cell-store.ts
+++ b/src/lib/multi-cell-store.ts
@@ -24,7 +24,10 @@ const [displayCount, setDisplayCount] = createSignal<number>(5);
 const [multiCellResults, setMultiCellResults] = createSignal<Map<number, CellTraces>>(new Map());
 const [multiCellSolving, setMultiCellSolving] = createSignal<boolean>(false);
 const [multiCellProgress, setMultiCellProgress] = createSignal<{ current: number; total: number } | null>(null);
+const [solvingCells, setSolvingCells] = createSignal<ReadonlySet<number>>(new Set());
+const [activelySolvingCell, setActivelySolvingCell] = createSignal<number | null>(null);
 const [activityRanking, setActivityRanking] = createSignal<number[] | null>(null);
+const [gridColumns, setGridColumns] = createSignal<number>(2);
 
 // --- Actions ---
 
@@ -78,6 +81,18 @@ function clearMultiCellResults(): void {
   setMultiCellResults(new Map());
 }
 
+/**
+ * Reset all multi-cell state (results + selection). Use when switching datasets.
+ */
+function clearMultiCellState(): void {
+  setMultiCellResults(new Map());
+  setSelectedCells([]);
+  setSolvingCells(new Set<number>());
+  setActivelySolvingCell(null);
+  setActivityRanking(null);
+  setSelectionMode('top-active');
+}
+
 // --- Exports ---
 
 export {
@@ -88,7 +103,10 @@ export {
   multiCellResults,
   multiCellSolving,
   multiCellProgress,
+  solvingCells,
+  activelySolvingCell,
   activityRanking,
+  gridColumns,
   // Setters
   setSelectionMode,
   setSelectedCells,
@@ -96,9 +114,13 @@ export {
   setMultiCellResults,
   setMultiCellSolving,
   setMultiCellProgress,
+  setSolvingCells,
+  setActivelySolvingCell,
   setActivityRanking,
+  setGridColumns,
   // Actions
   computeAndCacheRanking,
   updateCellSelection,
   clearMultiCellResults,
+  clearMultiCellState,
 };

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,139 @@
+/* Card Grid and Cell Card styles */
+
+/* ========================
+   Card Grid Container — only scrollable area
+   ======================== */
+.card-grid-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.card-grid {
+  --grid-cols: 2;
+  display: grid;
+  grid-template-columns: repeat(var(--grid-cols), minmax(0, 1fr));
+  gap: var(--panel-gap);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: var(--space-xs);
+  flex: 1;
+  min-height: 0;
+}
+
+.card-grid__progress {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--accent);
+  padding: var(--space-sm);
+  animation: convergence-pulse 1s ease-in-out infinite;
+}
+
+.card-grid__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+/* ========================
+   Cell Card
+   ======================== */
+.cell-card {
+  background: var(--panel-bg-data);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--panel-radius);
+  box-shadow: var(--shadow-panel);
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  min-height: 280px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.cell-card:hover {
+  border-color: var(--accent);
+}
+
+.cell-card--active {
+  border-color: var(--accent-warm);
+  box-shadow: 0 0 12px rgba(212, 165, 116, 0.25);
+}
+
+.cell-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-xs);
+}
+
+.cell-card__title {
+  font-size: 0.8rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* ========================
+   Trace Overview (minimap)
+   ======================== */
+.cell-card__overview {
+  flex-shrink: 0;
+}
+
+.trace-overview {
+  width: 100%;
+  cursor: crosshair;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-inset);
+}
+
+.trace-overview__canvas {
+  display: block;
+  width: 100%;
+}
+
+/* ========================
+   Zoom Window
+   ======================== */
+.cell-card__zoom {
+  flex: 1;
+  min-height: 100px;
+}
+
+.zoom-window {
+  height: 100%;
+}
+
+.zoom-window .trace-panel {
+  height: 100% !important;
+}
+
+.zoom-hint {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  pointer-events: none;
+  animation: zoom-hint-fade 1.5s ease-out forwards;
+}
+
+@keyframes zoom-hint-fade {
+  0% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -185,6 +185,38 @@
 }
 
 /* ========================
+   Submit Modal (Portal overlay)
+   ======================== */
+
+.submit-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.submit-modal__content {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--panel-radius);
+  padding: var(--panel-padding);
+  width: 480px;
+  max-width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.submit-modal__title {
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  margin: 0 0 var(--space-md);
+}
+
+/* ========================
    SubmitPanel
    ======================== */
 

--- a/src/styles/compact-header.css
+++ b/src/styles/compact-header.css
@@ -1,0 +1,61 @@
+/* Compact Header — thin bar for dashboard mode */
+
+.compact-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+  min-height: 48px;
+}
+
+.compact-header__brand {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.compact-header__title {
+  font-size: 1.1rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+.compact-header__version {
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+.compact-header__info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex: 1;
+  min-width: 0;
+  font-size: 0.85rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.compact-header__file {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compact-header__sep {
+  color: var(--text-tertiary);
+}
+
+.compact-header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -6,7 +6,7 @@
 .param-panel {
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  padding: var(--space-lg);
+  padding: var(--space-md);
 }
 
 .param-panel__header {
@@ -29,20 +29,27 @@
   margin-bottom: 0;
 }
 
+.param-slider__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
 .param-slider__label {
-  display: block;
   font-size: 0.75rem;
   color: var(--text-secondary);
-  margin-bottom: var(--space-xs);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  white-space: nowrap;
 }
 
-.param-slider__controls {
+.param-slider__inline-value {
   display: flex;
-  align-items: center;
-  gap: var(--space-sm);
+  align-items: baseline;
+  gap: 2px;
 }
 
 /* --- Range input: cross-browser dark theme --- */
@@ -111,13 +118,13 @@
 /* --- Numeric input --- */
 
 .param-slider__number {
-  width: 80px;
+  width: 72px;
   background: var(--bg-inset);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  padding: 4px 8px;
-  font-size: 0.85rem;
+  padding: 2px 6px;
+  font-size: 0.8rem;
   font-family: var(--font-mono);
   text-align: right;
   outline: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,6 +110,18 @@ body::before {
   flex-direction: column;
 }
 
+/* Dashboard mode: viewport-filling, no scroll */
+html.dashboard-mode,
+html.dashboard-mode body,
+html.dashboard-mode #root {
+  height: 100vh;
+  overflow: hidden;
+}
+
+html.dashboard-mode #root {
+  min-height: 0;
+}
+
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
@@ -777,19 +789,23 @@ a:hover {
 
 /* Kernel display */
 .kernel-section {
-  max-width: 400px;
-  margin-bottom: var(--space-lg);
+  max-width: 100%;
+  margin-bottom: 0;
 }
 
-.kernel-section__header {
-  margin-bottom: var(--space-xs);
+/* Remove inner box from kernel chart — already inside a DashboardPanel */
+.kernel-section .u-wrap {
+  background: none;
+  border: none;
+  border-radius: 0;
 }
 
-.kernel-section__params {
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  margin: 0 0 var(--space-xs);
-  font-family: var(--font-mono);
+.kernel-section .trace-panel {
+  margin-bottom: 0;
+}
+
+.kernel-section .panel-label {
+  margin-bottom: 0;
 }
 
 /* ========================

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -65,33 +65,265 @@
 }
 
 /* ========================
-   Future dashboard grid mode (commented out)
-   Activate by switching class from viz-layout--scroll to viz-layout--grid
+   Dashboard Shell — outer 100vh grid: header + main + sidebar
    ======================== */
-
-/*
-.viz-layout--grid {
+.dashboard-shell {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto;
+  height: 100vh;
+  grid-template-columns: 1fr 0;
+  grid-template-rows: auto 1fr;
   grid-template-areas:
-    "parameters  parameters"
-    "toolbar     toolbar"
-    "traces      traces"
-    "selector    selector"
-    "kernel      multi-trace"
-    "community   community";
-  gap: var(--panel-gap);
+    "header  header"
+    "main    sidebar";
+  overflow: hidden;
+  transition: grid-template-columns var(--transition-slow);
 }
 
-.viz-layout--grid [data-panel-id="parameters"]  { grid-area: parameters; }
-.viz-layout--grid [data-panel-id="toolbar"]      { grid-area: toolbar; }
-.viz-layout--grid [data-panel-id="traces"]       { grid-area: traces; }
-.viz-layout--grid [data-panel-id="selector"]     { grid-area: selector; }
-.viz-layout--grid [data-panel-id="kernel"]       { grid-area: kernel; }
-.viz-layout--grid [data-panel-id="multi-trace"]  { grid-area: multi-trace; }
-.viz-layout--grid [data-panel-id="community"]    { grid-area: community; }
-*/
+.dashboard-shell--sidebar-open {
+  grid-template-columns: 1fr var(--sidebar-width, 380px);
+}
+
+.dashboard-shell__header {
+  grid-area: header;
+  min-width: 0;
+}
+
+.dashboard-shell__main {
+  grid-area: main;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.dashboard-shell__sidebar {
+  grid-area: sidebar;
+  overflow: hidden;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border-subtle);
+  transition: opacity var(--transition-slow);
+  opacity: 0;
+}
+
+.dashboard-shell--sidebar-open .dashboard-shell__sidebar {
+  overflow-y: auto;
+  opacity: 1;
+  padding: var(--space-md);
+}
+
+/* ========================
+   VizLayout — dashboard mode (3-column inner grid)
+   ======================== */
+.viz-layout--dashboard {
+  display: grid;
+  height: 100%;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 1fr;
+  gap: var(--panel-gap);
+  padding: var(--space-md) var(--space-lg);
+  overflow: hidden;
+}
+
+/* Prevent grid blowout for all dashboard children */
+.viz-layout--dashboard > * {
+  min-height: 0;
+  min-width: 0;
+}
+
+.dashboard-shell .dashboard-panel {
+  min-height: 0;
+  min-width: 0;
+}
+
+/* Utility: fill remaining flex space */
+.dashboard-panel--grow {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+/* ========================
+   Parameter Strip — compact left column
+   ======================== */
+.param-strip {
+  display: flex;
+  flex-direction: column;
+  gap: var(--panel-gap);
+  width: 260px;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+/* Main content area: selector bar + card grid stacked */
+.main-content-area {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.param-strip__toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.param-strip__pin-info {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* ========================
+   Sidebar Tabs
+   ======================== */
+.sidebar-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.sidebar-tabs__bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  margin-bottom: var(--space-md);
+}
+
+.sidebar-tabs__tab {
+  flex: 1;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-family: var(--font-body);
+  font-weight: var(--font-weight-medium);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.sidebar-tabs__tab:hover {
+  color: var(--text-primary);
+}
+
+.sidebar-tabs__tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.sidebar-tabs__content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* ========================
+   Metrics Panel
+   ======================== */
+.metrics-panel {
+  padding: var(--space-sm) 0;
+}
+
+.metrics-panel__title {
+  font-size: 1.1rem;
+  margin: 0 0 var(--space-md);
+  color: var(--text-primary);
+}
+
+.metrics-panel__empty {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: var(--space-lg) 0;
+}
+
+.metrics-panel__summary {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.metrics-panel__stat {
+  flex: 1;
+  background: var(--bg-inset);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  text-align: center;
+}
+
+.metrics-panel__stat-label {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 2px;
+}
+
+.metrics-panel__stat-value {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.metrics-panel__table {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+}
+
+.metrics-panel__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: var(--space-xs);
+  padding: var(--space-xs) 0;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.metrics-panel__row--header {
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+.metrics-panel__dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+/* Quality Badge */
+.quality-badge {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background 0.3s ease;
+}
+
+.quality-badge--solving {
+  animation: badge-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
 
 /* ========================
    Section Divider

--- a/src/styles/multi-trace.css
+++ b/src/styles/multi-trace.css
@@ -70,18 +70,16 @@
    ======================== */
 .cell-selector {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: var(--space-md);
   flex-wrap: wrap;
-  margin-bottom: var(--space-md);
-  padding: var(--space-md);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-md);
+  padding: var(--space-xs) var(--space-md);
 }
 
 .cell-selector__group {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   gap: var(--space-xs);
 }
 
@@ -137,6 +135,44 @@
 
 .cell-selector__count[type='number'] {
   -moz-appearance: textfield;
+}
+
+/* Stepper for grid columns */
+.cell-selector__stepper {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.cell-selector__step-btn {
+  background: var(--bg-inset);
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  line-height: 1;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.cell-selector__step-btn:hover {
+  background: var(--border-default);
+  color: var(--text-primary);
+}
+
+.cell-selector__step-value {
+  font-size: 0.85rem;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  padding: 2px 6px;
+  min-width: 20px;
+  text-align: center;
+  background: var(--bg-inset);
+  border-left: 1px solid var(--border-default);
+  border-right: 1px solid var(--border-default);
 }
 
 .cell-selector__manual {


### PR DESCRIPTION
## Summary

Complete dashboard overhaul: fixed header, collapsible sidebar, parameter strip, and a scrollable cell card grid replacing the old single-trace layout.

### Layout & Navigation
- **Dashboard Shell**: Viewport-filling CSS Grid (`DashboardShell` + `VizLayout`), 100vh with header/main/sidebar areas
- **Compact Header**: 48px bar with file info, tutorial launcher, sidebar toggle, "Change Data" button
- **Import Overlay**: Full-page import flow extracted from App
- **Collapsible Sidebar**: Smooth grid-template-columns transition, ScatterPlot ResizeObserver with RAF debounce

### Cell Card Grid
- **Cell cards** with canvas-based `TraceOverview` minimap + `ZoomWindow` (raw/deconvolved/reconvolved overlaid via uPlot)
- **Z-score normalized traces** with deconvolved trace offset below raw
- **Minimap click-and-drag** to reposition zoom window
- **Ctrl+scroll for time zoom**, bare scroll passes through for page navigation (hint tooltip on bare scroll)
- **Grid columns density control** with −/+ stepper buttons (1–6 columns)
- **Cards appear immediately** with raw traces before solver completes; stale results preserved on parameter change
- **Zoom/scroll position preserved** across parameter changes (stable `<For>` keys)
- **X-axis time labels** persist through zoom (fixed CSS variable canvas resolution bug)

### Metrics & Quality
- **Per-cell solver status badges**: green (fresh), yellow pulsing (solving), red (stale)
- **SidebarTabs** (Community | Metrics), **MetricsPanel** with aggregate stats + per-cell table
- **QualityBadge** color-coded by SNR (green/yellow/red)

### Kernel Display
- Simplified: title + enlarged plot (140px), no inner box or tau text
- "Time (s)" x-axis label, adaptive decimal formatting

### Submit to Community
- Metadata form rendered as centered Portal modal with backdrop
- Click-on-backdrop or Escape to close

### Code Quality Fixes
- `createMemo` with side effects → `createEffect`
- ResizeObserver setup → `onMount`
- Unnecessary functional setter wrapping removed
- ZoomWindow empty data series count corrected
- State reset on "Change Data" clears multi-cell store
- Sidebar toggle button label generalized

### New files (14)
| File | Purpose |
|------|---------|
| `DashboardShell.tsx` | Outer 100vh grid: header + main + sidebar |
| `CompactHeader.tsx` | Thin header bar with file info and actions |
| `ImportOverlay.tsx` | Full-page import flow (extracted from App) |
| `SidebarTabs.tsx` | Tab switcher: Community / Metrics |
| `CellCard.tsx` | Individual cell card: overview + zoom |
| `TraceOverview.tsx` | Canvas-based multi-row minimap |
| `ZoomWindow.tsx` | Zoomed analysis window with overlaid traces |
| `CardGrid.tsx` | Auto-fill grid container for CellCards |
| `MetricsPanel.tsx` | Aggregate metrics dashboard |
| `QualityBadge.tsx` | Per-card quality indicator |
| `snr.ts` | Peak/RMS SNR computation |
| `solver-metrics.ts` | Sparsity, residual RMS, R-squared |
| `cards.css` | Card grid and cell card styles |
| `compact-header.css` | Header bar styles |

## Test plan

- [x] Load demo data → viewport filled, no vertical scrollbar
- [x] Resize browser → layout adjusts, cards reflow columns
- [x] Grid columns stepper (1–6) → cards squeeze to fit
- [x] Import flow steps 1–4 → work in full-page overlay
- [x] "Change Data" → full state reset, back to import flow
- [x] Cell cards show overview minimap + zoom window with traces
- [x] Click/drag minimap → repositions zoom window
- [x] Ctrl+scroll in card → zooms in time, x-axis labels persist
- [x] Bare scroll → page scrolls through cards (hint tooltip appears)
- [x] Adjust parameters → cards update, zoom position preserved
- [x] Solver status badges: red→yellow→green progression
- [x] Sidebar toggle → smooth open/close transition
- [x] Submit to Community → centered modal, Escape/backdrop to close
- [x] Kernel plot → clean, no inner box, "Time (s)" label
- [x] 67/67 existing tests pass
- [x] TypeScript: 0 errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)