### PR TITLE
feat: data source filtering, median marker, and demo submission UX

### DIFF
--- a/src/components/community/SubmitPanel.tsx
+++ b/src/components/community/SubmitPanel.tsx
@@ -20,6 +20,7 @@ import {
   rawFile,
   parsedData,
   durationSeconds,
+  isDemo,
 } from '../../lib/data-store';
 import { computeAR2 } from '../../lib/ar2';
 import { buildExportData, downloadExport } from '../../lib/export';
@@ -71,9 +72,10 @@ export function SubmitPanel() {
 
   // --- Derived ---
   const requiredFieldsFilled = () =>
-    indicator().trim() !== '' &&
+    isDemo() ||
+    (indicator().trim() !== '' &&
     species().trim() !== '' &&
-    brainRegion().trim() !== '';
+    brainRegion().trim() !== '');
 
   // --- Handlers ---
 
@@ -146,19 +148,19 @@ export function SubmitPanel() {
         sampling_rate: fs,
         ar2_g1: ar2.g1,
         ar2_g2: ar2.g2,
-        indicator: indicator().trim(),
-        species: species().trim(),
-        brain_region: brainRegion().trim(),
+        indicator: isDemo() ? 'simulated' : indicator().trim(),
+        species: isDemo() ? 'simulated' : species().trim(),
+        brain_region: isDemo() ? 'simulated' : brainRegion().trim(),
         lab_name: labName().trim() || undefined,
         orcid: orcid().trim() || undefined,
-        virus_construct: virusConstruct().trim() || undefined,
-        time_since_injection_days: timeSinceInjection()
-          ? parseInt(timeSinceInjection(), 10)
-          : undefined,
+        virus_construct: isDemo() ? undefined : virusConstruct().trim() || undefined,
+        time_since_injection_days: isDemo() ? undefined
+          : timeSinceInjection() ? parseInt(timeSinceInjection(), 10) : undefined,
         notes: notes().trim() || undefined,
-        microscope_type: microscopeType().trim() || undefined,
-        imaging_depth_um: imagingDepth() ? parseFloat(imagingDepth()) : undefined,
-        cell_type: cellType().trim() || undefined,
+        microscope_type: isDemo() ? undefined : microscopeType().trim() || undefined,
+        imaging_depth_um: isDemo() ? undefined
+          : imagingDepth() ? parseFloat(imagingDepth()) : undefined,
+        cell_type: isDemo() ? undefined : cellType().trim() || undefined,
         num_cells: shape?.[0],
         recording_length_s: durationSeconds() ?? undefined,
         fps: fs,
@@ -253,93 +255,126 @@ export function SubmitPanel() {
           >
             <div class="submit-modal__content">
               <h3 class="submit-modal__title">Submit to Community</h3>
+
+              <Show when={isDemo()}>
+                <div class="submit-panel__demo-notice">
+                  You're tuning on simulated demo data — submitting is encouraged!
+                  This helps the community see what parameters work well for the demo dataset.
+                </div>
+              </Show>
+
               <AuthGate />
 
               <Show when={user()}>
-                {/* Required fields */}
-                <div class="submit-panel__field">
-                  <label>
-                    Calcium Indicator <span class="submit-panel__required-marker">*</span>
-                  </label>
-                  <SearchableSelect
-                    options={fieldOptions().indicators}
-                    value={indicator()}
-                    onChange={setIndicator}
-                    placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. GCaMP6f (AAV)'}
-                  />
-                  <div class="submit-panel__request-link">
-                    Don't see yours? <a href={buildFieldOptionRequestUrl('indicator')} target="_blank" rel="noopener noreferrer">Request it</a>
+                {/* Experiment metadata fields — hidden for demo data */}
+                <Show when={!isDemo()}>
+                  {/* Required fields */}
+                  <div class="submit-panel__field">
+                    <label>
+                      Calcium Indicator <span class="submit-panel__required-marker">*</span>
+                    </label>
+                    <SearchableSelect
+                      options={fieldOptions().indicators}
+                      value={indicator()}
+                      onChange={setIndicator}
+                      placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. GCaMP6f (AAV)'}
+                    />
+                    <div class="submit-panel__request-link">
+                      Don't see yours? <a href={buildFieldOptionRequestUrl('indicator')} target="_blank" rel="noopener noreferrer">Request it</a>
+                    </div>
                   </div>
-                </div>
 
-                <div class="submit-panel__field">
-                  <label>
-                    Species <span class="submit-panel__required-marker">*</span>
-                  </label>
-                  <SearchableSelect
-                    options={fieldOptions().species}
-                    value={species()}
-                    onChange={setSpecies}
-                    placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. mouse'}
-                  />
-                  <div class="submit-panel__request-link">
-                    Don't see yours? <a href={buildFieldOptionRequestUrl('species')} target="_blank" rel="noopener noreferrer">Request it</a>
+                  <div class="submit-panel__field">
+                    <label>
+                      Species <span class="submit-panel__required-marker">*</span>
+                    </label>
+                    <SearchableSelect
+                      options={fieldOptions().species}
+                      value={species()}
+                      onChange={setSpecies}
+                      placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. mouse'}
+                    />
+                    <div class="submit-panel__request-link">
+                      Don't see yours? <a href={buildFieldOptionRequestUrl('species')} target="_blank" rel="noopener noreferrer">Request it</a>
+                    </div>
                   </div>
-                </div>
 
-                <div class="submit-panel__field">
-                  <label>
-                    Brain Region <span class="submit-panel__required-marker">*</span>
-                  </label>
-                  <SearchableSelect
-                    options={fieldOptions().brainRegions}
-                    value={brainRegion()}
-                    onChange={setBrainRegion}
-                    placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. cortex'}
-                  />
-                  <div class="submit-panel__request-link">
-                    Don't see yours? <a href={buildFieldOptionRequestUrl('brain_region')} target="_blank" rel="noopener noreferrer">Request it</a>
+                  <div class="submit-panel__field">
+                    <label>
+                      Brain Region <span class="submit-panel__required-marker">*</span>
+                    </label>
+                    <SearchableSelect
+                      options={fieldOptions().brainRegions}
+                      value={brainRegion()}
+                      onChange={setBrainRegion}
+                      placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. cortex'}
+                    />
+                    <div class="submit-panel__request-link">
+                      Don't see yours? <a href={buildFieldOptionRequestUrl('brain_region')} target="_blank" rel="noopener noreferrer">Request it</a>
+                    </div>
                   </div>
-                </div>
 
-                {/* Optional fields */}
-                <div class="submit-panel__field">
-                  <label>Microscope Type</label>
-                  <SearchableSelect
-                    options={fieldOptions().microscopeTypes}
-                    value={microscopeType()}
-                    onChange={setMicroscopeType}
-                    placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. 2-photon'}
-                  />
-                  <div class="submit-panel__request-link">
-                    Don't see yours? <a href={buildFieldOptionRequestUrl('microscope_type')} target="_blank" rel="noopener noreferrer">Request it</a>
+                  {/* Optional experiment fields */}
+                  <div class="submit-panel__field">
+                    <label>Microscope Type</label>
+                    <SearchableSelect
+                      options={fieldOptions().microscopeTypes}
+                      value={microscopeType()}
+                      onChange={setMicroscopeType}
+                      placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. 2-photon'}
+                    />
+                    <div class="submit-panel__request-link">
+                      Don't see yours? <a href={buildFieldOptionRequestUrl('microscope_type')} target="_blank" rel="noopener noreferrer">Request it</a>
+                    </div>
                   </div>
-                </div>
 
-                <div class="submit-panel__field">
-                  <label>Cell Type</label>
-                  <SearchableSelect
-                    options={fieldOptions().cellTypes}
-                    value={cellType()}
-                    onChange={setCellType}
-                    placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. pyramidal cell'}
-                  />
-                  <div class="submit-panel__request-link">
-                    Don't see yours? <a href={buildFieldOptionRequestUrl('cell_type')} target="_blank" rel="noopener noreferrer">Request it</a>
+                  <div class="submit-panel__field">
+                    <label>Cell Type</label>
+                    <SearchableSelect
+                      options={fieldOptions().cellTypes}
+                      value={cellType()}
+                      onChange={setCellType}
+                      placeholder={fieldOptionsLoading() ? 'Loading...' : 'e.g. pyramidal cell'}
+                    />
+                    <div class="submit-panel__request-link">
+                      Don't see yours? <a href={buildFieldOptionRequestUrl('cell_type')} target="_blank" rel="noopener noreferrer">Request it</a>
+                    </div>
                   </div>
-                </div>
 
-                <div class="submit-panel__field">
-                  <label>Imaging Depth (um)</label>
-                  <input
-                    type="number"
-                    value={imagingDepth()}
-                    onInput={(e) => setImagingDepth(e.currentTarget.value)}
-                    placeholder="Optional"
-                    min="0"
-                  />
-                </div>
+                  <div class="submit-panel__field">
+                    <label>Imaging Depth (um)</label>
+                    <input
+                      type="number"
+                      value={imagingDepth()}
+                      onInput={(e) => setImagingDepth(e.currentTarget.value)}
+                      placeholder="Optional"
+                      min="0"
+                    />
+                  </div>
 
+                  <div class="submit-panel__field">
+                    <label>Virus / Construct</label>
+                    <input
+                      type="text"
+                      value={virusConstruct()}
+                      onInput={(e) => setVirusConstruct(e.currentTarget.value)}
+                      placeholder="Optional"
+                    />
+                  </div>
+
+                  <div class="submit-panel__field">
+                    <label>Time Since Injection (days)</label>
+                    <input
+                      type="number"
+                      value={timeSinceInjection()}
+                      onInput={(e) => setTimeSinceInjection(e.currentTarget.value)}
+                      placeholder="Optional"
+                      min="0"
+                    />
+                  </div>
+                </Show>
+
+                {/* General optional fields — always visible */}
                 <div class="submit-panel__field">
                   <label>Lab Name</label>
                   <input
@@ -357,27 +392,6 @@ export function SubmitPanel() {
                     value={orcid()}
                     onInput={(e) => setOrcid(e.currentTarget.value)}
                     placeholder="0000-0000-0000-0000"
-                  />
-                </div>
-
-                <div class="submit-panel__field">
-                  <label>Virus / Construct</label>
-                  <input
-                    type="text"
-                    value={virusConstruct()}
-                    onInput={(e) => setVirusConstruct(e.currentTarget.value)}
-                    placeholder="Optional"
-                  />
-                </div>
-
-                <div class="submit-panel__field">
-                  <label>Time Since Injection (days)</label>
-                  <input
-                    type="number"
-                    value={timeSinceInjection()}
-                    onInput={(e) => setTimeSinceInjection(e.currentTarget.value)}
-                    placeholder="Optional"
-                    min="0"
                   />
                 </div>
 

--- a/src/lib/community/quality-checks.ts
+++ b/src/lib/community/quality-checks.ts
@@ -8,7 +8,7 @@ import type { QualityCheckResult } from './types.ts';
 const HARD_LIMITS = {
   tauRise: { min: 0.001, max: 0.5, label: 'tau_rise' },
   tauDecay: { min: 0.01, max: 10, label: 'tau_decay' },
-  lambda: { min: 1e-6, max: 1.0, label: 'lambda' },
+  lambda: { min: 1e-6, max: 10, label: 'lambda' },
   samplingRate: { min: 1, max: 1000, label: 'sampling_rate' },
 } as const;
 

--- a/src/lib/data-store.ts
+++ b/src/lib/data-store.ts
@@ -45,6 +45,9 @@ const durationSeconds = createMemo<number | null>(() => {
   return rate && tp ? tp / rate : null;
 });
 
+/** True when loaded data is demo-generated (parsedData present but no rawFile). */
+const isDemo = createMemo(() => parsedData() !== null && rawFile() === null);
+
 const importStep = createMemo<ImportStep>(() => {
   if (!parsedData()) return 'drop';
   if (!dimensionsConfirmed()) return 'confirm-dims';
@@ -125,6 +128,7 @@ export {
   numTimepoints,
   durationSeconds,
   importStep,
+  isDemo,
   // Actions
   resetImport,
   loadDemoData,

--- a/src/lib/param-config.ts
+++ b/src/lib/param-config.ts
@@ -21,7 +21,7 @@ export const PARAM_RANGES = {
   },
   lambda: {
     min: 0,        // No sparsity penalty
-    max: 4.0,      // High sparsity (only largest events)
+    max: 10,       // High sparsity (only largest events)
     default: 0.01, // Moderate sparsity
     logScale: false,
   },

--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -285,6 +285,17 @@
   min-height: 60px;
 }
 
+.submit-panel__demo-notice {
+  background: var(--accent-muted);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
 .submit-panel__required-marker {
   color: var(--error);
   font-weight: 700;
@@ -438,6 +449,53 @@
   border-color: var(--accent);
   color: var(--accent);
   background: var(--accent-muted);
+}
+
+/* Data source toggle */
+
+.community-browser__source-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.community-browser__source-toggle {
+  display: flex;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  width: fit-content;
+}
+
+.community-browser__source-btn {
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: none;
+  padding: var(--space-xs) var(--space-md);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.community-browser__source-btn:not(:last-child) {
+  border-right: 1px solid var(--border-default);
+}
+
+.community-browser__source-btn:hover {
+  color: var(--text-primary);
+}
+
+.community-browser__source-btn--active {
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-weight: var(--font-weight-medium);
+}
+
+.community-browser__source-hint {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-style: italic;
 }
 
 /* ========================

--- a/supabase/migrations/001_community_submissions.sql
+++ b/supabase/migrations/001_community_submissions.sql
@@ -52,7 +52,7 @@ CREATE TABLE community_submissions (
   -- Constraints
   CONSTRAINT valid_tau_rise CHECK (tau_rise > 0 AND tau_rise < 1),
   CONSTRAINT valid_tau_decay CHECK (tau_decay > 0 AND tau_decay < 10),
-  CONSTRAINT valid_lambda CHECK (lambda > 0 AND lambda < 1),
+  CONSTRAINT valid_lambda CHECK (lambda >= 0 AND lambda <= 10),
   CONSTRAINT valid_sampling_rate CHECK (sampling_rate > 0 AND sampling_rate <= 1000),
   CONSTRAINT valid_data_source CHECK (data_source IN ('user', 'demo', 'training'))
 );


### PR DESCRIPTION
## Summary
- **Data source toggle**: Community browser filters submissions by `data_source` (user/demo) via a segmented control that auto-switches when demo data is loaded
- **Median crosshairs**: Scatter plot now shows thin crosshair lines and a marker at the median tau_rise/tau_decay values
- **Simplified demo submissions**: Hides experiment-specific fields (indicator, species, brain region, microscope, etc.) for demo data, auto-fills DB `NOT NULL` columns with `'simulated'`, and shows an encouragement notice; Lab Name, ORCID, and Notes remain visible
- **Lambda range extended**: Increased from [0, 1] to [0, 10] across app validation, GUI slider, and DB CHECK constraint

## Files changed
- `src/lib/data-store.ts` — new `isDemo` derived signal
- `src/components/community/CommunityBrowser.tsx` — data source toggle + filtering
- `src/components/community/ScatterPlot.tsx` — median crosshairs + marker
- `src/components/community/SubmitPanel.tsx` — demo-aware form with encouragement notice
- `src/lib/community/quality-checks.ts` — lambda hard limit → 10
- `src/lib/param-config.ts` — GUI slider max → 10
- `src/styles/community.css` — toggle + notice styles
- `supabase/migrations/001_community_submissions.sql` — lambda CHECK → [0, 10]

## DB migration required
Run on the live Supabase instance:
```sql
ALTER TABLE community_submissions
  DROP CONSTRAINT valid_lambda,
  ADD CONSTRAINT valid_lambda CHECK (lambda >= 0 AND lambda <= 10);
```

## Test plan
- [x] Load demo data → community browser auto-switches to "Demo data" toggle
- [x] Load a real file → switches back to "User data"
- [x] Manual toggle between User/Demo data sources filters scatter plot
- [x] Scatter plot shows median crosshair lines + marker at correct position
- [x] Submit with demo data: form shows only Lab Name, ORCID, Notes + encouragement notice
- [x] Submit with user data: full form with all required/optional fields
- [x] Lambda values up to 10 accepted by app validation and DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)