### PR TITLE
feat: fix pin overlay rendering in zoom charts

### DIFF
--- a/src/components/cards/CardGrid.tsx
+++ b/src/components/cards/CardGrid.tsx
@@ -15,6 +15,7 @@ import {
   multiCellResults,
   cellSolverStatuses,
   gridColumns,
+  pinnedMultiCellResults,
 } from '../../lib/multi-cell-store';
 import { reportCellZoom } from '../../lib/cell-solve-manager';
 import { samplingRate } from '../../lib/data-store';
@@ -42,6 +43,7 @@ export function CardGrid(props: CardGridProps) {
           <For each={cells()}>
             {(cellIndex) => {
               const traces = createMemo(() => multiCellResults().get(cellIndex));
+              const pinnedTraces = createMemo(() => pinnedMultiCellResults().get(cellIndex));
               return (
                 <Show when={traces()}>
                   {(t) => (
@@ -56,6 +58,9 @@ export function CardGrid(props: CardGridProps) {
                       onClick={() => props.onCellClick(cellIndex)}
                       onZoomChange={reportCellZoom}
                       windowStartSample={t().windowStartSample}
+                      pinnedDeconvolved={pinnedTraces()?.deconvolved}
+                      pinnedReconvolution={pinnedTraces()?.reconvolution}
+                      pinnedWindowStartSample={pinnedTraces()?.windowStartSample}
                     />
                   )}
                 </Show>

--- a/src/components/cards/CellCard.tsx
+++ b/src/components/cards/CellCard.tsx
@@ -21,6 +21,9 @@ export interface CellCardProps {
   onClick?: () => void;
   onZoomChange?: (cellIndex: number, startS: number, endS: number) => void;
   windowStartSample?: number;
+  pinnedDeconvolved?: Float32Array;
+  pinnedReconvolution?: Float32Array;
+  pinnedWindowStartSample?: number;
 }
 
 const DEFAULT_ZOOM_WINDOW_S = 60; // 60 seconds default zoom window
@@ -86,6 +89,9 @@ export function CellCard(props: CellCardProps) {
             syncKey={`${ZOOM_SYNC_KEY}-${props.cellIndex}`}
             onZoomChange={handleZoomChange}
             deconvWindowOffset={props.windowStartSample}
+            pinnedDeconvolved={props.pinnedDeconvolved}
+            pinnedReconvolution={props.pinnedReconvolution}
+            pinnedWindowOffset={props.pinnedWindowStartSample}
             data-tutorial={props.isActive ? 'zoom-window' : undefined}
           />
         </div>

--- a/src/lib/chart/series-config.ts
+++ b/src/lib/chart/series-config.ts
@@ -19,23 +19,22 @@ export function createResidualSeries(): uPlot.Series {
 }
 
 /**
- * Create a dimmed dashed overlay variant for pinned snapshot comparison.
- * Uses 35% opacity and a [4,4] dash pattern.
+ * Create a dashed overlay variant for pinned snapshot comparison.
+ * Uses 65% opacity and a [8,4] dash pattern for clear visibility.
  */
 export function createPinnedOverlaySeries(
   label: string,
   baseStroke: string,
   baseWidth: number,
 ): uPlot.Series {
-  // Convert hex to 35% opacity rgba, or handle hsl→hsla
-  let hslaStroke: string;
+  let stroke: string;
   if (baseStroke.startsWith('#')) {
     const r = parseInt(baseStroke.slice(1, 3), 16);
     const g = parseInt(baseStroke.slice(3, 5), 16);
     const b = parseInt(baseStroke.slice(5, 7), 16);
-    hslaStroke = `rgba(${r}, ${g}, ${b}, 0.35)`;
+    stroke = `rgba(${r}, ${g}, ${b}, 0.65)`;
   } else {
-    hslaStroke = baseStroke.replace('hsl(', 'hsla(').replace(')', ', 0.35)');
+    stroke = baseStroke.replace('hsl(', 'hsla(').replace(')', ', 0.65)');
   }
-  return { label, stroke: hslaStroke, width: baseWidth, dash: [4, 4] };
+  return { label, stroke, width: baseWidth + 0.5, dash: [8, 4] };
 }

--- a/src/lib/multi-cell-store.ts
+++ b/src/lib/multi-cell-store.ts
@@ -33,6 +33,9 @@ const [activityRanking, setActivityRanking] = createSignal<number[] | null>(null
 const [gridColumns, setGridColumns] = createSignal<number>(2);
 const [cellSolverStatuses, setCellSolverStatuses] = createSignal<Map<number, CellSolverStatus>>(new Map());
 
+// --- Pinned multi-cell results for before/after comparison ---
+const [pinnedMultiCellResults, setPinnedMultiCellResults] = createSignal<Map<number, CellTraces>>(new Map());
+
 // --- Per-cell update helpers ---
 
 function updateOneCellStatus(cellIndex: number, status: CellSolverStatus): void {
@@ -108,6 +111,25 @@ function updateCellSelection(): void {
   }
 }
 
+/** Snapshot current multi-cell results for pinned overlay comparison. */
+function pinMultiCellResults(): void {
+  const current = multiCellResults();
+  const snapshot = new Map<number, CellTraces>();
+  for (const [cellIdx, traces] of current) {
+    snapshot.set(cellIdx, {
+      ...traces,
+      deconvolved: new Float32Array(traces.deconvolved),
+      reconvolution: new Float32Array(traces.reconvolution),
+    });
+  }
+  setPinnedMultiCellResults(snapshot);
+}
+
+/** Clear pinned multi-cell results. */
+function unpinMultiCellResults(): void {
+  setPinnedMultiCellResults(new Map());
+}
+
 /**
  * Clear all multi-cell solver results (e.g., when parameters change).
  */
@@ -142,6 +164,7 @@ export {
   activityRanking,
   gridColumns,
   cellSolverStatuses,
+  pinnedMultiCellResults,
   // Setters
   setSelectionMode,
   setSelectedCells,
@@ -162,4 +185,6 @@ export {
   updateCellSelection,
   clearMultiCellResults,
   clearMultiCellState,
+  pinMultiCellResults,
+  unpinMultiCellResults,
 };

--- a/src/lib/viz-store.ts
+++ b/src/lib/viz-store.ts
@@ -5,6 +5,7 @@
 import { createSignal, createMemo } from 'solid-js';
 import type { NpyResult } from './types';
 import { extractCellTrace } from './array-utils';
+import { pinMultiCellResults, unpinMultiCellResults } from './multi-cell-store';
 
 // --- Cell selection ---
 
@@ -57,6 +58,9 @@ function pinCurrentSnapshot(): void {
     tauDecay: tauDecay(),
     lambda: lambda(),
   });
+
+  // Also snapshot all multi-cell results for card grid overlays
+  pinMultiCellResults();
 }
 
 /** Clear pinned snapshot data. */
@@ -64,6 +68,7 @@ function unpinSnapshot(): void {
   setPinnedDeconvolved(null);
   setPinnedReconvolution(null);
   setPinnedParams(null);
+  unpinMultiCellResults();
 }
 
 // --- Derived: residual trace ---


### PR DESCRIPTION
## Summary
- **Fixed the Pin button** — it stored snapshot data but never passed pinned traces to the chart rendering pipeline
- **Wired full data flow**: pinned multi-cell results are deep-copied on pin, then passed through `CardGrid → CellCard → ZoomWindow` and rendered as dashed overlay series (deconv + reconvolution)
- **Improved pinned trace visibility**: bumped opacity from 35% → 65%, dash pattern from `[4,4]` → `[8,4]`, and added +0.5px line width so overlays are clearly distinguishable

## Test plan
- [x] Load demo data, wait for solver to complete on all cells
- [x] Click "Pin" — button should show active state with parameter info
- [x] Adjust tau_rise or tau_decay slider — new solid traces should appear alongside dashed pinned traces
- [x] Verify both pinned deconvolved (green dashed) and pinned fit (orange dashed) are visible
- [x] Click "Unpin" — dashed overlays should disappear
- [x] Switch cells — pinned state should auto-clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)