### PR TITLE
test: add unit tests for @catune/core (~48 tests)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "valibot": "^1.2.0"
   }

--- a/packages/core/src/__tests__/ar2.test.ts
+++ b/packages/core/src/__tests__/ar2.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeAR2 } from '../ar2.ts';
+
+describe('computeAR2', () => {
+  it('computes hand-verified values for tauRise=0.01, tauDecay=1.0, fs=30', () => {
+    const result = computeAR2(0.01, 1.0, 30);
+    const dt = 1 / 30;
+    const expectedDecayRoot = Math.exp(-dt / 1.0);
+    const expectedRiseRoot = Math.exp(-dt / 0.01);
+
+    expect(result.dt).toBeCloseTo(dt, 10);
+    expect(result.decayRoot).toBeCloseTo(expectedDecayRoot, 10);
+    expect(result.riseRoot).toBeCloseTo(expectedRiseRoot, 10);
+    expect(result.g1).toBeCloseTo(expectedDecayRoot + expectedRiseRoot, 10);
+    expect(result.g2).toBeCloseTo(-(expectedDecayRoot * expectedRiseRoot), 10);
+  });
+
+  it('computes dt = 1/fs', () => {
+    const result = computeAR2(0.01, 1.0, 100);
+    expect(result.dt).toBeCloseTo(0.01, 10);
+  });
+
+  it('computes g1 = decayRoot + riseRoot', () => {
+    const result = computeAR2(0.05, 0.5, 30);
+    expect(result.g1).toBeCloseTo(result.decayRoot + result.riseRoot, 10);
+  });
+
+  it('computes g2 = -(decayRoot * riseRoot)', () => {
+    const result = computeAR2(0.05, 0.5, 30);
+    expect(result.g2).toBeCloseTo(-(result.decayRoot * result.riseRoot), 10);
+  });
+
+  it('higher tauDecay produces decayRoot closer to 1', () => {
+    const low = computeAR2(0.01, 0.5, 30);
+    const high = computeAR2(0.01, 2.0, 30);
+    expect(high.decayRoot).toBeGreaterThan(low.decayRoot);
+    expect(high.decayRoot).toBeLessThan(1);
+  });
+
+  it('higher fs produces roots closer to 1', () => {
+    const lowFs = computeAR2(0.01, 1.0, 10);
+    const highFs = computeAR2(0.01, 1.0, 1000);
+    expect(highFs.decayRoot).toBeGreaterThan(lowFs.decayRoot);
+    expect(highFs.riseRoot).toBeGreaterThan(lowFs.riseRoot);
+  });
+
+  it('all roots are in (0, 1) range for valid parameters', () => {
+    const result = computeAR2(0.01, 1.0, 30);
+    expect(result.decayRoot).toBeGreaterThan(0);
+    expect(result.decayRoot).toBeLessThan(1);
+    expect(result.riseRoot).toBeGreaterThan(0);
+    expect(result.riseRoot).toBeLessThan(1);
+  });
+
+  it('equal tau values produce equal roots', () => {
+    const result = computeAR2(0.5, 0.5, 30);
+    expect(result.decayRoot).toBeCloseTo(result.riseRoot, 10);
+  });
+});

--- a/packages/core/src/__tests__/export-schema.test.ts
+++ b/packages/core/src/__tests__/export-schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import * as v from 'valibot';
+import { CaTuneExportSchema } from '../schemas/export-schema.ts';
+
+function makeValidExport() {
+  return {
+    schema_version: '1.0',
+    catune_version: '2.0.0',
+    export_date: '2024-01-01T00:00:00Z',
+    parameters: {
+      tau_rise_s: 0.01,
+      tau_decay_s: 1.0,
+      lambda: 0.1,
+      sampling_rate_hz: 30,
+      filter_enabled: false,
+    },
+    ar2_coefficients: {
+      decayRoot: 0.967,
+      riseRoot: 0.717,
+      g1: 1.684,
+      g2: -0.693,
+      dt: 0.0333,
+    },
+    formulation: {
+      model: 'AR(2)',
+      objective: 'min ||y - Cx||² + λ||x||₁',
+      kernel: 'calcium impulse response',
+      ar2_relation: 'g1*c[t-1] + g2*c[t-2]',
+      lambda_definition: 'sparsity penalty',
+      convergence: 'FISTA',
+    },
+    metadata: {},
+  };
+}
+
+describe('CaTuneExportSchema', () => {
+  it('validates a complete valid object', () => {
+    const result = v.safeParse(CaTuneExportSchema, makeValidExport());
+    expect(result.success).toBe(true);
+  });
+
+  it('validates when optional metadata fields are omitted', () => {
+    const data = makeValidExport();
+    // metadata has all optional fields, so empty object should work
+    data.metadata = {};
+    const result = v.safeParse(CaTuneExportSchema, data);
+    expect(result.success).toBe(true);
+  });
+
+  it('fails when required field (parameters) is missing', () => {
+    const data = makeValidExport();
+    const { parameters: _, ...incomplete } = data;
+    const result = v.safeParse(CaTuneExportSchema, incomplete);
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when a number field has wrong type', () => {
+    const data = makeValidExport();
+    (data.parameters as Record<string, unknown>).tau_rise_s = 'not-a-number';
+    const result = v.safeParse(CaTuneExportSchema, data);
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when a nested required field is missing', () => {
+    const data = makeValidExport();
+    const { g1: _, ...incompleteAR2 } = data.ar2_coefficients;
+    (data as Record<string, unknown>).ar2_coefficients = incompleteAR2;
+    const result = v.safeParse(CaTuneExportSchema, data);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts extra fields (valibot strips by default)', () => {
+    const data = makeValidExport();
+    (data as Record<string, unknown>).extra_field = 'should be ignored';
+    const result = v.safeParse(CaTuneExportSchema, data);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/fft.test.ts
+++ b/packages/core/src/__tests__/fft.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { computePeriodogram } from '../spectrum/fft.ts';
+
+describe('computePeriodogram', () => {
+  it('returns correct output lengths: nfft/2 + 1', () => {
+    const signal = new Float64Array(100);
+    const fs = 1000;
+    const { freqs, psd } = computePeriodogram(signal, fs);
+    // nextPow2(100) = 128, so halfN = 128/2 + 1 = 65
+    expect(freqs.length).toBe(65);
+    expect(psd.length).toBe(65);
+  });
+
+  it('frequency axis ends at Nyquist (fs/2)', () => {
+    const signal = new Float64Array(64);
+    const fs = 1000;
+    const { freqs } = computePeriodogram(signal, fs);
+    // nextPow2(64) = 64, df = 1000/64 = 15.625
+    // last freq = 32 * 15.625 = 500 = fs/2
+    expect(freqs[freqs.length - 1]).toBeCloseTo(fs / 2, 5);
+  });
+
+  it('first frequency is 0 (DC)', () => {
+    const signal = new Float64Array(64);
+    const fs = 1000;
+    const { freqs } = computePeriodogram(signal, fs);
+    expect(freqs[0]).toBe(0);
+  });
+
+  it('sinusoid at known frequency has peak at that frequency', () => {
+    const fs = 256;
+    const N = 256;
+    const targetFreq = 32; // Hz
+    const signal = new Float64Array(N);
+    for (let i = 0; i < N; i++) {
+      signal[i] = Math.sin((2 * Math.PI * targetFreq * i) / fs);
+    }
+    const { freqs, psd } = computePeriodogram(signal, fs);
+
+    // Find the index of the peak PSD value (excluding DC at index 0)
+    let peakIdx = 1;
+    for (let i = 2; i < psd.length; i++) {
+      if (psd[i] > psd[peakIdx]) peakIdx = i;
+    }
+    expect(freqs[peakIdx]).toBeCloseTo(targetFreq, 0);
+  });
+
+  it('power-of-2 length signal works correctly', () => {
+    const signal = new Float64Array(64);
+    const fs = 100;
+    const { freqs, psd } = computePeriodogram(signal, fs);
+    // nextPow2(64) = 64, halfN = 33
+    expect(freqs.length).toBe(33);
+    expect(psd.length).toBe(33);
+  });
+
+  it('non-power-of-2 length signal gets zero-padded', () => {
+    const signal = new Float64Array(50);
+    const fs = 100;
+    const { freqs, psd } = computePeriodogram(signal, fs);
+    // nextPow2(50) = 64, halfN = 33
+    expect(freqs.length).toBe(33);
+    expect(psd.length).toBe(33);
+  });
+});

--- a/packages/core/src/__tests__/format-utils.test.ts
+++ b/packages/core/src/__tests__/format-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatDuration } from '../format-utils.ts';
+
+describe('formatDuration', () => {
+  it('returns null for null input', () => {
+    expect(formatDuration(null)).toBeNull();
+  });
+
+  it('formats 30 seconds as "30.0s"', () => {
+    expect(formatDuration(30)).toBe('30.0s');
+  });
+
+  it('formats 59.9 seconds as "59.9s"', () => {
+    expect(formatDuration(59.9)).toBe('59.9s');
+  });
+
+  it('formats 60 seconds as "1.0 min"', () => {
+    expect(formatDuration(60)).toBe('1.0 min');
+  });
+
+  it('formats 90 seconds with showBoth as "90.0s (1.5 min)"', () => {
+    expect(formatDuration(90, true)).toBe('90.0s (1.5 min)');
+  });
+
+  it('formats 0 seconds as "0.0s"', () => {
+    expect(formatDuration(0)).toBe('0.0s');
+  });
+});

--- a/packages/core/src/__tests__/param-config.test.ts
+++ b/packages/core/src/__tests__/param-config.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { PARAM_RANGES } from '../param-config.ts';
+
+describe('PARAM_RANGES', () => {
+  it('has expected keys: tauRise, tauDecay, lambda', () => {
+    expect(PARAM_RANGES).toHaveProperty('tauRise');
+    expect(PARAM_RANGES).toHaveProperty('tauDecay');
+    expect(PARAM_RANGES).toHaveProperty('lambda');
+  });
+
+  it('has min < max for each parameter', () => {
+    expect(PARAM_RANGES.tauRise.min).toBeLessThan(PARAM_RANGES.tauRise.max);
+    expect(PARAM_RANGES.tauDecay.min).toBeLessThan(PARAM_RANGES.tauDecay.max);
+    expect(PARAM_RANGES.lambda.min).toBeLessThan(PARAM_RANGES.lambda.max);
+  });
+
+  it('has default within [min, max] for each parameter', () => {
+    for (const key of ['tauRise', 'tauDecay', 'lambda'] as const) {
+      const range = PARAM_RANGES[key];
+      expect(range.default).toBeGreaterThanOrEqual(range.min);
+      expect(range.default).toBeLessThanOrEqual(range.max);
+    }
+  });
+
+  it('has step > 0 for tauRise and tauDecay', () => {
+    expect(PARAM_RANGES.tauRise.step).toBeGreaterThan(0);
+    expect(PARAM_RANGES.tauDecay.step).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/__tests__/snr.test.ts
+++ b/packages/core/src/__tests__/snr.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computePeakSNR, snrToQuality } from '../metrics/snr.ts';
+
+describe('computePeakSNR', () => {
+  it('returns 0 for short trace (length < 10)', () => {
+    const trace = new Float64Array([1, 2, 3, 4, 5]);
+    expect(computePeakSNR(trace)).toBe(0);
+  });
+
+  it('returns Infinity for flat trace (all same value)', () => {
+    const trace = new Float64Array(100).fill(5.0);
+    expect(computePeakSNR(trace)).toBe(Infinity);
+  });
+
+  it('returns positive SNR for a clear signal trace', () => {
+    // Baseline near 0 with some peaks
+    const trace = new Float64Array(200);
+    for (let i = 0; i < 200; i++) {
+      trace[i] = i % 50 < 5 ? 10.0 : 0.1 + Math.random() * 0.01;
+    }
+    const snr = computePeakSNR(trace);
+    expect(snr).toBeGreaterThan(0);
+  });
+
+  it('returns Infinity for all-zero trace (zero std)', () => {
+    const trace = new Float64Array(100).fill(0);
+    expect(computePeakSNR(trace)).toBe(Infinity);
+  });
+});
+
+describe('snrToQuality', () => {
+  it('returns "good" for snr=10', () => {
+    expect(snrToQuality(10)).toBe('good');
+  });
+
+  it('returns "good" for snr=5.0 (boundary)', () => {
+    expect(snrToQuality(5.0)).toBe('good');
+  });
+
+  it('returns "fair" for snr=3.0', () => {
+    expect(snrToQuality(3.0)).toBe('fair');
+  });
+
+  it('returns "fair" for snr=2.0 (boundary)', () => {
+    expect(snrToQuality(2.0)).toBe('fair');
+  });
+
+  it('returns "poor" for snr=1.0', () => {
+    expect(snrToQuality(1.0)).toBe('poor');
+  });
+
+  it('returns "poor" for snr=0', () => {
+    expect(snrToQuality(0)).toBe('poor');
+  });
+
+  it('returns "good" for snr=Infinity', () => {
+    expect(snrToQuality(Infinity)).toBe('good');
+  });
+});

--- a/packages/core/src/__tests__/solver-metrics.test.ts
+++ b/packages/core/src/__tests__/solver-metrics.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeSparsityRatio,
+  computeResidualRMS,
+  computeRSquared,
+} from '../metrics/solver-metrics.ts';
+
+describe('computeSparsityRatio', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeSparsityRatio(new Float64Array([]))).toBe(0);
+  });
+
+  it('returns 1.0 for all-zero array', () => {
+    expect(computeSparsityRatio(new Float64Array([0, 0, 0, 0]))).toBe(1.0);
+  });
+
+  it('returns 0 for array with no values below threshold', () => {
+    expect(computeSparsityRatio(new Float64Array([1, 2, 3, 4]))).toBe(0);
+  });
+
+  it('respects custom threshold', () => {
+    const data = new Float64Array([0.001, 0.01, 0.1, 1.0]);
+    expect(computeSparsityRatio(data, 0.005)).toBe(0.25); // only 0.001 is below 0.005
+  });
+
+  it('handles mix of zero and non-zero values', () => {
+    const data = new Float64Array([0, 0, 1, 2]);
+    expect(computeSparsityRatio(data)).toBe(0.5);
+  });
+});
+
+describe('computeResidualRMS', () => {
+  it('returns 0 for empty arrays', () => {
+    expect(computeResidualRMS(new Float64Array([]), new Float64Array([]))).toBe(0);
+  });
+
+  it('returns 0 for length mismatch', () => {
+    expect(computeResidualRMS(new Float64Array([1, 2]), new Float64Array([1]))).toBe(0);
+  });
+
+  it('returns approximately 0 for perfect reconstruction', () => {
+    const raw = new Float64Array([1, 2, 3, 4, 5]);
+    const recon = new Float64Array([1, 2, 3, 4, 5]);
+    expect(computeResidualRMS(raw, recon)).toBeCloseTo(0, 10);
+  });
+
+  it('computes correct RMS for known residuals', () => {
+    const raw = new Float64Array([1, 2, 3, 4]);
+    const recon = new Float64Array([2, 3, 4, 5]); // diff is always 1
+    // sqrt(mean([1,1,1,1])) = sqrt(1) = 1
+    expect(computeResidualRMS(raw, recon)).toBeCloseTo(1.0, 10);
+  });
+});
+
+describe('computeRSquared', () => {
+  it('returns approximately 1.0 for perfect reconstruction', () => {
+    const raw = new Float64Array([1, 2, 3, 4, 5]);
+    const recon = new Float64Array([1, 2, 3, 4, 5]);
+    expect(computeRSquared(raw, recon)).toBeCloseTo(1.0, 10);
+  });
+
+  it('returns 0 for empty arrays', () => {
+    expect(computeRSquared(new Float64Array([]), new Float64Array([]))).toBe(0);
+  });
+
+  it('returns 0 for length mismatch', () => {
+    expect(computeRSquared(new Float64Array([1, 2]), new Float64Array([1]))).toBe(0);
+  });
+
+  it('returns 1 when raw signal is constant (SS_total=0)', () => {
+    const raw = new Float64Array([5, 5, 5, 5]);
+    const recon = new Float64Array([5, 5, 5, 5]);
+    expect(computeRSquared(raw, recon)).toBe(1);
+  });
+
+  it('returns negative value when reconstruction is worse than mean', () => {
+    const raw = new Float64Array([1, 2, 3, 4, 5]);
+    // Reconstruct with wildly wrong values — far from mean (3)
+    const recon = new Float64Array([10, 10, 10, 10, 10]);
+    expect(computeRSquared(raw, recon)).toBeLessThan(0);
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@catune/core': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add vitest config and test script to `@catune/core`
- 48 tests across 7 files covering all pure functions: AR2 coefficients, peak SNR, quality classification, solver metrics (sparsity, residual RMS, R²), FFT periodogram, duration formatting, param config validation, export schema validation

## Test plan
- [x] `npm test` runs all 145 tests across 18 files — all pass
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)