### PR TITLE
feat: add PyPI publishing for catune Python package

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,51 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags: ['py/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+        working-directory: python
+
+      - name: Run tests
+        run: pytest
+        working-directory: python
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+        working-directory: python
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Daniel Aharoni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,28 @@ description = "CaTune companion: calcium imaging deconvolution and data preparat
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Daniel Aharoni" }]
+keywords = ["calcium-imaging", "deconvolution", "neuroscience", "FISTA", "spike-inference"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Typing :: Typed",
+]
 dependencies = ["numpy>=1.24"]
+
+[project.urls]
+Homepage = "https://github.com/miniscope/CaTune"
+Repository = "https://github.com/miniscope/CaTune"
+Issues = "https://github.com/miniscope/CaTune/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]


### PR DESCRIPTION
## Summary
- Add CI workflow (`.github/workflows/publish-python.yml`) to publish the `catune` Python package to PyPI using trusted publisher (OIDC) — no API token secrets needed
- Use `py/v*` tag prefix for Python releases, keeping `v*` for web app deploys
- Add MIT LICENSE file to `python/`
- Enhance `pyproject.toml` with author, classifiers, keywords, and project URLs for the PyPI listing

## Setup required after merge
1. On [PyPI](https://pypi.org/manage/project/catune/settings/publishing/), add a trusted publisher:
   - Owner: `miniscope`, Repo: `CaTune`, Workflow: `publish-python.yml`, Environment: `pypi`
2. On GitHub, create a `pypi` [environment](https://github.com/miniscope/CaTune/settings/environments)
3. To publish: `git tag py/v0.1.0 && git push origin py/v0.1.0`

## Test plan
- [x] Verify `publish-python.yml` syntax is valid (CI will check)
- [ ] After merge, configure trusted publisher on PyPI and test with `py/v0.1.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)