### PR TITLE
refactor: deduplicate CSS and extract shared CompactHeader

### DIFF
--- a/apps/carank/src/components/Header.tsx
+++ b/apps/carank/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'solid-js';
+import { CompactHeader } from '@catune/ui';
 
 interface HeaderProps {
   fileName: string;
@@ -8,28 +9,26 @@ interface HeaderProps {
 }
 
 export function Header(props: HeaderProps): JSX.Element {
+  const version = () => `CaLab ${import.meta.env.VITE_APP_VERSION || 'dev'}`;
+
   return (
-    <header class="compact-header">
-      <div class="compact-header__brand">
-        <span class="compact-header__title">CaRank</span>
-        <span class="compact-header__version">
-          CaLab {import.meta.env.VITE_APP_VERSION || 'dev'}
-        </span>
-      </div>
-
-      <div class="compact-header__info">
-        <span class="compact-header__file">{props.fileName}</span>
-        <span class="compact-header__sep">&middot;</span>
-        <span>{props.numCells} cells</span>
-        <span class="compact-header__sep">&middot;</span>
-        <span>{props.numTimepoints.toLocaleString()} tp</span>
-      </div>
-
-      <div class="compact-header__actions">
+    <CompactHeader
+      title="CaRank"
+      version={version()}
+      info={
+        <>
+          <span class="compact-header__file">{props.fileName}</span>
+          <span class="compact-header__sep">&middot;</span>
+          <span>{props.numCells} cells</span>
+          <span class="compact-header__sep">&middot;</span>
+          <span>{props.numTimepoints.toLocaleString()} tp</span>
+        </>
+      }
+      actions={
         <button class="btn-secondary btn-small" onClick={props.onChangeData}>
           Change Data
         </button>
-      </div>
-    </header>
+      }
+    />
   );
 }

--- a/apps/carank/src/index.tsx
+++ b/apps/carank/src/index.tsx
@@ -1,11 +1,6 @@
 import { render } from 'solid-js/web';
 import App from './App.tsx';
-import '@catune/ui/styles/tokens.css';
-import '@catune/ui/styles/reset.css';
-import '@catune/ui/styles/buttons.css';
-import '@catune/ui/styles/components.css';
-import '@catune/ui/styles/animations.css';
-import '@catune/ui/styles/layout.css';
+import '@catune/ui/styles/base.css';
 import './styles/global.css';
 
 render(() => <App />, document.getElementById('root')!);

--- a/apps/carank/src/styles/global.css
+++ b/apps/carank/src/styles/global.css
@@ -1,5 +1,9 @@
 /* CaRank App-Specific Styles */
 
+:root {
+  --header-bg: var(--bg-primary);
+}
+
 /* App-specific overrides for shared components */
 .drop-zone__icon {
   font-size: 1.5rem;
@@ -8,63 +12,6 @@
 .error-card {
   margin-top: var(--space-md);
   margin-bottom: 0;
-}
-
-/* ========================
-   Compact Header
-   ======================== */
-.compact-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  padding: var(--space-sm) var(--space-lg);
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-primary);
-  min-height: 48px;
-}
-
-.compact-header__brand {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-xs);
-  flex-shrink: 0;
-}
-
-.compact-header__title {
-  font-size: 1.1rem;
-  font-weight: var(--font-weight-semibold);
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-}
-
-.compact-header__info {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  min-width: 0;
-  overflow: hidden;
-}
-
-.compact-header__file {
-  font-weight: var(--font-weight-medium);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.compact-header__sep {
-  color: var(--text-tertiary);
-}
-
-.compact-header__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  margin-left: auto;
-  flex-shrink: 0;
 }
 
 /* ========================

--- a/apps/catune/src/App.tsx
+++ b/apps/catune/src/App.tsx
@@ -11,7 +11,7 @@ import { SubmitPanel } from './components/community/SubmitPanel.tsx';
 import { CommunityBrowser } from './components/community/CommunityBrowser.tsx';
 import { TutorialPanel } from './components/tutorial/TutorialPanel.tsx';
 import { DashboardPanel, VizLayout, DashboardShell } from '@catune/ui';
-import { CompactHeader } from './components/layout/CompactHeader.tsx';
+import { CaTuneHeader } from './components/layout/CompactHeader.tsx';
 import { ImportOverlay } from './components/layout/ImportOverlay.tsx';
 import { KernelDisplay } from './components/traces/KernelDisplay.tsx';
 import { CardGrid } from './components/cards/CardGrid.tsx';
@@ -69,7 +69,7 @@ const App: Component = () => {
 
   const hasFile = () => !!rawFile();
 
-  // Sidebar state — owned by the app, passed to DashboardShell & CompactHeader
+  // Sidebar state — owned by the app, passed to DashboardShell & CaTuneHeader
   const [sidebarOpen, setSidebarOpen] = createSignal(false);
   const toggleSidebar = () => setSidebarOpen((prev) => !prev);
 
@@ -160,7 +160,7 @@ const App: Component = () => {
           sidebarOpen={sidebarOpen()}
           onToggleSidebar={toggleSidebar}
           header={
-            <CompactHeader
+            <CaTuneHeader
               tutorialOpen={tutorialOpen}
               onTutorialToggle={() => setTutorialOpen((prev) => !prev)}
               sidebarOpen={sidebarOpen()}

--- a/apps/catune/src/components/layout/CompactHeader.tsx
+++ b/apps/catune/src/components/layout/CompactHeader.tsx
@@ -1,4 +1,5 @@
 import { Show, type Accessor } from 'solid-js';
+import { CompactHeader } from '@catune/ui';
 import {
   rawFile,
   effectiveShape,
@@ -7,13 +8,11 @@ import {
   resetImport,
 } from '../../lib/data-store.ts';
 import { clearMultiCellState } from '../../lib/multi-cell-store.ts';
-import { supabaseEnabled } from '../../lib/community/index.ts';
 import { TutorialLauncher } from '../tutorial/TutorialLauncher.tsx';
 import { FeedbackMenu } from './FeedbackMenu.tsx';
 import { formatDuration } from '@catune/core';
-import '../../styles/compact-header.css';
 
-export interface CompactHeaderProps {
+export interface CaTuneHeaderProps {
   tutorialOpen: Accessor<boolean>;
   onTutorialToggle: () => void;
   /** Whether the sidebar is currently open. */
@@ -22,7 +21,7 @@ export interface CompactHeaderProps {
   onToggleSidebar?: () => void;
 }
 
-export function CompactHeader(props: CompactHeaderProps) {
+export function CaTuneHeader(props: CaTuneHeaderProps) {
   const handleChangeData = () => {
     clearMultiCellState();
     resetImport();
@@ -30,53 +29,54 @@ export function CompactHeader(props: CompactHeaderProps) {
 
   const durationDisplay = () => formatDuration(durationSeconds());
 
+  const version = () => `CaLab ${import.meta.env.VITE_APP_VERSION || 'dev'}`;
+
   return (
-    <header class="compact-header" data-tutorial="header-bar">
-      <div class="compact-header__brand">
-        <span class="compact-header__title">CaTune</span>
-        <span class="compact-header__version">
-          CaLab {import.meta.env.VITE_APP_VERSION || 'dev'}
-        </span>
-      </div>
-
-      <div class="compact-header__info">
-        <Show when={rawFile()}>
-          {(file) => <span class="compact-header__file">{file().name}</span>}
-        </Show>
-        <Show when={effectiveShape()}>
-          {(shape) => (
-            <>
-              <span class="compact-header__sep">&middot;</span>
-              <span>{shape()[0]} cells</span>
-              <span class="compact-header__sep">&middot;</span>
-              <span>{shape()[1].toLocaleString()} tp</span>
-            </>
-          )}
-        </Show>
-        <Show when={samplingRate()}>
-          <span class="compact-header__sep">&middot;</span>
-          <span>{samplingRate()} Hz</span>
-        </Show>
-        <Show when={durationDisplay()}>
-          <span class="compact-header__sep">&middot;</span>
-          <span>{durationDisplay()}</span>
-        </Show>
-      </div>
-
-      <div class="compact-header__actions">
-        <FeedbackMenu />
-        <TutorialLauncher isOpen={props.tutorialOpen} onToggle={props.onTutorialToggle} />
-        <button
-          class={`btn-secondary btn-small${props.sidebarOpen ? ' btn-active' : ''}`}
-          data-tutorial="sidebar-toggle"
-          onClick={() => props.onToggleSidebar?.()}
-        >
-          Sidebar
-        </button>
-        <button class="btn-secondary btn-small" onClick={handleChangeData}>
-          Change Data
-        </button>
-      </div>
-    </header>
+    <CompactHeader
+      title="CaTune"
+      version={version()}
+      data-tutorial="header-bar"
+      info={
+        <>
+          <Show when={rawFile()}>
+            {(file) => <span class="compact-header__file">{file().name}</span>}
+          </Show>
+          <Show when={effectiveShape()}>
+            {(shape) => (
+              <>
+                <span class="compact-header__sep">&middot;</span>
+                <span>{shape()[0]} cells</span>
+                <span class="compact-header__sep">&middot;</span>
+                <span>{shape()[1].toLocaleString()} tp</span>
+              </>
+            )}
+          </Show>
+          <Show when={samplingRate()}>
+            <span class="compact-header__sep">&middot;</span>
+            <span>{samplingRate()} Hz</span>
+          </Show>
+          <Show when={durationDisplay()}>
+            <span class="compact-header__sep">&middot;</span>
+            <span>{durationDisplay()}</span>
+          </Show>
+        </>
+      }
+      actions={
+        <>
+          <FeedbackMenu />
+          <TutorialLauncher isOpen={props.tutorialOpen} onToggle={props.onTutorialToggle} />
+          <button
+            class={`btn-secondary btn-small${props.sidebarOpen ? ' btn-active' : ''}`}
+            data-tutorial="sidebar-toggle"
+            onClick={() => props.onToggleSidebar?.()}
+          >
+            Sidebar
+          </button>
+          <button class="btn-secondary btn-small" onClick={handleChangeData}>
+            Change Data
+          </button>
+        </>
+      }
+    />
   );
 }

--- a/apps/catune/src/index.tsx
+++ b/apps/catune/src/index.tsx
@@ -1,11 +1,6 @@
 import { render } from 'solid-js/web';
 import App from './App.tsx';
-import '@catune/ui/styles/tokens.css';
-import '@catune/ui/styles/reset.css';
-import '@catune/ui/styles/buttons.css';
-import '@catune/ui/styles/components.css';
-import '@catune/ui/styles/animations.css';
-import '@catune/ui/styles/layout.css';
+import '@catune/ui/styles/base.css';
 import './styles/global.css';
 import './styles/layout.css';
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles/*": "./src/styles/*"
+  },
   "dependencies": {
     "solid-js": "^1.9.11"
   }

--- a/packages/ui/src/CompactHeader.tsx
+++ b/packages/ui/src/CompactHeader.tsx
@@ -1,0 +1,29 @@
+import type { JSX } from 'solid-js';
+import { Show } from 'solid-js';
+
+export interface CompactHeaderProps {
+  title: string;
+  version?: string;
+  info?: JSX.Element;
+  actions?: JSX.Element;
+  'data-tutorial'?: string;
+}
+
+export function CompactHeader(props: CompactHeaderProps) {
+  return (
+    <header class="compact-header" data-tutorial={props['data-tutorial']}>
+      <div class="compact-header__brand">
+        <h1 class="compact-header__title">{props.title}</h1>
+        <Show when={props.version}>
+          <span class="compact-header__version">{props.version}</span>
+        </Show>
+      </div>
+      <Show when={props.info}>
+        <div class="compact-header__info">{props.info}</div>
+      </Show>
+      <Show when={props.actions}>
+        <div class="compact-header__actions">{props.actions}</div>
+      </Show>
+    </header>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,3 +2,5 @@ export { DashboardShell } from './DashboardShell.tsx';
 export type { DashboardShellProps } from './DashboardShell.tsx';
 export { DashboardPanel } from './DashboardPanel.tsx';
 export { VizLayout } from './VizLayout.tsx';
+export { CompactHeader } from './CompactHeader.tsx';
+export type { CompactHeaderProps } from './CompactHeader.tsx';

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -1,0 +1,8 @@
+/* Base CSS imports for CaLab apps */
+@import './tokens.css';
+@import './reset.css';
+@import './buttons.css';
+@import './components.css';
+@import './animations.css';
+@import './layout.css';
+@import './compact-header.css';

--- a/packages/ui/src/styles/compact-header.css
+++ b/packages/ui/src/styles/compact-header.css
@@ -1,11 +1,12 @@
-/* Compact Header — thin bar for dashboard mode */
+/* Compact Header — thin bar for dashboard mode
+   Background: override via --header-bg (defaults to --bg-secondary) */
 
 .compact-header {
   display: flex;
   align-items: center;
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-lg);
-  background: var(--bg-secondary);
+  background: var(--header-bg, var(--bg-secondary));
   border-bottom: 1px solid var(--border-subtle);
   min-height: 48px;
 }
@@ -45,8 +46,10 @@
 
 .compact-header__file {
   color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compact-header__sep {
@@ -57,5 +60,6 @@
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  margin-left: auto;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- Merge compact-header CSS from both apps into `@catune/ui` with `var(--header-bg)` for per-app theming
- Create `base.css` aggregate import (replaces 6 individual CSS imports per app entry point)
- Add `exports` field to `@catune/ui` package.json for CSS path resolution
- Extract shared `CompactHeader` component to `@catune/ui` with slot props (title, version, info, actions)
- Rename CaTune's component to `CaTuneHeader`, update CaRank's `Header` — both wrap shared component

## Test plan
- [x] `npm run typecheck` and `npm run build` pass
- [x] Headers render identically: CaTune gets grey bg (`--bg-secondary`), CaRank gets white (`--bg-primary`)
- [x] Visual verification in both `npm run dev` and `npm run dev:carank`

🤖 Generated with [Claude Code](https://claude.com/claude-code)