### PR TITLE
feat: add feedback / feature request / bug report button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Report something that isn't working correctly in CaTune
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect instead?
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: >
+        Optional. Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: false
+
+  - type: input
+    id: browser-os
+    attributes:
+      label: Browser / OS
+      description: >
+        Optional. e.g. Chrome 120 on macOS 14, Firefox on Ubuntu 22.04
+      placeholder: e.g. Chrome 120 / macOS 14
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Optional. Screenshots, console errors, or other details.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Suggest a new feature or improvement for CaTune
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: >
+        What problem does this feature solve, or what workflow would it
+        improve?
+      placeholder: I often find myself needing to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: >
+        Optional. How do you envision this feature working?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: >
+        Optional. Other approaches or workarounds you've tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,23 @@
+name: General Feedback
+description: Share thoughts, suggestions, or general feedback about CaTune
+title: "[Feedback] "
+labels: ["feedback"]
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      description: What would you like to share?
+      placeholder: Your feedback here...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Optional. Screenshots, links, or other context that helps
+        explain your feedback.
+    validations:
+      required: false

--- a/src/components/layout/CompactHeader.tsx
+++ b/src/components/layout/CompactHeader.tsx
@@ -4,6 +4,7 @@ import { clearMultiCellState } from '../../lib/multi-cell-store.ts';
 import { supabaseEnabled } from '../../lib/supabase.ts';
 import { sidebarOpen, setSidebarOpen } from './DashboardShell.tsx';
 import { TutorialLauncher } from '../tutorial/TutorialLauncher.tsx';
+import { FeedbackMenu } from './FeedbackMenu.tsx';
 import { formatDuration } from '../../lib/format-utils.ts';
 import '../../styles/compact-header.css';
 
@@ -52,6 +53,7 @@ export function CompactHeader(props: CompactHeaderProps) {
       </div>
 
       <div class="compact-header__actions">
+        <FeedbackMenu />
         <TutorialLauncher isOpen={props.tutorialOpen} onToggle={props.onTutorialToggle} />
         <button
           class={`btn-secondary btn-small${sidebarOpen() ? ' btn-active' : ''}`}

--- a/src/components/layout/FeedbackMenu.tsx
+++ b/src/components/layout/FeedbackMenu.tsx
@@ -1,0 +1,72 @@
+import { createSignal, onCleanup, Show } from 'solid-js';
+import { buildFeedbackUrl, buildFeatureRequestUrl, buildBugReportUrl } from '../../lib/community/github-issue-url.ts';
+import '../../styles/feedback-menu.css';
+
+const MENU_ITEMS = [
+  { label: 'General Feedback', desc: 'Share thoughts or suggestions', url: buildFeedbackUrl },
+  { label: 'Feature Request', desc: 'Suggest a new feature', url: buildFeatureRequestUrl },
+  { label: 'Bug Report', desc: 'Report something broken', url: buildBugReportUrl },
+] as const;
+
+export function FeedbackMenu() {
+  const [open, setOpen] = createSignal(false);
+  let containerRef!: HTMLDivElement;
+
+  const close = () => setOpen(false);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') close();
+  };
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (!containerRef.contains(e.target as Node)) close();
+  };
+
+  // Attach/detach global listeners when menu opens/closes
+  const attach = () => {
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handleClickOutside);
+  };
+  const detach = () => {
+    document.removeEventListener('keydown', handleKeyDown);
+    document.removeEventListener('pointerdown', handleClickOutside);
+  };
+
+  onCleanup(detach);
+
+  const toggle = () => {
+    const next = !open();
+    setOpen(next);
+    if (next) attach(); else detach();
+  };
+
+  return (
+    <div class="feedback-menu" ref={containerRef}>
+      <button
+        class="btn-secondary btn-small"
+        aria-expanded={open()}
+        aria-haspopup="true"
+        onClick={toggle}
+      >
+        Feedback
+      </button>
+      <Show when={open()}>
+        <div class="feedback-menu__dropdown" role="menu">
+          {MENU_ITEMS.map((item) => (
+            <a
+              class="feedback-menu__item"
+              role="menuitem"
+              href={item.url()}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={close}
+            >
+              <span class="feedback-menu__item-label">{item.label}</span>
+              <span class="feedback-menu__item-desc">{item.desc}</span>
+            </a>
+          ))}
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/layout/ImportOverlay.tsx
+++ b/src/components/layout/ImportOverlay.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../lib/data-store.ts';
 import { formatDuration } from '../../lib/format-utils.ts';
 import { DEMO_PRESETS, DEFAULT_PRESET_ID } from '../../lib/chart/demo-presets.ts';
+import { buildFeedbackUrl, buildFeatureRequestUrl, buildBugReportUrl } from '../../lib/community/github-issue-url.ts';
 
 const STEP_LABELS: Record<string, { num: number; label: string }> = {
   'drop':          { num: 1, label: 'Load Data' },
@@ -243,6 +244,15 @@ export function ImportOverlay(props: ImportOverlayProps): JSX.Element {
           </p>
         </div>
       </Show>
+
+      {/* Feedback links */}
+      <footer class="import-feedback">
+        <a href={buildFeedbackUrl()} target="_blank" rel="noopener noreferrer">Feedback</a>
+        <span class="import-feedback__sep">&middot;</span>
+        <a href={buildFeatureRequestUrl()} target="_blank" rel="noopener noreferrer">Feature Request</a>
+        <span class="import-feedback__sep">&middot;</span>
+        <a href={buildBugReportUrl()} target="_blank" rel="noopener noreferrer">Bug Report</a>
+      </footer>
     </main>
   );
 }

--- a/src/lib/community/github-issue-url.ts
+++ b/src/lib/community/github-issue-url.ts
@@ -1,4 +1,6 @@
-/** Builds a pre-filled GitHub issue URL for requesting a new field option. */
+/** Builds pre-filled GitHub issue URLs for various issue templates. */
+
+const REPO_BASE = 'https://github.com/miniscope/CaTune/issues/new';
 
 const FIELD_LABELS: Record<string, string> = {
   indicator: 'Calcium Indicator',
@@ -17,5 +19,32 @@ export function buildFieldOptionRequestUrl(
     title: `[Field Option] New ${label}: `,
     labels: 'field-option-request',
   });
-  return `https://github.com/miniscope/CaTune/issues/new?${params.toString()}`;
+  return `${REPO_BASE}?${params.toString()}`;
+}
+
+export function buildFeedbackUrl(): string {
+  const params = new URLSearchParams({
+    template: 'feedback.yml',
+    title: '[Feedback] ',
+    labels: 'feedback',
+  });
+  return `${REPO_BASE}?${params.toString()}`;
+}
+
+export function buildFeatureRequestUrl(): string {
+  const params = new URLSearchParams({
+    template: 'feature-request.yml',
+    title: '[Feature] ',
+    labels: 'enhancement',
+  });
+  return `${REPO_BASE}?${params.toString()}`;
+}
+
+export function buildBugReportUrl(): string {
+  const params = new URLSearchParams({
+    template: 'bug-report.yml',
+    title: '[Bug] ',
+    labels: 'bug',
+  });
+  return `${REPO_BASE}?${params.toString()}`;
 }

--- a/src/styles/feedback-menu.css
+++ b/src/styles/feedback-menu.css
@@ -1,0 +1,46 @@
+/* FeedbackMenu — dropdown for feedback / feature request / bug report */
+
+.feedback-menu {
+  position: relative;
+}
+
+.feedback-menu__dropdown {
+  position: absolute;
+  top: calc(100% + var(--space-xs));
+  right: 0;
+  min-width: 220px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-elevated);
+  z-index: 100;
+  padding: var(--space-xs) 0;
+  animation: fade-in 0.15s ease-out;
+}
+
+.feedback-menu__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-sm) var(--space-md);
+  color: var(--text-primary);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.feedback-menu__item:hover,
+.feedback-menu__item:focus-visible {
+  background: var(--accent-muted);
+  outline: none;
+}
+
+.feedback-menu__item-label {
+  font-size: 0.85rem;
+  font-weight: var(--font-weight-medium);
+}
+
+.feedback-menu__item-desc {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -133,6 +133,32 @@ a:hover {
   width: 100%;
 }
 
+.import-feedback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-xl);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.8rem;
+}
+
+.import-feedback a {
+  color: var(--text-tertiary);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.import-feedback a:hover {
+  color: var(--text-secondary);
+}
+
+.import-feedback__sep {
+  color: var(--text-tertiary);
+  opacity: 0.5;
+}
+
 /* ========================
    App Header
    ======================== */


### PR DESCRIPTION
## Summary
- Add a **Feedback** dropdown button to the dashboard header with three options: General Feedback, Feature Request, and Bug Report — each opens a pre-filled GitHub issue template in a new tab
- Add matching feedback links to the import/landing page footer
- Create three new GitHub issue templates (`feedback.yml`, `feature-request.yml`, `bug-report.yml`)
- Extract `REPO_BASE` constant in `github-issue-url.ts` and add URL builder functions for each template

## Test plan
- [x] Verify Feedback button appears in the dashboard header (leftmost in actions)
- [x] Verify dropdown opens/closes on click, dismisses on Escape and outside click
- [x] Verify each dropdown option opens the correct GitHub issue template in a new tab
- [x] Verify feedback links appear at the bottom of the import page
- [x] Verify no overflow on narrow viewports
- [x] `npm run build` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)