### PR TITLE
Remove community submission quality score

### DIFF
--- a/src/components/community/SubmissionSummary.tsx
+++ b/src/components/community/SubmissionSummary.tsx
@@ -1,7 +1,6 @@
 /**
  * Post-submission confirmation card.
- * Displays what was submitted, quality score, and actions
- * (close or delete the submission).
+ * Displays what was submitted and actions (close or delete the submission).
  */
 
 import { createSignal, Show } from 'solid-js';
@@ -55,12 +54,6 @@ export function SubmissionSummary(props: SubmissionSummaryProps) {
         <span>Species: {props.submission.species}</span>
         <span>Brain region: {props.submission.brain_region}</span>
       </div>
-
-      <Show when={props.submission.quality_score != null}>
-        <p class="submission-summary__quality">
-          Quality score: {((props.submission.quality_score ?? 0) * 100).toFixed(0)}%
-        </p>
-      </Show>
 
       <p class="submission-summary__timestamp">
         Submitted: {new Date(props.submission.created_at).toLocaleString()}

--- a/src/components/community/SubmitPanel.tsx
+++ b/src/components/community/SubmitPanel.tsx
@@ -89,8 +89,6 @@ export function SubmitPanel() {
       tauDecay: tauDecay(),
       lambda: lambda(),
       samplingRate: fs,
-      numCells: shape?.[0],
-      recordingLengthS: durationSeconds() ?? undefined,
     });
 
     if (!validation.valid) {

--- a/src/lib/community/quality-checks.ts
+++ b/src/lib/community/quality-checks.ts
@@ -1,8 +1,7 @@
-// Parameter validation and quality scoring for community submissions.
+// Parameter validation for community submissions.
 // Hard limits block submission (validateSubmission).
-// Soft scoring provides informational quality (computeQualityScore).
 
-import type { QualityCheckResult } from './types.ts';
+import type { ValidationResult } from './types.ts';
 
 /** Hard parameter range limits that block submission if violated. */
 const HARD_LIMITS = {
@@ -22,14 +21,10 @@ interface ValidationParams {
 /**
  * Validate parameters against hard limits.
  * Returns valid=false with human-readable issues if any check fails.
- * Also includes a soft quality score.
  */
 export function validateSubmission(
-  params: ValidationParams & {
-    numCells?: number;
-    recordingLengthS?: number;
-  },
-): QualityCheckResult {
+  params: ValidationParams,
+): ValidationResult {
   const issues: string[] = [];
 
   // tau_rise range check
@@ -67,55 +62,8 @@ export function validateSubmission(
     );
   }
 
-  const score = computeQualityScore(params);
-
   return {
     valid: issues.length === 0,
-    score,
     issues,
   };
-}
-
-/**
- * Compute a soft quality score from 0.0 to 1.0.
- * Does not block submission -- provides informational quality assessment.
- * Penalizes unusual parameter ranges and rewards larger datasets.
- */
-export function computeQualityScore(params: {
-  tauRise: number;
-  tauDecay: number;
-  lambda?: number;
-  samplingRate?: number;
-  numCells?: number;
-  recordingLengthS?: number;
-}): number {
-  let score = 1.0;
-
-  // Penalize unusual tau_rise (typical: 5-100ms)
-  if (params.tauRise < 0.005 || params.tauRise > 0.1) {
-    score *= 0.7;
-  }
-
-  // Penalize unusual tau_decay (typical: 100ms - 2s)
-  if (params.tauDecay < 0.1 || params.tauDecay > 2.0) {
-    score *= 0.7;
-  }
-
-  // Penalize if tau_rise >= tau_decay (physically implausible)
-  if (params.tauRise >= params.tauDecay) {
-    score *= 0.3;
-  }
-
-  // Bonus for adequate dataset size
-  if (params.numCells != null && params.numCells >= 10) {
-    score *= 1.1;
-  }
-
-  // Bonus for long recording
-  if (params.recordingLengthS != null && params.recordingLengthS >= 60) {
-    score *= 1.1;
-  }
-
-  // Clamp to [0.0, 1.0]
-  return Math.min(1.0, Math.max(0.0, score));
 }

--- a/src/lib/community/submitAction.ts
+++ b/src/lib/community/submitAction.ts
@@ -6,7 +6,6 @@
  */
 
 import { computeAR2 } from '../ar2.ts';
-import { computeQualityScore } from './quality-checks.ts';
 import { computeDatasetHash } from './dataset-hash.ts';
 import { submitParameters } from './community-service.ts';
 import type { SubmissionPayload, CommunitySubmission } from './types.ts';
@@ -59,16 +58,8 @@ export async function submitToSupabase(
     datasetHash = await computeDatasetHash(floatData);
   }
 
-  // Compute AR2 coefficients and quality score
+  // Compute AR2 coefficients
   const ar2 = computeAR2(ctx.tauRise, ctx.tauDecay, ctx.samplingRate);
-  const qualityScore = computeQualityScore({
-    tauRise: ctx.tauRise,
-    tauDecay: ctx.tauDecay,
-    lambda: ctx.lambda,
-    samplingRate: ctx.samplingRate,
-    numCells: ctx.numCells,
-    recordingLengthS: ctx.recordingLengthS,
-  });
 
   // Build payload
   const payload: SubmissionPayload = {
@@ -101,7 +92,6 @@ export async function submitToSupabase(
     recording_length_s: ctx.recordingLengthS,
     fps: ctx.samplingRate,
     dataset_hash: datasetHash,
-    quality_score: qualityScore,
     filter_enabled: ctx.filterEnabled,
     data_source: ctx.rawFileName ? 'user' : 'demo',
     catune_version: import.meta.env.VITE_APP_VERSION || 'dev',

--- a/src/lib/community/types.ts
+++ b/src/lib/community/types.ts
@@ -41,9 +41,8 @@ export interface CommunitySubmission {
   recording_length_s?: number;
   fps?: number;
 
-  // Quality & deduplication
+  // Deduplication
   dataset_hash: string;
-  quality_score?: number;
   catune_version: string;
 
   // Data source
@@ -91,9 +90,8 @@ export interface FilterState {
 }
 
 /** Result of parameter validation before submission. */
-export interface QualityCheckResult {
+export interface ValidationResult {
   valid: boolean;
-  score: number;
   issues: string[];
 }
 

--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -358,12 +358,6 @@
   margin-bottom: var(--space-sm);
 }
 
-.submission-summary__quality {
-  font-size: 0.85rem;
-  color: var(--accent);
-  margin: 0 0 var(--space-xs);
-}
-
 .submission-summary__timestamp {
   font-size: 0.8rem;
   color: var(--text-tertiary);


### PR DESCRIPTION
## Summary
- Remove the `computeQualityScore()` function and all references to the soft quality score from community submissions
- Drop `quality_score` from the submission payload, `CommunitySubmission` type, and `SubmissionSummary` display
- Rename `QualityCheckResult` → `ValidationResult` (no longer carries a score)
- Hard validation (`validateSubmission`) is unchanged and still blocks invalid parameters

## Test plan
- [x] Verify `npx tsc --noEmit` passes with no errors
- [x] Submit community parameters for a demo dataset and confirm no quality score is shown in the summary card
- [x] Submit community parameters for real data and confirm submission succeeds without quality score in the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)