### PR TITLE
feat: scientific instrument light theme redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/components/TracePreview.tsx
+++ b/src/components/TracePreview.tsx
@@ -11,11 +11,11 @@ import type { NumericTypedArray } from '../lib/types.ts';
 
 const NUM_TRACES = 5;
 const TRACE_COLORS = [
-  'hsl(200, 80%, 60%)',
-  'hsl(140, 70%, 50%)',
-  'hsl(30, 90%, 55%)',
-  'hsl(280, 70%, 60%)',
-  'hsl(350, 80%, 55%)',
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
 ];
 
 export function TracePreview() {

--- a/src/components/cards/TraceOverview.tsx
+++ b/src/components/cards/TraceOverview.tsx
@@ -106,17 +106,17 @@ export function TraceOverview(props: TraceOverviewProps) {
       if (zoomEnd > rowStartTime && zoomStart < rowEndTime) {
         const hlStart = Math.max(0, (zoomStart - rowStartTime) / rowDuration) * width;
         const hlEnd = Math.min(1, (zoomEnd - rowStartTime) / rowDuration) * width;
-        ctx.fillStyle = 'rgba(83, 199, 240, 0.15)';
+        ctx.fillStyle = 'rgba(33, 113, 181, 0.1)';
         ctx.fillRect(hlStart, rowY, hlEnd - hlStart, ROW_HEIGHT);
 
         // Border lines for highlight
-        ctx.strokeStyle = 'rgba(83, 199, 240, 0.4)';
+        ctx.strokeStyle = 'rgba(33, 113, 181, 0.3)';
         ctx.lineWidth = 1;
         ctx.strokeRect(hlStart, rowY, hlEnd - hlStart, ROW_HEIGHT);
       }
 
       // Draw trace line
-      ctx.strokeStyle = 'hsl(200, 60%, 50%)';
+      ctx.strokeStyle = '#1f77b4';
       ctx.lineWidth = 1;
       ctx.beginPath();
 

--- a/src/components/cards/ZoomWindow.tsx
+++ b/src/components/cards/ZoomWindow.tsx
@@ -274,6 +274,7 @@ export function ZoomWindow(props: ZoomWindowProps) {
         disableWheelZoom={!!props.onZoomChange}
         yRange={globalYRange()}
         hideYValues
+        xLabel="Time (s)"
       />
       <Show when={showHint()}>
         <div class="zoom-hint">Hold Ctrl to zoom</div>

--- a/src/components/community/ScatterPlot.tsx
+++ b/src/components/community/ScatterPlot.tsx
@@ -133,7 +133,7 @@ export function ScatterPlot(props: ScatterPlotProps) {
                 lambdaRange().min || up.lambda,
                 lambdaRange().max || up.lambda,
               );
-              ctx.strokeStyle = '#fff';
+              ctx.strokeStyle = '#ffffff';
               ctx.lineWidth = 2 * devicePixelRatio;
               ctx.beginPath();
               ctx.arc(ucx, ucy, uSize / 2, 0, 2 * Math.PI);

--- a/src/components/controls/ParameterPanel.tsx
+++ b/src/components/controls/ParameterPanel.tsx
@@ -52,7 +52,7 @@ export function ParameterPanel(props: ParameterPanelProps) {
           data-tutorial="slider-decay"
         />
         <ParameterSlider
-          label="Sparsity (lambda)"
+          label="Sparsity"
           value={lambda}
           setValue={setLambda}
           min={PARAM_RANGES.lambda.min}

--- a/src/components/controls/ParameterSlider.tsx
+++ b/src/components/controls/ParameterSlider.tsx
@@ -84,7 +84,7 @@ export function ParameterSlider(props: ParameterSliderProps) {
             onInput={handleNumericInput}
             onChange={handleNumericChange}
           />
-          {props.unit && <span class="param-slider__unit">{props.unit}</span>}
+          <span class="param-slider__unit">{props.unit ?? ''}</span>
         </span>
       </div>
       <input

--- a/src/components/traces/TracePanel.tsx
+++ b/src/components/traces/TracePanel.tsx
@@ -64,16 +64,16 @@ export function TracePanel(props: TracePanelProps) {
   // Use resolved hex colors (not CSS variables) — uPlot draws axis labels
   // on canvas via fillText, and CSS variable resolution can fail during
   // setData redraws, causing tick labels to vanish.
-  const AXIS_TEXT = '#8b92a8';
-  const AXIS_GRID = 'rgba(160, 160, 160, 0.15)';
-  const AXIS_TICK = 'rgba(160, 160, 160, 0.3)';
+  const AXIS_TEXT = '#616161';
+  const AXIS_GRID = 'rgba(0, 0, 0, 0.06)';
+  const AXIS_TICK = 'rgba(0, 0, 0, 0.15)';
 
   const xAxis: uPlot.Axis = {
     stroke: AXIS_TEXT,
     grid: { stroke: AXIS_GRID },
     ticks: { stroke: AXIS_TICK },
     values: formatTimeValues,
-    ...(props.xLabel ? { label: props.xLabel, labelSize: 14, labelGap: 2, labelFont: '11px sans-serif' } : {}),
+    ...(props.xLabel ? { label: props.xLabel, labelSize: 10, labelGap: 0, labelFont: '10px sans-serif', size: 30 } : {}),
   };
 
   const yAxisBase: uPlot.Axis = {

--- a/src/lib/chart/chart-theme.css
+++ b/src/lib/chart/chart-theme.css
@@ -1,12 +1,12 @@
 /*
- * CaTune dark theme overrides for uPlot.
+ * CaTune light theme overrides for uPlot.
  * Import after uPlot.min.css to override default light theme.
  * References CSS custom properties from src/styles/global.css.
  */
 
-/* Chart wrapper — inset background */
+/* Chart wrapper — clean white with thin border */
 .u-wrap {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
 }
@@ -18,25 +18,25 @@
 
 /* Axis tick labels — mono font */
 .u-axis .u-label {
-  color: #8b92a8;
+  color: #616161;
   font-size: 11px;
   font-family: var(--font-mono);
 }
 
 /* Axis tick marks */
 .u-axis .u-tick {
-  stroke: color-mix(in srgb, var(--text-secondary) 30%, transparent);
+  stroke: rgba(0, 0, 0, 0.15);
 }
 
-/* Grid lines at 15% opacity */
+/* Grid lines — subtle */
 .u-grid .u-stroke {
-  stroke: color-mix(in srgb, var(--text-secondary) 15%, transparent);
+  stroke: rgba(0, 0, 0, 0.06);
 }
 
 /* Cursor crosshair lines */
 .u-cursor-x,
 .u-cursor-y {
-  border-color: var(--accent) !important;
+  border-color: rgba(0, 0, 0, 0.3) !important;
 }
 
 /* Legend text — mono font */

--- a/src/lib/chart/series-config.ts
+++ b/src/lib/chart/series-config.ts
@@ -3,19 +3,19 @@
 import type uPlot from 'uplot';
 
 export function createRawSeries(): uPlot.Series {
-  return { label: 'Raw', stroke: 'hsl(200, 60%, 50%)', width: 1 };
+  return { label: 'Raw', stroke: '#1f77b4', width: 1 };
 }
 
 export function createFitSeries(): uPlot.Series {
-  return { label: 'Fit', stroke: 'hsl(30, 90%, 60%)', width: 1.5 };
+  return { label: 'Fit', stroke: '#ff7f0e', width: 1.5 };
 }
 
 export function createDeconvolvedSeries(): uPlot.Series {
-  return { label: 'Deconvolved', stroke: 'hsl(120, 70%, 50%)', width: 1 };
+  return { label: 'Deconvolved', stroke: '#2ca02c', width: 1 };
 }
 
 export function createResidualSeries(): uPlot.Series {
-  return { label: 'Residuals', stroke: 'hsl(0, 70%, 60%)', width: 1 };
+  return { label: 'Residuals', stroke: '#d62728', width: 1 };
 }
 
 /**
@@ -27,7 +27,15 @@ export function createPinnedOverlaySeries(
   baseStroke: string,
   baseWidth: number,
 ): uPlot.Series {
-  // Convert solid HSL to 35% opacity HSLA
-  const hslaStroke = baseStroke.replace('hsl(', 'hsla(').replace(')', ', 0.35)');
+  // Convert hex to 35% opacity rgba, or handle hsl→hsla
+  let hslaStroke: string;
+  if (baseStroke.startsWith('#')) {
+    const r = parseInt(baseStroke.slice(1, 3), 16);
+    const g = parseInt(baseStroke.slice(3, 5), 16);
+    const b = parseInt(baseStroke.slice(5, 7), 16);
+    hslaStroke = `rgba(${r}, ${g}, ${b}, 0.35)`;
+  } else {
+    hslaStroke = baseStroke.replace('hsl(', 'hsla(').replace(')', ', 0.35)');
+  }
   return { label, stroke: hslaStroke, width: baseWidth, dash: [4, 4] };
 }

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -44,16 +44,15 @@
    Cell Card
    ======================== */
 .cell-card {
-  background: var(--panel-bg-data);
+  background: var(--bg-primary);
   border: 1px solid var(--border-subtle);
   border-radius: var(--panel-radius);
-  box-shadow: var(--shadow-panel);
   padding: var(--space-sm);
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
   cursor: pointer;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition: border-color var(--transition-fast);
   min-height: 280px;
   min-width: 0;
   overflow: hidden;
@@ -64,8 +63,8 @@
 }
 
 .cell-card--active {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 12px rgba(212, 165, 116, 0.25);
+  border-color: var(--accent);
+  border-width: 2px;
 }
 
 .cell-card__header {
@@ -94,7 +93,7 @@
   cursor: crosshair;
   border-radius: var(--radius-sm);
   overflow: hidden;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
 }
 
 .trace-overview__canvas {
@@ -123,11 +122,11 @@
   bottom: 8px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.75);
-  color: var(--text-secondary);
+  background: rgba(0, 0, 0, 0.7);
+  color: #ffffff;
   font-size: 11px;
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: 2px;
   pointer-events: none;
   animation: zoom-hint-fade 1.5s ease-out forwards;
 }

--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -1,4 +1,4 @@
-/* Community feature styles - Scientific Instrument theme */
+/* Community feature styles - Scientific Instrument light theme */
 
 /* ========================
    AuthGate
@@ -25,7 +25,7 @@
 }
 
 .auth-gate__input {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -37,8 +37,8 @@
 
 .auth-gate__input:focus {
   outline: none;
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 .auth-gate__sent {
@@ -49,7 +49,7 @@
 }
 
 .auth-gate__error {
-  color: #e57373;
+  color: var(--error);
   font-size: 0.85rem;
   margin-top: var(--space-xs);
 }
@@ -62,7 +62,7 @@
 }
 
 .auth-gate__btn {
-  background: var(--bg-surface);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -83,9 +83,9 @@
 }
 
 .auth-gate__btn--github:hover {
-  background: rgba(110, 84, 148, 0.15);
-  border-color: #9b7fc4;
-  color: #c9b8e8;
+  background: rgba(110, 84, 148, 0.06);
+  border-color: #6e5494;
+  color: #6e5494;
 }
 
 .auth-gate__btn--google {
@@ -93,14 +93,14 @@
 }
 
 .auth-gate__btn--google:hover {
-  background: rgba(66, 133, 244, 0.15);
-  border-color: #6ea5f8;
-  color: #a4c6fa;
+  background: rgba(66, 133, 244, 0.06);
+  border-color: #4285f4;
+  color: #4285f4;
 }
 
 .auth-gate__btn--signout {
   background: transparent;
-  border-color: var(--text-secondary);
+  border-color: var(--border-default);
   padding: var(--space-xs) var(--space-md);
   font-size: 0.85rem;
 }
@@ -137,7 +137,7 @@
    ======================== */
 
 .privacy-notice {
-  background: rgba(46, 204, 113, 0.06);
+  background: rgba(46, 125, 50, 0.04);
   border-left: 3px solid var(--success);
   border-radius: var(--radius-sm);
   padding: var(--space-md);
@@ -191,7 +191,7 @@
 .submit-modal__backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.3);
   z-index: 1000;
   display: flex;
   align-items: center;
@@ -199,7 +199,7 @@
 }
 
 .submit-modal__content {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--panel-radius);
   padding: var(--panel-padding);
@@ -207,7 +207,7 @@
   max-width: 90vw;
   max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-elevated);
 }
 
 .submit-modal__title {
@@ -263,7 +263,7 @@
 .submit-panel__field select,
 .submit-panel__field textarea {
   width: 100%;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -277,8 +277,8 @@
 .submit-panel__field input:focus,
 .submit-panel__field select:focus,
 .submit-panel__field textarea:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 .submit-panel__field input::placeholder,
@@ -377,7 +377,7 @@
    ======================== */
 
 .community-browser {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
   border: 1px solid var(--border-subtle);
@@ -426,7 +426,7 @@
 }
 
 .community-browser__compare-btn {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -556,7 +556,7 @@
 }
 
 .filter-bar__select {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -567,8 +567,8 @@
 
 .filter-bar__select:focus {
   outline: none;
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 .filter-bar__count {

--- a/src/styles/compact-header.css
+++ b/src/styles/compact-header.css
@@ -20,7 +20,7 @@
 .compact-header__title {
   font-size: 1.1rem;
   font-weight: var(--font-weight-semibold);
-  color: var(--accent);
+  color: var(--text-primary);
   letter-spacing: -0.02em;
 }
 

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -1,4 +1,4 @@
-/* Parameter control panel styles - Scientific Instrument theme */
+/* Parameter control panel styles - Scientific Instrument light theme */
 
 /* ========================
    Parameter Panel
@@ -50,17 +50,19 @@
   display: flex;
   align-items: baseline;
   gap: 2px;
+  min-width: 100px;
+  justify-content: flex-end;
 }
 
-/* --- Range input: cross-browser dark theme --- */
+/* --- Range input: cross-browser light theme --- */
 
 .param-slider__range {
   -webkit-appearance: none;
   appearance: none;
   flex: 1;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--bg-surface);
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border-default);
   outline: none;
   cursor: pointer;
 }
@@ -69,57 +71,57 @@
 .param-slider__range::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
   border: 2px solid var(--bg-primary);
-  box-shadow: 0 0 4px rgba(83, 199, 240, 0.3);
+  box-shadow: 0 0 0 1px var(--border-default);
   transition: box-shadow var(--transition-fast);
 }
 
 .param-slider__range::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 8px rgba(83, 199, 240, 0.5);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 /* Thumb - Firefox */
 .param-slider__range::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
   border: 2px solid var(--bg-primary);
-  box-shadow: 0 0 4px rgba(83, 199, 240, 0.3);
+  box-shadow: 0 0 0 1px var(--border-default);
   transition: box-shadow var(--transition-fast);
 }
 
 .param-slider__range::-moz-range-thumb:hover {
-  box-shadow: 0 0 8px rgba(83, 199, 240, 0.5);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 /* Track - Firefox */
 .param-slider__range::-moz-range-track {
-  height: 6px;
-  border-radius: 3px;
-  background: var(--bg-surface);
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border-default);
 }
 
-/* Focus ring for accessibility — warm accent */
+/* Focus ring for accessibility */
 .param-slider__range:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 3px var(--accent-warm-muted);
+  box-shadow: 0 0 0 3px var(--accent-muted);
 }
 
 .param-slider__range:focus-visible::-moz-range-thumb {
-  box-shadow: 0 0 0 3px var(--accent-warm-muted);
+  box-shadow: 0 0 0 3px var(--accent-muted);
 }
 
 /* --- Numeric input --- */
 
 .param-slider__number {
   width: 72px;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -132,8 +134,8 @@
 }
 
 .param-slider__number:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 /* Hide spin buttons for cleaner look */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,59 +1,59 @@
-/* CaTune Global Styles - Scientific Instrument dark theme */
+/* CaTune Global Styles - Scientific Instrument light theme */
 
 :root {
-  /* Typography */
-  --font-body: 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  /* Typography — system fonts for scientific tool feel */
+  --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
 
-  /* Background layers — warmed blue-slate */
-  --bg-primary: #191a2c;
-  --bg-secondary: #1c2240;
-  --bg-surface: #1a3058;
-  --bg-elevated: #243a5e;
-  --bg-inset: #141726;
+  /* Background layers — white content, grey chrome */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f0f0f0;
+  --bg-surface: #e4e4e4;
+  --bg-elevated: #ffffff;
+  --bg-inset: #fafafa;
 
   /* Text hierarchy */
-  --text-primary: #e8e8e8;
-  --text-secondary: #8b92a8;
-  --text-tertiary: #5c6380;
+  --text-primary: #1a1a1a;
+  --text-secondary: #616161;
+  --text-tertiary: #9e9e9e;
 
-  /* Dual-temperature accents */
-  --accent: #53c7f0;
-  --accent-hover: #3db8e0;
-  --accent-muted: rgba(83, 199, 240, 0.12);
-  --accent-warm: #d4a574;
-  --accent-warm-hover: #c4955a;
-  --accent-warm-muted: rgba(212, 165, 116, 0.12);
+  /* Accent — muted blue, used sparingly */
+  --accent: #2171b5;
+  --accent-hover: #185a92;
+  --accent-muted: rgba(33, 113, 181, 0.08);
+  --accent-warm: #1a1a1a;
+  --accent-warm-hover: #333333;
+  --accent-warm-muted: rgba(0, 0, 0, 0.04);
 
   /* Status */
-  --warning: #f0a500;
-  --warning-bg: rgba(240, 165, 0, 0.1);
-  --error: #e74c3c;
-  --error-bg: rgba(231, 76, 60, 0.1);
-  --success: #2ecc71;
+  --warning: #e09800;
+  --warning-bg: rgba(224, 152, 0, 0.08);
+  --error: #d32f2f;
+  --error-bg: rgba(211, 47, 47, 0.06);
+  --success: #2e7d32;
 
-  /* Semantic borders */
-  --border-subtle: rgba(255, 255, 255, 0.06);
-  --border-default: rgba(255, 255, 255, 0.1);
-  --border-emphasis: rgba(255, 255, 255, 0.18);
+  /* Semantic borders — thin, neutral */
+  --border-subtle: #e8e8e8;
+  --border-default: #d4d4d4;
+  --border-emphasis: #bdbdbd;
 
-  /* Panel tokens (dashboard prep) */
-  --panel-bg: var(--bg-secondary);
+  /* Panel tokens */
+  --panel-bg: var(--bg-primary);
   --panel-bg-controls: var(--bg-secondary);
-  --panel-bg-data: var(--bg-inset);
-  --panel-bg-interactive: var(--bg-surface);
+  --panel-bg-data: var(--bg-primary);
+  --panel-bg-interactive: var(--bg-primary);
   --panel-border: var(--border-subtle);
   --panel-radius: var(--radius-md);
   --panel-padding: var(--space-lg);
   --panel-gap: var(--space-md);
 
-  /* Shadows */
-  --shadow-panel: 0 2px 8px rgba(0, 0, 0, 0.25), 0 1px 3px rgba(0, 0, 0, 0.15);
-  --shadow-elevated: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
-  --shadow-inset: inset 0 1px 4px rgba(0, 0, 0, 0.3);
+  /* Shadows — flat UI, minimal */
+  --shadow-panel: none;
+  --shadow-elevated: 0 2px 8px rgba(0, 0, 0, 0.12);
+  --shadow-inset: none;
 
   /* Transitions */
   --transition-fast: 0.1s ease;
@@ -67,10 +67,10 @@
   --space-lg: 24px;
   --space-xl: 32px;
 
-  /* Border radius */
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  /* Border radius — tight for scientific feel */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
 }
 
 /* Box-sizing reset */
@@ -80,27 +80,16 @@
   box-sizing: border-box;
 }
 
-/* Body — subtle diagonal gradient + noise texture */
+/* Body — clean white, no gradients or texture */
 body {
   margin: 0;
   font-family: var(--font-body);
   font-weight: var(--font-weight-normal);
-  background: linear-gradient(135deg, var(--bg-primary) 0%, #1b1e34 50%, var(--bg-primary) 100%);
+  background: var(--bg-primary);
   color: var(--text-primary);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-/* Barely-perceptible noise overlay */
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  pointer-events: none;
-  opacity: 0.025;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
 /* Root container */
@@ -149,7 +138,7 @@ a:hover {
 }
 
 /* ========================
-   App Header — left-aligned, instrument aesthetic
+   App Header
    ======================== */
 .app-header {
   text-align: left;
@@ -160,7 +149,7 @@ a:hover {
 
 .app-header__title {
   font-size: 1.75rem;
-  color: var(--accent);
+  color: var(--text-primary);
   margin-bottom: var(--space-xs);
   letter-spacing: -0.03em;
   font-weight: var(--font-weight-semibold);
@@ -184,7 +173,7 @@ a:hover {
 }
 
 /* ========================
-   Step Indicator — left-aligned, rounded-rect dots
+   Step Indicator
    ======================== */
 .step-indicator {
   text-align: left;
@@ -201,7 +190,7 @@ a:hover {
 .step-dot {
   width: 32px;
   height: 24px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -215,16 +204,15 @@ a:hover {
 }
 
 .step-dot--active {
-  background: var(--bg-surface);
+  background: var(--bg-primary);
   color: var(--accent);
   border-color: var(--accent);
 }
 
 .step-dot--current {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: #ffffff;
   border-color: var(--accent);
-  box-shadow: 0 0 12px rgba(83, 199, 240, 0.3);
 }
 
 .step-indicator__label {
@@ -236,15 +224,14 @@ a:hover {
 }
 
 /* ========================
-   Cards — depth hierarchy
+   Cards — flat, thin borders
    ======================== */
 .card {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
   margin-bottom: var(--space-md);
   border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-panel);
   animation: fade-in 0.3s ease both;
 }
 
@@ -260,15 +247,14 @@ a:hover {
   padding: var(--space-lg);
   margin-bottom: var(--space-md);
   border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-inset);
 }
 
 /* ========================
-   Buttons — dual-temperature
+   Buttons — flat, no gradients
    ======================== */
 .btn-primary {
-  background: linear-gradient(180deg, var(--accent-warm) 0%, var(--accent-warm-hover) 100%);
-  color: var(--bg-primary);
+  background: var(--accent-warm);
+  color: #ffffff;
   border: none;
   border-radius: var(--radius-sm);
   padding: var(--space-sm) var(--space-lg);
@@ -276,18 +262,15 @@ a:hover {
   font-weight: var(--font-weight-semibold);
   font-family: var(--font-body);
   cursor: pointer;
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), var(--shadow-panel);
+  transition: background var(--transition-fast);
 }
 
 .btn-primary:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 4px 12px rgba(212, 165, 116, 0.3);
+  background: var(--accent-warm-hover);
 }
 
 .btn-primary:active:not(:disabled) {
-  transform: translateY(0);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  background: #000000;
 }
 
 .btn-primary:disabled {
@@ -298,7 +281,7 @@ a:hover {
 .btn-secondary {
   background: transparent;
   color: var(--text-primary);
-  border: 1px solid var(--text-secondary);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   padding: var(--space-sm) var(--space-lg);
   font-size: 0.95rem;
@@ -319,7 +302,7 @@ a:hover {
 }
 
 .btn-preset {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -327,7 +310,7 @@ a:hover {
   font-size: 0.85rem;
   font-family: var(--font-mono);
   cursor: pointer;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition: border-color var(--transition-fast);
 }
 
 .btn-preset:hover {
@@ -338,25 +321,24 @@ a:hover {
   border-color: var(--accent);
   color: var(--accent);
   background: var(--accent-muted);
-  box-shadow: var(--shadow-inset);
 }
 
 .btn-active {
-  border-color: var(--accent-warm) !important;
-  color: var(--accent-warm) !important;
-  background: var(--accent-warm-muted) !important;
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+  background: var(--accent-muted) !important;
 }
 
 /* ========================
-   Drop Zone — inset background, warm drag accent
+   Drop Zone
    ======================== */
 .drop-zone-wrapper {
   margin-bottom: var(--space-md);
 }
 
 .drop-zone {
-  border: 2px dashed var(--text-tertiary);
-  border-radius: var(--radius-lg);
+  border: 2px dashed var(--border-default);
+  border-radius: var(--radius-md);
   padding: var(--space-xl) var(--space-lg);
   text-align: center;
   cursor: pointer;
@@ -370,10 +352,9 @@ a:hover {
 }
 
 .drop-zone--active {
-  border-color: var(--accent-warm);
-  background: var(--accent-warm-muted);
+  border-color: var(--accent);
+  background: var(--accent-muted);
   border-style: solid;
-  box-shadow: 0 0 20px rgba(212, 165, 116, 0.15);
 }
 
 .drop-zone__icon {
@@ -382,7 +363,7 @@ a:hover {
 }
 
 .drop-zone--active .drop-zone__icon {
-  color: var(--accent-warm);
+  color: var(--accent);
 }
 
 .drop-zone__text {
@@ -432,7 +413,7 @@ a:hover {
   height: 20px;
   border-radius: 50%;
   background: var(--warning);
-  color: var(--bg-primary);
+  color: #ffffff;
   font-size: 0.75rem;
   font-weight: 700;
   flex-shrink: 0;
@@ -466,7 +447,7 @@ a:hover {
 }
 
 /* ========================
-   Dimension Confirmation — monospace data values
+   Dimension Confirmation
    ======================== */
 .dimension-display {
   margin-bottom: var(--space-lg);
@@ -496,7 +477,7 @@ a:hover {
   display: block;
   font-size: 1.8rem;
   font-weight: 700;
-  color: var(--accent);
+  color: var(--text-primary);
   font-family: var(--font-mono);
 }
 
@@ -535,7 +516,7 @@ a:hover {
 }
 
 .custom-rate-input__field {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -548,12 +529,12 @@ a:hover {
 }
 
 .custom-rate-input__field:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 .duration-display {
-  background: var(--bg-surface);
+  background: var(--bg-secondary);
   border-radius: var(--radius-sm);
   padding: var(--space-md);
   margin-bottom: var(--space-md);
@@ -577,7 +558,7 @@ a:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: var(--bg-surface);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   padding: var(--space-md);
@@ -603,7 +584,7 @@ a:hover {
 }
 
 /* ========================
-   Stats Grid — monospace values
+   Stats Grid
    ======================== */
 .stats-grid {
   display: grid;
@@ -613,10 +594,11 @@ a:hover {
 }
 
 .stat-item {
-  background: var(--bg-surface);
+  background: var(--bg-secondary);
   border-radius: var(--radius-sm);
   padding: var(--space-sm) var(--space-md);
   text-align: center;
+  border: 1px solid var(--border-subtle);
 }
 
 .stat-item__label {
@@ -653,7 +635,7 @@ a:hover {
 }
 
 /* ========================
-   Info Summary Bar — monospace values
+   Info Summary Bar
    ======================== */
 .info-summary {
   display: flex;
@@ -727,9 +709,9 @@ a:hover {
 .demo-data-row__field input {
   width: 80px;
   padding: 4px 8px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-0);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.85rem;
@@ -782,8 +764,7 @@ a:hover {
 .viz-header {
   margin-bottom: var(--space-md);
   padding-bottom: var(--space-sm);
-  border-bottom: 2px solid transparent;
-  border-image: linear-gradient(90deg, var(--accent-warm), transparent) 1;
+  border-bottom: 1px solid var(--border-default);
 }
 
 .viz-header__title {
@@ -859,7 +840,6 @@ a:hover {
   }
 }
 
-/* Convergence animation (kept as-is) */
 @keyframes convergence-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(1.3); }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -7,7 +7,6 @@
   border-radius: var(--panel-radius);
   padding: var(--panel-padding);
   border: 1px solid var(--panel-border);
-  box-shadow: var(--shadow-panel);
   animation: fade-in-up 0.4s ease both;
 }
 
@@ -21,18 +20,17 @@
 .dashboard-panel:nth-child(7) { animation-delay: 0.30s; }
 .dashboard-panel:nth-child(8) { animation-delay: 0.35s; }
 
-/* Variant: controls — secondary bg, raised */
+/* Variant: controls — light grey bg */
 .dashboard-panel--controls {
   background: var(--panel-bg-controls);
 }
 
-/* Variant: data — inset bg, recessed feel */
+/* Variant: data — white bg */
 .dashboard-panel--data {
   background: var(--panel-bg-data);
-  box-shadow: var(--shadow-inset);
 }
 
-/* Variant: interactive — surface bg */
+/* Variant: interactive — white bg */
 .dashboard-panel--interactive {
   background: var(--panel-bg-interactive);
 }
@@ -252,7 +250,8 @@
 
 .metrics-panel__stat {
   flex: 1;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   padding: var(--space-sm);
   text-align: center;
@@ -326,12 +325,12 @@
 }
 
 /* ========================
-   Section Divider
+   Section Divider — solid thin line
    ======================== */
 .section-divider {
   border: none;
   height: 1px;
-  background: linear-gradient(90deg, transparent, var(--border-default), transparent);
+  background: var(--border-subtle);
   margin: var(--space-sm) 0;
 }
 
@@ -346,18 +345,4 @@
   .dashboard-panel {
     padding: var(--space-md);
   }
-
-  /*
-  .viz-layout--grid {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "parameters"
-      "toolbar"
-      "traces"
-      "selector"
-      "kernel"
-      "multi-trace"
-      "community";
-  }
-  */
 }

--- a/src/styles/multi-trace.css
+++ b/src/styles/multi-trace.css
@@ -1,4 +1,4 @@
-/* Multi-trace view styles - Scientific Instrument theme */
+/* Multi-trace view styles - Scientific Instrument light theme */
 
 /* ========================
    Multi-Trace Section
@@ -37,15 +37,15 @@
 }
 
 /* ========================
-   Mini-Panel — inset bg, warm active state
+   Mini-Panel — flat, thin borders
    ======================== */
 .mini-panel {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: var(--space-xs);
   cursor: pointer;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition: border-color var(--transition-fast);
 }
 
 .mini-panel:hover {
@@ -53,8 +53,8 @@
 }
 
 .mini-panel--active {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 8px rgba(212, 165, 116, 0.2);
+  border-color: var(--accent);
+  border-width: 2px;
 }
 
 .mini-panel__label {
@@ -92,7 +92,7 @@
 }
 
 .cell-selector__mode {
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -104,13 +104,13 @@
 }
 
 .cell-selector__mode:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 .cell-selector__count {
   width: 60px;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -122,8 +122,8 @@
 }
 
 .cell-selector__count:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 /* Hide spin buttons for cleaner look */
@@ -148,7 +148,7 @@
 }
 
 .cell-selector__step-btn {
-  background: var(--bg-inset);
+  background: var(--bg-secondary);
   border: none;
   color: var(--text-secondary);
   font-size: 0.85rem;
@@ -170,14 +170,14 @@
   padding: 2px 6px;
   min-width: 20px;
   text-align: center;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border-left: 1px solid var(--border-default);
   border-right: 1px solid var(--border-default);
 }
 
 .cell-selector__manual {
   width: 180px;
-  background: var(--bg-inset);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -189,8 +189,8 @@
 }
 
 .cell-selector__manual:focus {
-  border-color: var(--accent-warm);
-  box-shadow: 0 0 0 2px var(--accent-warm-muted);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
 }
 
 /* ========================
@@ -220,7 +220,7 @@
 }
 
 /* ========================
-   Toolbar Row — border + warm active
+   Toolbar Row
    ======================== */
 .viz-toolbar {
   display: flex;

--- a/src/styles/tutorial.css
+++ b/src/styles/tutorial.css
@@ -1,8 +1,8 @@
-/* CaTune dark theme overrides for driver.js popovers.
+/* CaTune light theme overrides for driver.js popovers.
    Must be imported AFTER driver.js/dist/driver.css to override defaults. */
 
 .driver-popover {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -10,7 +10,7 @@
 }
 
 .driver-popover .driver-popover-title {
-  color: var(--accent);
+  color: var(--text-primary);
   font-size: 1.1rem;
   font-weight: var(--font-weight-semibold);
 }
@@ -26,10 +26,10 @@
   font-family: var(--font-mono);
 }
 
-/* Next and Done buttons: accent-colored */
+/* Next and Done buttons */
 .driver-popover-next-btn {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: #ffffff;
   border: none;
   border-radius: var(--radius-sm);
   padding: var(--space-xs) var(--space-md);
@@ -41,7 +41,7 @@
 .driver-popover-prev-btn {
   background: transparent;
   color: var(--text-secondary);
-  border: 1px solid var(--text-secondary);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   padding: var(--space-xs) var(--space-md);
   font-weight: var(--font-weight-semibold);
@@ -58,14 +58,14 @@
 .driver-popover-arrow-side-right .driver-popover-arrow,
 .driver-popover-arrow-side-top .driver-popover-arrow,
 .driver-popover-arrow-side-bottom .driver-popover-arrow {
-  border-color: var(--bg-secondary);
+  border-color: var(--bg-primary);
 }
 
 /* ========================
-   Tutorial Panel — elevated shadow, warm borders
+   Tutorial Panel
    ======================== */
 .tutorial-panel {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
   margin-bottom: var(--space-md);
@@ -76,10 +76,10 @@
 }
 
 /* ========================
-   Tutorial Cards — inset bg
+   Tutorial Cards
    ======================== */
 .tutorial-card {
-  background: var(--bg-inset);
+  background: var(--bg-secondary);
   border-radius: var(--radius-sm);
   padding: var(--space-md);
   margin-bottom: var(--space-sm);
@@ -142,26 +142,26 @@
 }
 
 .level-badge--beginner {
-  background: rgba(46, 204, 113, 0.15);
+  background: rgba(46, 125, 50, 0.1);
   color: var(--success);
 }
 
 .level-badge--intermediate {
-  background: rgba(83, 199, 240, 0.15);
+  background: rgba(33, 113, 181, 0.1);
   color: var(--accent);
 }
 
 .level-badge--advanced {
-  background: rgba(240, 165, 0, 0.15);
+  background: rgba(224, 152, 0, 0.1);
   color: var(--warning);
 }
 
 /* ========================
-   First-Time Tutorial Banner — warm accent
+   First-Time Tutorial Banner
    ======================== */
 .tutorial-banner {
-  background: linear-gradient(90deg, var(--accent-warm-muted), transparent);
-  border-left: 3px solid var(--accent-warm);
+  background: var(--bg-secondary);
+  border-left: 3px solid var(--accent);
   border-radius: var(--radius-md);
   padding: var(--space-md) var(--space-lg);
   margin-bottom: var(--space-md);


### PR DESCRIPTION
## Summary
- **Complete visual overhaul** from dark glassmorphic SaaS aesthetic to a clean, technical light theme inspired by JupyterLab, MATLAB plots, and scientific journal figures
- **White content + grey chrome** layout pattern — data areas are white for accurate color perception, UI frame uses neutral grey (#f0f0f0)
- **Matplotlib tab10 palette** for all data traces (raw=#1f77b4, fit=#ff7f0e, deconv=#2ca02c, residuals=#d62728) replacing neon accent colors
- **Flat UI everywhere** — no shadows, no gradients, thin solid borders (1px #e8e8e8), tight radii (2/4/6px), system fonts for body text
- Adds "Time (s)" x-axis label to zoom windows, fixes parameter slider text box alignment

## Changes across 18 files
- `global.css` — Full design token rewrite (colors, spacing, typography, borders, shadows)
- `layout.css`, `cards.css`, `controls.css`, `multi-trace.css`, `community.css`, `compact-header.css`, `tutorial.css` — Light theme component styles
- `chart-theme.css` — Light uPlot theme (white background, grey gridlines)
- `series-config.ts` — Matplotlib tab10 trace colors
- `TracePanel.tsx`, `TraceOverview.tsx`, `ScatterPlot.tsx`, `TracePreview.tsx` — Hardcoded canvas colors (uPlot can't resolve CSS variables in fillText)
- `ZoomWindow.tsx` — Added x-axis "Time (s)" label
- `ParameterSlider.tsx`, `ParameterPanel.tsx` — Always render unit span for alignment
- `index.html` — Removed DM Sans font import

## Test plan
- [x] Load app and verify light theme renders correctly across all panels
- [x] Verify trace colors match matplotlib tab10 palette in zoom windows and overview
- [x] Check parameter sliders align properly (tau/lambda with units vs unitless sparsity)
- [x] Verify zoom window x-axis shows "Time (s)" with minimal gap
- [x] Test community/auth modals for light theme consistency
- [x] Verify uPlot axis labels remain visible on data updates (canvas color regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)