### PR TITLE
docs: add app template, NEW_APP guide, and CHANGELOG

### DIFF
--- a/apps/_template/index.html
+++ b/apps/_template/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>__APP_DISPLAY_NAME__</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=optional"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/apps/_template/package.json
+++ b/apps/_template/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "app-template",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "calab": {
+    "displayName": "__APP_DISPLAY_NAME__",
+    "description": ""
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@catune/core": "*",
+    "@catune/io": "*",
+    "@catune/ui": "*",
+    "solid-js": "^1.9.11"
+  }
+}

--- a/apps/_template/src/App.tsx
+++ b/apps/_template/src/App.tsx
@@ -1,0 +1,12 @@
+import type { Component } from 'solid-js';
+import { DashboardShell, CompactHeader } from '@catune/ui';
+
+const App: Component = () => {
+  return (
+    <DashboardShell header={<CompactHeader title="__APP_DISPLAY_NAME__" />}>
+      <p>Hello from __APP_DISPLAY_NAME__!</p>
+    </DashboardShell>
+  );
+};
+
+export default App;

--- a/apps/_template/src/index.tsx
+++ b/apps/_template/src/index.tsx
@@ -1,0 +1,6 @@
+import { render } from 'solid-js/web';
+import App from './App.tsx';
+import '@catune/ui/styles/base.css';
+import './styles/global.css';
+
+render(() => <App />, document.getElementById('root')!);

--- a/apps/_template/src/styles/global.css
+++ b/apps/_template/src/styles/global.css
@@ -1,0 +1,1 @@
+/* App-specific styles and design token overrides */

--- a/apps/_template/src/vite-env.d.ts
+++ b/apps/_template/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/_template/tsconfig.json
+++ b/apps/_template/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "baseUrl": ".",
+    "paths": {
+      "@catune/core": ["../../packages/core/src/index.ts"],
+      "@catune/core/*": ["../../packages/core/src/*"],
+      "@catune/io": ["../../packages/io/src/index.ts"],
+      "@catune/io/*": ["../../packages/io/src/*"],
+      "@catune/ui": ["../../packages/ui/src/index.ts"],
+      "@catune/ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/io" },
+    { "path": "../../packages/ui" }
+  ]
+}

--- a/apps/_template/vite.config.ts
+++ b/apps/_template/vite.config.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { defineConfig } from 'vite';
+import solidPlugin from 'vite-plugin-solid';
+
+const repoRoot = path.resolve(__dirname, '../..');
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
+const displayName = pkg.calab?.displayName ?? path.basename(__dirname);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@catune/core': path.resolve(repoRoot, 'packages/core/src'),
+      '@catune/io': path.resolve(repoRoot, 'packages/io/src'),
+      '@catune/ui': path.resolve(repoRoot, 'packages/ui/src'),
+    },
+  },
+  envDir: repoRoot,
+  base: process.env.GITHUB_ACTIONS ? `/CaLab/${displayName}/` : '/',
+  plugins: [solidPlugin()],
+  build: {
+    target: 'esnext',
+  },
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+Repo-level changelog for the CaLab monorepo. Uses [Keep a Changelog](https://keepachangelog.com/) format.
+Versions correspond to git tags (`v*`) and apply to the entire monorepo.
+
+## [Unreleased]
+
+### Added
+
+- Unit tests for `@catune/core` and `@catune/community` packages
+- Shared `CompactHeader` component in `@catune/ui`
+- `base.css` aggregate import for shared styles
+- Glob-based `build-apps.mjs` and dynamic `combine-dist.mjs`
+- App template (`apps/_template`) and `docs/NEW_APP.md` guide
+- This changelog
+
+### Changed
+
+- Barrel exports trimmed to only externally consumed symbols
+- CI build step uses `build:apps` instead of hardcoded app names
+- App `package.json` files include `calab` metadata for build discovery
+
+### Fixed
+
+- `@catune/io` missing direct `valibot` dependency (phantom dep via `@catune/core`)
+
+## [2.0.3] - 2025-02-16
+
+### Changed
+
+- Extracted chart logic to `@catune/compute` and shared CSS to `@catune/ui`
+
+## [2.0.2] - 2025-02-15
+
+### Changed
+
+- Removed dead code: unused exports, signals, props, barrel re-exports
+- Naming, import, and minor cleanup across monorepo
+
+### Fixed
+
+- Optimized build pipeline and CI caching
+
+## [2.0.1] - 2025-02-14
+
+### Fixed
+
+- AR2 dt mismatch, ESLint rule override, CaRank missing memo
+- Capitalize app names in deploy URLs (CaTune, CaRank)
+- Bundle worker properly for production builds
+
+### Changed
+
+- Fixed 5 architecture boundary issues from codebase audit
+
+## [2.0.0] - 2025-02-13
+
+### Changed
+
+- Restructured repository into monorepo with `apps/` and `packages/`
+- Renamed Python package from catune to calab

--- a/docs/NEW_APP.md
+++ b/docs/NEW_APP.md
@@ -1,0 +1,101 @@
+# Adding a New App to CaLab
+
+This guide walks through creating a new app in the CaLab monorepo.
+
+## Steps
+
+### 1. Copy the template
+
+```bash
+cp -r apps/_template apps/<name>
+```
+
+### 2. Replace placeholders
+
+In your new `apps/<name>/` directory, find-and-replace these tokens:
+
+| Placeholder            | Replace with                     | Example  |
+| ---------------------- | -------------------------------- | -------- |
+| `app-template`         | npm workspace name (lowercase)   | `caview` |
+| `__APP_DISPLAY_NAME__` | Human-readable name (PascalCase) | `CaView` |
+
+Files that contain placeholders:
+
+- `package.json` — name (`app-template`), calab.displayName, calab.description
+- `index.html` — `<title>`
+- `src/App.tsx` — header title, placeholder text
+
+Also fill in `calab.description` in `package.json` (e.g., `"Trace visualization"`).
+
+### 3. Install dependencies
+
+From the repo root:
+
+```bash
+npm install
+```
+
+npm auto-discovers the new workspace under `apps/*`.
+
+### 4. Add dev script to root package.json
+
+```jsonc
+// package.json (root)
+"scripts": {
+  "dev:<name>": "npm run dev -w apps/<name>"
+}
+```
+
+### 5. Add to typecheck
+
+```jsonc
+// package.json (root)
+"scripts": {
+  "typecheck": "tsc -b apps/catune apps/carank apps/<name>"
+}
+```
+
+### 6. Verify
+
+```bash
+npm run dev:<name>     # Dev server starts
+npm run typecheck      # No errors
+npm run build:apps     # Builds all apps including yours
+```
+
+The build and deploy scripts auto-discover apps from `apps/*/package.json`,
+so no changes are needed to `build-apps.mjs`, `combine-dist.mjs`, or CI.
+
+## Adding more `@catune/*` packages
+
+The template includes `@catune/core`, `@catune/io`, and `@catune/ui` by default.
+To add another package (e.g., `@catune/compute`):
+
+1. **package.json** — add to `dependencies`:
+
+   ```json
+   "@catune/compute": "*"
+   ```
+
+2. **vite.config.ts** — add alias:
+
+   ```ts
+   '@catune/compute': path.resolve(repoRoot, 'packages/compute/src'),
+   ```
+
+3. **tsconfig.json** — add path mapping and reference:
+
+   ```json
+   "paths": {
+     "@catune/compute": ["../../packages/compute/src/index.ts"],
+     "@catune/compute/*": ["../../packages/compute/src/*"]
+   }
+   ```
+
+   ```json
+   "references": [
+     { "path": "../../packages/compute" }
+   ]
+   ```
+
+4. Run `npm install` from the root to link the workspace dependency.


### PR DESCRIPTION
## Summary
- Create `apps/_template/` with all boilerplate: package.json, vite.config (reads `calab.displayName` for dynamic base path), tsconfig, index.html, entry point, minimal App using `DashboardShell` + `CompactHeader`
- Add `docs/NEW_APP.md` — step-by-step guide for adding a new app
- Initialize `docs/CHANGELOG.md` with entries for v2.0.0 through v2.0.3

**Stacked on #PR5** (depends on `calab` metadata convention and `build-apps.mjs`).

## Test plan
- [x] `npm install` succeeds with `_template` in workspace
- [x] `npm run build:apps` does NOT build `_template`
- [x] `npm run typecheck` does NOT include `_template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)