### PR TITLE
chore: clean up barrel exports + fix phantom valibot dep

### DIFF
--- a/packages/community/src/index.ts
+++ b/packages/community/src/index.ts
@@ -5,7 +5,6 @@ export {
   fetchFieldOptions,
   deleteSubmission,
 } from './community-service.ts';
-export { computeDatasetHash } from './dataset-hash.ts';
 export {
   INDICATOR_OPTIONS,
   SPECIES_OPTIONS,

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -1,5 +1,5 @@
 export { createWorkerPool } from './worker-pool.ts';
-export type { PoolJob, WorkerPool } from './worker-pool.ts';
+export type { WorkerPool } from './worker-pool.ts';
 export {
   computePaddedWindow,
   computeSafeMargin,
@@ -11,5 +11,5 @@ export { computeKernel, computeKernelAnnotations } from './kernel-math.ts';
 export { downsampleMinMax } from './downsample.ts';
 export { makeTimeAxis } from './time-axis.ts';
 export { DEMO_PRESETS, DEFAULT_PRESET_ID, getPresetById, getPresetLabels } from './demo-presets.ts';
-export type { MarkovParams, NoiseParams, SimulationParams, DemoPreset } from './demo-presets.ts';
+export type { DemoPreset } from './demo-presets.ts';
 export { generateSyntheticTrace, generateSyntheticDataset } from './mock-traces.ts';

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@catune/core": "*",
-    "fflate": "^0.8.0"
+    "fflate": "^0.8.0",
+    "valibot": "^1.2.0"
   }
 }

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -1,7 +1,7 @@
 export { parseNpy } from './npy-parser.ts';
 export { parseNpz } from './npz-parser.ts';
 export { validateTraceData } from './validation.ts';
-export { extractCellTrace, transposeFortranToC, processNpyResult } from './array-utils.ts';
+export { extractCellTrace, processNpyResult } from './array-utils.ts';
 export { rankCellsByActivity, sampleRandomCells } from './cell-ranking.ts';
 export { buildExportData, downloadExport, parseExport } from './export.ts';
 export type { CaTuneExport } from './export.ts';

--- a/packages/tutorials/src/index.ts
+++ b/packages/tutorials/src/index.ts
@@ -1,2 +1,2 @@
-export type { TutorialStep, Tutorial, TutorialProgress } from './types.ts';
-export { saveProgress, getProgress, getAllProgress, isCompleted } from './progress.ts';
+export type { TutorialStep, Tutorial } from './types.ts';
+export { saveProgress, getProgress, isCompleted } from './progress.ts';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,3 @@
 export { DashboardShell } from './DashboardShell.tsx';
-export type { DashboardShellProps } from './DashboardShell.tsx';
 export { DashboardPanel } from './DashboardPanel.tsx';
 export { VizLayout } from './VizLayout.tsx';


### PR DESCRIPTION
## Summary
- Remove 9 unused exports from 5 package barrel files (PoolJob, MarkovParams, NoiseParams, SimulationParams, transposeFortranToC, computeDatasetHash, TutorialProgress, getAllProgress, DashboardShellProps)
- Add `valibot` to `@catune/io` dependencies (fixes phantom dep — `export.ts` imports valibot directly but only core declared it)

## Test plan
- [x] `npm run typecheck` passes (confirms nothing external depended on removed exports)
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)