### PR TITLE
test: add unit tests for @catune/community (~22 tests)

### DIFF
--- a/packages/community/package.json
+++ b/packages/community/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@catune/core": "*",
     "@supabase/supabase-js": "^2.95.3"

--- a/packages/community/src/__tests__/dataset-hash.test.ts
+++ b/packages/community/src/__tests__/dataset-hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { computeDatasetHash } from '../dataset-hash.ts';
+
+describe('computeDatasetHash', () => {
+  it('returns a 64-character hex string', async () => {
+    const data = new Float64Array([1.0, 2.0, 3.0]);
+    const hash = await computeDatasetHash(data);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic — same input gives same hash', async () => {
+    const data = new Float64Array([1.0, 2.0, 3.0]);
+    const hash1 = await computeDatasetHash(data);
+    const hash2 = await computeDatasetHash(data);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hashes for different data', async () => {
+    const a = new Float64Array([1.0, 2.0, 3.0]);
+    const b = new Float64Array([4.0, 5.0, 6.0]);
+    const hashA = await computeDatasetHash(a);
+    const hashB = await computeDatasetHash(b);
+    expect(hashA).not.toBe(hashB);
+  });
+
+  it('works with an empty Float64Array', async () => {
+    const data = new Float64Array([]);
+    const hash = await computeDatasetHash(data);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/community/src/__tests__/field-options.test.ts
+++ b/packages/community/src/__tests__/field-options.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  INDICATOR_OPTIONS,
+  SPECIES_OPTIONS,
+  MICROSCOPE_TYPE_OPTIONS,
+  CELL_TYPE_OPTIONS,
+  BRAIN_REGION_OPTIONS,
+} from '../field-options.ts';
+
+const ALL_ARRAYS = {
+  INDICATOR_OPTIONS,
+  SPECIES_OPTIONS,
+  MICROSCOPE_TYPE_OPTIONS,
+  CELL_TYPE_OPTIONS,
+  BRAIN_REGION_OPTIONS,
+} as const;
+
+describe('field-options arrays', () => {
+  it('all 5 arrays are non-empty', () => {
+    for (const [name, arr] of Object.entries(ALL_ARRAYS)) {
+      expect(arr.length, `${name} should be non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('all items are non-empty strings', () => {
+    for (const [name, arr] of Object.entries(ALL_ARRAYS)) {
+      for (const item of arr) {
+        expect(typeof item, `${name} contains non-string`).toBe('string');
+        expect(item.length, `${name} contains empty string`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('no duplicates in any array', () => {
+    for (const [name, arr] of Object.entries(ALL_ARRAYS)) {
+      const unique = new Set(arr);
+      expect(unique.size, `${name} has duplicates`).toBe(arr.length);
+    }
+  });
+
+  it('INDICATOR_OPTIONS has at least 30 items', () => {
+    expect(INDICATOR_OPTIONS.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('BRAIN_REGION_OPTIONS has at least 60 items', () => {
+    expect(BRAIN_REGION_OPTIONS.length).toBeGreaterThanOrEqual(60);
+  });
+});

--- a/packages/community/src/__tests__/github-issue-url.test.ts
+++ b/packages/community/src/__tests__/github-issue-url.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFieldOptionRequestUrl,
+  buildFeedbackUrl,
+  buildFeatureRequestUrl,
+  buildBugReportUrl,
+} from '../github-issue-url.ts';
+
+const BASE = 'https://github.com/miniscope/CaLab/issues/new?';
+
+describe('GitHub issue URL builders', () => {
+  it('all produce URLs starting with the correct base', () => {
+    expect(buildFieldOptionRequestUrl('indicator')).toContain(BASE);
+    expect(buildFeedbackUrl()).toContain(BASE);
+    expect(buildFeatureRequestUrl()).toContain(BASE);
+    expect(buildBugReportUrl()).toContain(BASE);
+  });
+
+  it('buildFieldOptionRequestUrl includes correct template and label', () => {
+    const url = buildFieldOptionRequestUrl('indicator');
+    expect(url).toContain('template=field-option-request.yml');
+    expect(url).toContain('labels=field-option-request');
+    expect(url).toContain('Calcium+Indicator');
+  });
+
+  it('buildFeedbackUrl has template=feedback.yml and labels=feedback', () => {
+    const url = buildFeedbackUrl();
+    expect(url).toContain('template=feedback.yml');
+    expect(url).toContain('labels=feedback');
+  });
+
+  it('buildFeatureRequestUrl has labels=enhancement', () => {
+    const url = buildFeatureRequestUrl();
+    expect(url).toContain('template=feature-request.yml');
+    expect(url).toContain('labels=enhancement');
+  });
+
+  it('buildBugReportUrl has labels=bug', () => {
+    const url = buildBugReportUrl();
+    expect(url).toContain('template=bug-report.yml');
+    expect(url).toContain('labels=bug');
+  });
+});

--- a/packages/community/src/__tests__/quality-checks.test.ts
+++ b/packages/community/src/__tests__/quality-checks.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { validateSubmission } from '../quality-checks.ts';
+
+/** Helper that returns a valid baseline parameter set. */
+function validParams() {
+  return { tauRise: 0.05, tauDecay: 0.5, lambda: 0.01, samplingRate: 30 };
+}
+
+describe('validateSubmission', () => {
+  it('accepts valid params', () => {
+    const result = validateSubmission(validParams());
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it('accepts tauRise at exact min boundary (0.001)', () => {
+    const result = validateSubmission({ ...validParams(), tauRise: 0.001 });
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('accepts tauRise at exact max boundary (0.5)', () => {
+    // tauDecay must be greater than tauRise, so bump it up
+    const result = validateSubmission({ ...validParams(), tauRise: 0.5, tauDecay: 1.0 });
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('rejects tauRise below min (0.0001)', () => {
+    const result = validateSubmission({ ...validParams(), tauRise: 0.0001 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.stringContaining('tau_rise')]));
+  });
+
+  it('rejects tauDecay above max (11)', () => {
+    const result = validateSubmission({ ...validParams(), tauDecay: 11 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.stringContaining('tau_decay')]));
+  });
+
+  it('rejects lambda below min (0)', () => {
+    const result = validateSubmission({ ...validParams(), lambda: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([expect.stringContaining('lambda')]));
+  });
+
+  it('rejects samplingRate above max (1001)', () => {
+    const result = validateSubmission({ ...validParams(), samplingRate: 1001 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([expect.stringContaining('sampling_rate')]),
+    );
+  });
+
+  it('rejects tauRise >= tauDecay', () => {
+    const result = validateSubmission({ ...validParams(), tauRise: 0.5, tauDecay: 0.5 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([expect.stringContaining('must be less than')]),
+    );
+  });
+
+  it('collects multiple violations in the issues array', () => {
+    const result = validateSubmission({
+      tauRise: 999,
+      tauDecay: 0.001,
+      lambda: 0,
+      samplingRate: 9999,
+    });
+    expect(result.valid).toBe(false);
+    // At least tau_rise, tau_decay, lambda, sampling_rate, and tau_rise >= tau_decay
+    expect(result.issues.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/community/vitest.config.ts
+++ b/packages/community/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@catune/core': path.resolve(__dirname, '../core/src'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add vitest config and test script to `@catune/community`
- 23 tests across 4 files: dataset hash (SHA-256), submission validation (range + tau constraint), GitHub issue URL builders, field option arrays (non-empty, no duplicates)

## Test plan
- [x] `npm test` runs all tests — all pass
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)