### PR TITLE
fix: hide convolution transient artifact at trace start

### DIFF
--- a/src/lib/cell-solve-manager.ts
+++ b/src/lib/cell-solve-manager.ts
@@ -243,8 +243,8 @@ function ensureCellState(cellIndex: number, data: NpyResult, shape: [number, num
     state = {
       cellIndex,
       rawTrace,
-      zoomStart: 0,
-      zoomEnd: Math.min(DEFAULT_ZOOM_WINDOW_S, duration),
+      zoomStart: Math.min(2 * tauDecay(), duration),
+      zoomEnd: Math.min(2 * tauDecay() + DEFAULT_ZOOM_WINDOW_S, duration),
       warmStartCache: new WarmStartCache(),
       activeJobId: null,
       debounceTimer: null,


### PR DESCRIPTION
## Summary
- Null-mask the first 2×tauDecay seconds of the **fit** and **residual** traces at the trace boundary so uPlot draws a clean gap instead of showing the convolution ramp-up artifact
- Shift the default zoom window start past the transient (adaptive to current tauDecay), so new cells open to clean data
- Stored data and quality metrics (R², residual RMS) are unaffected — masking is purely visual

## Test plan
- [x] Load a dataset and verify the fit trace no longer shows the initial downward dip at t=0
- [x] Scroll/zoom back to t=0 — the fit and residual traces should have a gap for the first ~2×tauDecay seconds
- [x] Verify new cells open with the zoom window past the transient region
- [x] Change tauDecay — confirm the mask and default zoom offset adapt accordingly
- [x] Verify metrics panel values are unchanged (no NaN contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)