### PR TITLE
chore: glob-based build/deploy scripts with app auto-discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm run test
 
       - name: Build
-        run: npm run build -w apps/catune && npm run build -w apps/carank
+        run: npm run build:apps

--- a/apps/carank/package.json
+++ b/apps/carank/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
+  "calab": {
+    "displayName": "CaRank",
+    "description": "Trace quality ranking"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/apps/catune/package.json
+++ b/apps/catune/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
+  "calab": {
+    "displayName": "CaTune",
+    "description": "Deconvolution parameter tuning"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "npm run dev -w apps/catune",
     "dev:carank": "npm run dev -w apps/carank",
-    "build": "npm run build:wasm && (npm run build -w apps/catune & npm run build -w apps/carank & wait)",
+    "build": "npm run build:wasm && npm run build:apps",
+    "build:apps": "node scripts/build-apps.mjs",
     "build:pages": "npm run build && node scripts/combine-dist.mjs",
     "build:wasm": "cd wasm/catune-solver && wasm-pack build --target web --release",
     "test": "npm run test --workspaces --if-present",

--- a/scripts/build-apps.mjs
+++ b/scripts/build-apps.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '..');
+const appsDir = resolve(root, 'apps');
+
+const apps = readdirSync(appsDir).filter((name) => {
+  if (name === '_template') return false;
+  const dir = join(appsDir, name);
+  if (!statSync(dir).isDirectory()) return false;
+  const pkgPath = join(dir, 'package.json');
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return pkg.scripts?.build != null;
+  } catch {
+    return false;
+  }
+});
+
+if (apps.length === 0) {
+  console.error('No buildable apps found in apps/');
+  process.exit(1);
+}
+
+console.log(`Building ${apps.length} apps: ${apps.join(', ')}`);
+
+for (const name of apps) {
+  console.log(`\nBuilding ${name}...`);
+  execFileSync('npm', ['run', 'build', '-w', `apps/${name}`], {
+    stdio: 'inherit',
+    cwd: root,
+  });
+}
+
+console.log('\nAll apps built successfully.');


### PR DESCRIPTION
## Summary
- Add `calab` metadata (displayName, description) to app `package.json` files
- Create `build-apps.mjs` that auto-discovers `apps/*` (excluding `_template`), reads each package.json for build script
- Rewrite `combine-dist.mjs` to auto-discover apps and generate landing page HTML dynamically
- Update root `build` script and CI workflow to use `build:apps`

Adding a new app no longer requires editing build scripts or CI — just add `calab` metadata to its package.json.

## Test plan
- [x] `npm run build:apps` builds both apps, excludes `_template`
- [x] `npm run build:pages` produces correct `dist/CaLab/` with dynamic landing page
- [x] CI uses `build:apps` instead of hardcoded app names

🤖 Generated with [Claude Code](https://claude.com/claude-code)