### PR TITLE
Fix zoom window drag-pan conflict and cursor-centered zoom

### DIFF
--- a/src/components/cards/ZoomWindow.tsx
+++ b/src/components/cards/ZoomWindow.tsx
@@ -305,7 +305,8 @@ export function ZoomWindow(props: ZoomWindowProps) {
     const startStart = props.startTime;
     const startEnd = props.endTime;
     const windowDuration = startEnd - startStart;
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const overEl = (e.currentTarget as HTMLElement).querySelector<HTMLElement>('.u-over');
+    const rect = overEl ? overEl.getBoundingClientRect() : (e.currentTarget as HTMLElement).getBoundingClientRect();
     const pxToTime = windowDuration / rect.width;
     const totalDuration = props.rawTrace.length / props.samplingRate;
 
@@ -355,8 +356,9 @@ export function ZoomWindow(props: ZoomWindowProps) {
       ? Math.max(MIN_WINDOW_S, currentRange * ZOOM_FACTOR)
       : Math.min(totalDuration, currentRange / ZOOM_FACTOR);
 
-    // Center zoom on cursor horizontal position
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    // Center zoom on cursor horizontal position (use .u-over plot area, not outer div with y-axis gutter)
+    const overEl = (e.currentTarget as HTMLElement).querySelector<HTMLElement>('.u-over');
+    const rect = overEl ? overEl.getBoundingClientRect() : (e.currentTarget as HTMLElement).getBoundingClientRect();
     const cursorFraction = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
     const cursorTime = props.startTime + cursorFraction * currentRange;
 

--- a/src/components/traces/TracePanel.tsx
+++ b/src/components/traces/TracePanel.tsx
@@ -90,11 +90,14 @@ export function TracePanel(props: TracePanelProps) {
 
   const yAxis = () => props.hideYValues ? yAxisHidden : yAxisBase;
 
-  const cursorConfig = {
-    sync: {
-      key: props.syncKey,
-      setSeries: true,
-    },
+  const cursorConfig = (): uPlot.Cursor => {
+    const cfg: uPlot.Cursor = {
+      sync: { key: props.syncKey, setSeries: true },
+    };
+    if (props.disableWheelZoom) {
+      cfg.drag = { x: false, y: false };
+    }
+    return cfg;
   };
 
   return (
@@ -103,7 +106,7 @@ export function TracePanel(props: TracePanelProps) {
         data={props.data()}
         series={props.series}
         scales={scales()}
-        cursor={cursorConfig}
+        cursor={cursorConfig()}
         axes={[xAxis, yAxis()]}
         plugins={plugins()}
         height={height()}


### PR DESCRIPTION
## Summary
- **Disable uPlot box-select in zoom window:** Set `cursor.drag = { x: false, y: false }` when `disableWheelZoom` is true, preventing uPlot's default box-select from competing with ZoomWindow's custom pan handler
- **Fix cursor position calculations:** Use `.u-over` plot area bounding rect instead of outer `.zoom-window` div for both `handleMouseDown` (drag) and `handleWheel` (Ctrl+scroll zoom), accounting for the ~20px y-axis gutter offset

## Test plan
- [x] Open a cell card with data loaded
- [x] Left-click + drag in the zoom window — should pan smoothly with no box-select appearing
- [x] Ctrl+scroll in the zoom window — zoom should center on cursor position (hover at different x positions to verify)
- [x] Verify minimap drag still works correctly (untouched)
- [x] Verify non-zoom-window TracePanels still have working wheel zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)