### PR TITLE
fix: consistent CaLab version display

### DIFF
--- a/apps/carank/src/components/FileImport.tsx
+++ b/apps/carank/src/components/FileImport.tsx
@@ -58,6 +58,7 @@ export function FileImport(props: FileImportProps): JSX.Element {
     <div class="import-container">
       <div class="app-header">
         <h1 class="app-header__title">CaRank</h1>
+        <span class="app-header__version">CaLab {import.meta.env.VITE_APP_VERSION || 'dev'}</span>
         <p class="app-header__subtitle">Quality ranking for CNMF calcium traces</p>
       </div>
 

--- a/apps/catune/src/components/layout/ImportOverlay.tsx
+++ b/apps/catune/src/components/layout/ImportOverlay.tsx
@@ -62,10 +62,8 @@ export function ImportOverlay(props: ImportOverlayProps): JSX.Element {
     <main class="import-container">
       {/* Header */}
       <header class="app-header" data-tutorial="app-header">
-        <h1 class="app-header__title">
-          CaTune{' '}
-          <span class="app-header__version">{import.meta.env.VITE_APP_VERSION || 'dev'}</span>
-        </h1>
+        <h1 class="app-header__title">CaTune</h1>
+        <span class="app-header__version">CaLab {import.meta.env.VITE_APP_VERSION || 'dev'}</span>
         <p class="app-header__subtitle">Calcium Deconvolution Parameter Tuning</p>
       </header>
 

--- a/packages/ui/src/styles/compact-header.css
+++ b/packages/ui/src/styles/compact-header.css
@@ -13,9 +13,11 @@
 
 .compact-header__brand {
   display: flex;
-  align-items: baseline;
-  gap: var(--space-xs);
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
   flex-shrink: 0;
+  line-height: 1;
 }
 
 .compact-header__title {
@@ -23,12 +25,15 @@
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
   letter-spacing: -0.02em;
+  line-height: 1;
+  margin: 0;
 }
 
 .compact-header__version {
-  font-size: 0.65rem;
+  font-size: 0.6rem;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
+  line-height: 1;
 }
 
 .compact-header__info {

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -13,17 +13,19 @@
 .app-header__title {
   font-size: 1.75rem;
   color: var(--text-primary);
-  margin-bottom: var(--space-xs);
+  margin: 0;
+  line-height: 1;
   letter-spacing: -0.03em;
   font-weight: var(--font-weight-semibold);
 }
 
 .app-header__version {
+  display: block;
   font-size: 0.7rem;
   color: var(--text-tertiary);
   font-weight: var(--font-weight-normal);
   font-family: var(--font-mono);
-  vertical-align: super;
+  line-height: 1;
 }
 
 .app-header__subtitle {

--- a/scripts/combine-dist.mjs
+++ b/scripts/combine-dist.mjs
@@ -91,7 +91,7 @@ function renderCard(app) {
 }
 
 const version = process.env.VITE_APP_VERSION ?? '';
-const versionHtml = version ? `<span class="version">v${version}</span> &middot; ` : '';
+const versionHtml = version ? `<span class="version">${version}</span> &middot; ` : '';
 
 const cards = apps.map(renderCard).join('\n');
 


### PR DESCRIPTION
## Summary
- Fix double "v" prefix on landing page (`vv2.0.6` → `v2.0.6`)
- Show "CaLab v..." on import/loading pages for both CaTune and CaRank (was missing)
- Change version from superscript to small text below app name for cleaner look
- Tighten spacing so version feels connected to the app title

## Test plan
- [x] Verify landing page shows `v2.0.6` (not `vv2.0.6`) on deploy
- [x] Verify CaTune import page shows "CaLab v..." under "CaTune"
- [x] Verify CaTune dashboard header shows "CaLab v..." under "CaTune"
- [x] Verify CaRank import page shows "CaLab v..." under "CaRank"
- [x] Verify version text is left-aligned with app name on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)