### PR TITLE
Switch solver arrays from f64 to f32

### DIFF
--- a/src/components/cards/CellCard.tsx
+++ b/src/components/cards/CellCard.tsx
@@ -13,8 +13,8 @@ import { computePeakSNR, snrToQuality } from '../../lib/metrics/snr';
 export interface CellCardProps {
   cellIndex: number;
   rawTrace: Float64Array;
-  deconvolvedTrace?: Float64Array;
-  reconvolutionTrace?: Float64Array;
+  deconvolvedTrace?: Float32Array;
+  reconvolutionTrace?: Float32Array;
   samplingRate: number;
   isActive?: boolean;
   solverStatus?: SolverStatus;

--- a/src/components/cards/ZoomWindow.tsx
+++ b/src/components/cards/ZoomWindow.tsx
@@ -11,8 +11,8 @@ import { createRawSeries, createFitSeries, createDeconvolvedSeries } from '../..
 
 export interface ZoomWindowProps {
   rawTrace: Float64Array;
-  deconvolvedTrace?: Float64Array;
-  reconvolutionTrace?: Float64Array;
+  deconvolvedTrace?: Float32Array;
+  reconvolutionTrace?: Float32Array;
   samplingRate: number;
   /** Zoom window start time (seconds) */
   startTime: number;
@@ -120,7 +120,7 @@ export function ZoomWindow(props: ZoomWindowProps) {
     const deconvStartInWindow = startSample - offset;
     const deconvEndInWindow = endSample - offset;
     // Helper to scale deconv values to z-score space below the raw trace
-    const scaleDeconv = (dsDeconvRaw: number[], deconvFull: Float64Array): number[] => {
+    const scaleDeconv = (dsDeconvRaw: number[], deconvFull: Float32Array): number[] => {
       let dMin = Infinity;
       let dMax = -Infinity;
       for (let i = 0; i < deconvFull.length; i++) {

--- a/src/lib/cell-solve-manager.ts
+++ b/src/lib/cell-solve-manager.ts
@@ -90,16 +90,16 @@ function dispatchCellSolve(state: CellSolveState): void {
     onIntermediate(solution, reconvolution, _iteration) {
       if (state.activeJobId !== jobId) return; // stale
       // Extract visible region from padded result
-      const visSol = new Float64Array(solution.subarray(resultOffset, resultOffset + resultLength));
-      const visReconv = new Float64Array(reconvolution.subarray(resultOffset, resultOffset + resultLength));
+      const visSol = new Float32Array(solution.subarray(resultOffset, resultOffset + resultLength));
+      const visReconv = new Float32Array(reconvolution.subarray(resultOffset, resultOffset + resultLength));
       updateOneCellTraces(state.cellIndex, visSol, visReconv, visibleStart);
     },
     onComplete(solution, reconvolution, solverState, _iterations, _converged) {
       if (state.activeJobId !== jobId) return; // stale
       state.activeJobId = null;
       // Extract visible region
-      const visSol = new Float64Array(solution.subarray(resultOffset, resultOffset + resultLength));
-      const visReconv = new Float64Array(reconvolution.subarray(resultOffset, resultOffset + resultLength));
+      const visSol = new Float32Array(solution.subarray(resultOffset, resultOffset + resultLength));
+      const visReconv = new Float32Array(reconvolution.subarray(resultOffset, resultOffset + resultLength));
       updateOneCellTraces(state.cellIndex, visSol, visReconv, visibleStart);
       // Cache warm-start state
       state.warmStartCache.store(solverState, params, paddedStart, paddedEnd);
@@ -147,7 +147,7 @@ function ensureCellState(cellIndex: number, data: NpyResult, shape: [number, num
     // Ensure the cell has an entry in multiCellResults for immediate card rendering
     const results = multiCellResults();
     if (!results.has(cellIndex)) {
-      const zeros = new Float64Array(rawTrace.length);
+      const zeros = new Float32Array(rawTrace.length);
       const next = new Map(results);
       next.set(cellIndex, { cellIndex, raw: rawTrace, deconvolved: zeros, reconvolution: zeros });
       setMultiCellResults(next);

--- a/src/lib/chart/downsample.ts
+++ b/src/lib/chart/downsample.ts
@@ -14,8 +14,8 @@
  * @returns [xValues, yValues] suitable for uPlot
  */
 export function downsampleMinMax(
-  xData: Float64Array | number[],
-  yData: Float64Array | number[],
+  xData: Float64Array | Float32Array | number[],
+  yData: Float64Array | Float32Array | number[],
   targetBuckets: number,
 ): [number[], number[]] {
   const len = xData.length;

--- a/src/lib/metrics/solver-metrics.ts
+++ b/src/lib/metrics/solver-metrics.ts
@@ -8,7 +8,7 @@
  * Fraction of values that are effectively zero (below threshold).
  */
 export function computeSparsityRatio(
-  deconvolved: Float64Array,
+  deconvolved: Float64Array | Float32Array,
   threshold: number = 1e-6,
 ): number {
   if (deconvolved.length === 0) return 0;
@@ -25,7 +25,7 @@ export function computeSparsityRatio(
  */
 export function computeResidualRMS(
   raw: Float64Array,
-  reconvolution: Float64Array,
+  reconvolution: Float64Array | Float32Array,
 ): number {
   if (raw.length === 0 || raw.length !== reconvolution.length) return 0;
   let sumSq = 0;
@@ -42,7 +42,7 @@ export function computeResidualRMS(
  */
 export function computeRSquared(
   raw: Float64Array,
-  reconvolution: Float64Array,
+  reconvolution: Float64Array | Float32Array,
 ): number {
   if (raw.length === 0 || raw.length !== reconvolution.length) return 0;
 

--- a/src/lib/multi-cell-store.ts
+++ b/src/lib/multi-cell-store.ts
@@ -12,8 +12,8 @@ export type SelectionMode = 'top-active' | 'random' | 'manual';
 export interface CellTraces {
   cellIndex: number;
   raw: Float64Array;
-  deconvolved: Float64Array;
-  reconvolution: Float64Array;
+  deconvolved: Float32Array;
+  reconvolution: Float32Array;
   windowStartSample?: number;
 }
 
@@ -45,8 +45,8 @@ function updateOneCellStatus(cellIndex: number, status: CellSolverStatus): void 
 
 function updateOneCellTraces(
   cellIndex: number,
-  deconvolved: Float64Array,
-  reconvolution: Float64Array,
+  deconvolved: Float32Array,
+  reconvolution: Float32Array,
   windowStartSample?: number,
 ): void {
   setMultiCellResults(prev => {

--- a/src/lib/solver-types.ts
+++ b/src/lib/solver-types.ts
@@ -8,15 +8,15 @@ export interface SolverParams {
 
 /** Intermediate result emitted during solver iteration for live visualization. */
 export interface IntermediateResult {
-  solution: Float64Array;
-  reconvolution: Float64Array;
+  solution: Float32Array;
+  reconvolution: Float32Array;
   iteration: number;
 }
 
 /** Final result returned after solver convergence or termination. */
 export interface SolveResult {
-  solution: Float64Array;
-  reconvolution: Float64Array;
+  solution: Float32Array;
+  reconvolution: Float32Array;
   state: Uint8Array;          // serialized warm-start state
   iterations: number;
   converged: boolean;
@@ -54,15 +54,15 @@ export type PoolWorkerOutbound =
   | {
       type: 'intermediate';
       jobId: number;
-      solution: Float64Array;
-      reconvolution: Float64Array;
+      solution: Float32Array;
+      reconvolution: Float32Array;
       iteration: number;
     }
   | {
       type: 'complete';
       jobId: number;
-      solution: Float64Array;
-      reconvolution: Float64Array;
+      solution: Float32Array;
+      reconvolution: Float32Array;
       state: Uint8Array;
       iterations: number;
       converged: boolean;

--- a/src/lib/viz-store.ts
+++ b/src/lib/viz-store.ts
@@ -14,9 +14,9 @@ const [selectedCell, setSelectedCell] = createSignal<number>(0);
 
 const [rawTrace, setRawTrace] = createSignal<Float64Array | null>(null);
 const [deconvolvedTrace, setDeconvolvedTrace] =
-  createSignal<Float64Array | null>(null);
+  createSignal<Float32Array | null>(null);
 const [reconvolutionTrace, setReconvolutionTrace] =
-  createSignal<Float64Array | null>(null);
+  createSignal<Float32Array | null>(null);
 
 // --- Tau parameters (kernel shape) ---
 
@@ -35,9 +35,9 @@ const [solverStatus, setSolverStatus] = createSignal<SolverStatus>('idle');
 // --- Pinned snapshot for before/after comparison ---
 
 const [pinnedDeconvolved, setPinnedDeconvolved] =
-  createSignal<Float64Array | null>(null);
+  createSignal<Float32Array | null>(null);
 const [pinnedReconvolution, setPinnedReconvolution] =
-  createSignal<Float64Array | null>(null);
+  createSignal<Float32Array | null>(null);
 const [pinnedParams, setPinnedParams] = createSignal<{
   tauRise: number;
   tauDecay: number;
@@ -50,8 +50,8 @@ function pinCurrentSnapshot(): void {
   const reconv = reconvolutionTrace();
 
   // Deep copy to avoid sharing ArrayBuffer references
-  setPinnedDeconvolved(deconv ? new Float64Array(deconv) : null);
-  setPinnedReconvolution(reconv ? new Float64Array(reconv) : null);
+  setPinnedDeconvolved(deconv ? new Float32Array(deconv) : null);
+  setPinnedReconvolution(reconv ? new Float32Array(reconv) : null);
   setPinnedParams({
     tauRise: tauRise(),
     tauDecay: tauDecay(),

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -10,8 +10,8 @@ export interface PoolJob {
   params: SolverParams;
   warmState: Uint8Array | null;
   warmStrategy: WarmStartStrategy;
-  onIntermediate(solution: Float64Array, reconvolution: Float64Array, iteration: number): void;
-  onComplete(solution: Float64Array, reconvolution: Float64Array, state: Uint8Array, iterations: number, converged: boolean): void;
+  onIntermediate(solution: Float32Array, reconvolution: Float32Array, iteration: number): void;
+  onComplete(solution: Float32Array, reconvolution: Float32Array, state: Uint8Array, iterations: number, converged: boolean): void;
   onCancelled(): void;
   onError(message: string): void;
 }

--- a/src/workers/pool-worker.ts
+++ b/src/workers/pool-worker.ts
@@ -32,7 +32,7 @@ async function handleSolve(req: Extract<PoolWorkerInbound, { type: 'solve' }>): 
 
   // Configure solver
   solver.set_params(req.params.tauRise, req.params.tauDecay, req.params.lambda, req.params.fs);
-  solver.set_trace(req.trace);
+  solver.set_trace(new Float32Array(req.trace));
 
   // Warm-start handling
   if (req.warmStrategy === 'warm' && req.warmState) {

--- a/wasm/catune-solver/pkg/catune_solver.d.ts
+++ b/wasm/catune-solver/pkg/catune_solver.d.ts
@@ -24,11 +24,11 @@ export class Solver {
     /**
      * Returns a copy of the reconvolution (K * solution) for the active region.
      */
-    get_reconvolution(): Float64Array;
+    get_reconvolution(): Float32Array;
     /**
      * Returns a copy of the current solution (spike train) for the active region.
      */
-    get_solution(): Float64Array;
+    get_solution(): Float32Array;
     /**
      * Returns the current iteration count.
      */
@@ -54,7 +54,7 @@ export class Solver {
      * Load a trace for deconvolution. Grows buffers if needed (never shrinks).
      * Resets iteration state for a fresh solve.
      */
-    set_trace(trace: Float64Array): void;
+    set_trace(trace: Float32Array): void;
     /**
      * Run n_steps of FISTA iterations. Returns true if converged.
      *


### PR DESCRIPTION
## Summary
- Switch WASM FISTA solver signal arrays from `f64` to `f32`, halving per-worker buffer memory (~2MB → ~1MB per worker)
- Keep scalar FISTA convergence state (`t_fista`, `prev_objective`, `tolerance`, `lipschitz_constant`) as `f64` for precision
- TypeScript solver outputs become `Float32Array`; raw input traces stay `Float64Array` with conversion at the WASM boundary

## Test plan
- [x] `cargo test` — all 16 Rust tests pass (tolerances adjusted for f32)
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] Dev server: load demo data, verify traces render correctly
- [x] Solver output visually identical (f32 noise floor far below data noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)