### PR TITLE
docs: add comprehensive README files across monorepo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Daniel Aharoni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,140 @@
+# CaLab
+
+Calcium imaging analysis tools
+
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/miniscope/CaLab/actions/workflows/ci.yml/badge.svg)](https://github.com/miniscope/CaLab/actions/workflows/ci.yml)
+[![GitHub Pages](https://github.com/miniscope/CaLab/actions/workflows/deploy.yml/badge.svg)](https://miniscope.github.io/CaLab/)
+[![PyPI](https://img.shields.io/pypi/v/calab)](https://pypi.org/project/calab/)
+
+![CaTune screenshot](apps/catune/screenshot.png)
+
+## What is CaLab?
+
+CaLab is a suite of browser-based tools for calcium imaging analysis. The tools run entirely in the browser — no installation, no server, no data upload. Load your fluorescence traces, tune deconvolution parameters with real-time visual feedback, and export the results.
+
+The flagship app, **CaTune**, lets you interactively adjust deconvolution parameters (rise time, decay time, sparsity) while watching the solver update in real time. The deconvolution engine is a FISTA solver written in Rust and compiled to WebAssembly, running in Web Workers for parallel multi-cell processing.
+
+A companion **Python package** (`calab`) provides the same deconvolution algorithm in Python, with data exchange utilities for round-tripping parameters between the browser tools and analysis scripts. An optional **community sharing** feature (powered by Supabase) lets users share and browse deconvolution parameters across datasets and indicators.
+
+## Quick Start (Scientists)
+
+1. Open **[CaTune](https://miniscope.github.io/CaLab/catune/)** in your browser
+2. Try the built-in demo data to explore the interface
+3. Drag and drop your own `.npy` or `.npz` file containing calcium traces
+4. Adjust parameters with the sliders and observe real-time deconvolution
+5. Export your tuned parameters as JSON for use in analysis pipelines
+
+## Python Package
+
+```bash
+pip install calab
+```
+
+The `calab` Python package is the Python entrypoint to CaLab. It runs the same FISTA deconvolution algorithm in Python, and provides utilities for exchanging data with the web apps — load CaTune export JSON files, prepare traces for the browser tool, and run batch deconvolution with tuned parameters.
+
+> **Note:** The Python package is under active development — major updates are planned.
+
+See [`python/README.md`](python/README.md) for full API documentation.
+
+## Apps
+
+| App                    | Description                                        | Status |
+| ---------------------- | -------------------------------------------------- | ------ |
+| [CaTune](apps/catune/) | Interactive calcium deconvolution parameter tuning | Stable |
+
+## Monorepo Structure
+
+```
+.
+├── apps/
+│   ├── catune/                  # SolidJS SPA — deconvolution parameter tuning
+│   └── carank/                  # SolidJS SPA — trace quality ranking
+├── packages/
+│   ├── core/                    # @calab/core — shared types, pure math, WASM adapter
+│   ├── compute/                 # @calab/compute — worker pool, warm-start cache
+│   ├── io/                      # @calab/io — file parsers, validation, export
+│   ├── community/               # @calab/community — Supabase DAL, submission logic
+│   ├── tutorials/               # @calab/tutorials — tutorial types, progress persistence
+│   └── ui/                      # @calab/ui — shared layout components
+├── wasm/
+│   └── catune-solver/           # Rust FISTA solver crate (compiled to WASM)
+├── python/                      # Python companion package
+├── docs/                        # Documentation
+├── scripts/                     # Build and deploy scripts
+└── supabase/                    # Supabase config
+```
+
+## Packages
+
+| Package                                   | Description                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| [`@calab/core`](packages/core/)           | Shared types, pure utilities, domain math, WASM adapter              |
+| [`@calab/compute`](packages/compute/)     | Generic worker pool, warm-start caching, kernel math, downsampling   |
+| [`@calab/io`](packages/io/)               | File parsers (.npy/.npz), data validation, cell ranking, JSON export |
+| [`@calab/community`](packages/community/) | Supabase data access layer for community parameter sharing           |
+| [`@calab/tutorials`](packages/tutorials/) | Tutorial type definitions, progress persistence (localStorage)       |
+| [`@calab/ui`](packages/ui/)               | Shared SolidJS layout components (DashboardShell, panels, cards)     |
+
+## Development Quick Start
+
+### Prerequisites
+
+- **Node.js 22** (LTS) — use `.nvmrc`: `nvm use`
+- **Rust stable** + **wasm-pack** — only needed if modifying the solver
+- **Python >= 3.10** — only needed for the Python package
+
+### Setup
+
+```bash
+git clone https://github.com/miniscope/CaLab.git
+cd CaLab
+nvm use
+npm install
+npm run dev
+```
+
+### Key Scripts
+
+| Script                | Description                            |
+| --------------------- | -------------------------------------- |
+| `npm run dev`         | Start CaTune dev server                |
+| `npm run build`       | Build WASM + all apps                  |
+| `npm run build:pages` | Build + combine dist for GitHub Pages  |
+| `npm run build:wasm`  | Compile Rust solver to WASM            |
+| `npm run test`        | Run Vitest tests across all workspaces |
+| `npm run lint`        | Run ESLint                             |
+| `npm run typecheck`   | Run TypeScript type checking           |
+| `npm run format`      | Format all files with Prettier         |
+
+See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for the full development guide.
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — module layout, dependency DAG, state management, boundaries
+- [Contributing](docs/CONTRIBUTING.md) — setup, scripts, code style, CI
+- [Changelog](docs/CHANGELOG.md) — release history
+- [New App Guide](docs/NEW_APP.md) — adding a new app to the monorepo
+- [CaTune](apps/catune/README.md) — CaTune app documentation
+- [WASM Solver](wasm/catune-solver/README.md) — Rust FISTA solver documentation
+- [Python Package](python/README.md) — Python companion package
+
+## Tech Stack
+
+- **Frontend:** SolidJS + TypeScript + Vite
+- **Solver:** Rust + wasm-pack (WebAssembly)
+- **Charts:** uPlot
+- **Community:** Supabase (optional)
+- **Styling:** Pure CSS with custom properties
+
+## Versioning
+
+The monorepo uses a single `v*` tag for all web apps and packages (e.g., `v2.0.4`). The Python package has a separate `py/v*` tag series. See the [Changelog](docs/CHANGELOG.md) for release history.
+
+## License
+
+[MIT](LICENSE) — Copyright (c) 2025 Daniel Aharoni
+
+## Contributing
+
+Contributions are welcome! See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for setup instructions, code style guidelines, and the CI pipeline. Bug reports and feature requests can be filed via [GitHub Issues](https://github.com/miniscope/CaLab/issues).

--- a/apps/catune/README.md
+++ b/apps/catune/README.md
@@ -1,0 +1,93 @@
+# CaTune
+
+Interactive calcium deconvolution parameter tuning
+
+![CaTune screenshot](screenshot.png)
+
+## Overview
+
+CaTune is a browser-based tool for tuning calcium deconvolution parameters. Load fluorescence traces, adjust rise time, decay time, and sparsity parameters with sliders, and see the deconvolution update in real time. The solver is a FISTA algorithm written in Rust, compiled to WebAssembly, and executed in Web Workers for parallel multi-cell processing.
+
+## Getting Started
+
+### Live App
+
+Open **[CaTune](https://miniscope.github.io/CaLab/catune/)** in your browser — no installation required.
+
+### Loading Data
+
+1. **Choose a source** — drag and drop a `.npy` or `.npz` file, or try one of the 6 built-in demo presets
+2. **Confirm dimensions** — verify the data shape (cells × timepoints) and swap axes if needed
+3. **Set sampling rate** — enter your recording's frame rate in Hz (or select from common presets)
+4. **Validate** — CaTune checks for NaN, Inf, and other data issues before proceeding
+
+### Demo Data
+
+CaTune includes 6 synthetic demo presets with known ground truth, useful for understanding how parameters affect the deconvolution output. Ground truth can be revealed after tuning to compare results.
+
+## Features
+
+- **Parameter sliders** — rise time (1–500 ms), decay time (50–3000 ms), sparsity (0–10)
+- **Multi-cell dashboard** — view and compare deconvolution across multiple cells simultaneously, with priority-based solving (visible and hovered cells solve first)
+- **Trace overlays** — raw, filtered, fit (reconvolution + baseline), deconvolved, residual, and ground truth (demo data)
+- **Zoom windows** — windowed computation with overlap-and-discard for efficient zooming into long traces
+- **Spectrum panel** — power spectral density with filter cutoff visualization
+- **Quality metrics** — peak SNR, R², sparsity ratio
+- **Pin/compare snapshots** — pin the current parameters as a dimmed overlay, then adjust to compare before/after
+- **Bandpass filter** — FFT-based filter derived from kernel time constants, with cosine-tapered transitions
+- **Community sharing** — submit and browse deconvolution parameters shared by other users (optional, Supabase-backed)
+- **Tutorials** — 5 interactive tutorials powered by driver.js with localStorage progress persistence
+- **JSON export** — export tuned parameters for use with the `calab` Python package
+
+## Solver Overview
+
+CaTune uses a **FISTA** (Fast Iterative Shrinkage-Thresholding Algorithm) solver with the following objective:
+
+```
+minimize  (1/2)||y - K*s - b||² + λ·G_dc·||s||₁   subject to  s ≥ 0
+```
+
+where `y` is the fluorescence trace, `K` is the convolution matrix from a double-exponential kernel `h(t) = exp(-t/τ_decay) - exp(-t/τ_rise)`, `s` is the deconvolved activity, `b` is a jointly estimated scalar baseline, `λ` is the sparsity penalty, and `G_dc = Σh` scales lambda so the sparsity slider is effective across all kernel configurations.
+
+Key solver features:
+
+- **Adaptive restart** (O'Donoghue & Candes 2015) — resets momentum when it hurts convergence
+- **FFT convolution** — O(n log n) forward and adjoint convolutions via `realfft`/`rustfft`
+- **Rust → WASM** — compiled with wasm-pack, runs in Web Workers
+- **Warm-start caching** — 3-tier cache (lambda-only, kernel-changed, cold-start) reuses prior solver state
+- **Windowed computation** — only solves the visible zoom window (plus safety margin) for efficiency
+
+See [`wasm/catune-solver/README.md`](../../wasm/catune-solver/README.md) for detailed solver documentation.
+
+## Development
+
+### Running Locally
+
+```bash
+npm run dev          # Start CaTune dev server (from repo root)
+npm run test -w apps/catune  # Run CaTune tests
+```
+
+### Architecture
+
+CaTune uses **module-level SolidJS signals** instead of Context providers. State is organized into store modules that export signals and setters directly:
+
+| Store                   | Responsibility                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `data-store.ts`         | Loaded traces, import pipeline, demo data, ground truth                                                                   |
+| `viz-store.ts`          | Selected cell, tau/lambda parameters, filter toggle, trace visibility, pinned snapshots                                   |
+| `multi-cell-store.ts`   | Multi-cell selection (top-active / random / manual), per-cell solver results and status                                   |
+| `cell-solve-manager.ts` | Reactive orchestrator — watches params + cell selection, dispatches jobs through worker pool with debouncing and priority |
+
+Components are organized by feature area under `src/components/`: `cards/`, `community/`, `controls/`, `import/`, `layout/`, `metrics/`, `spectrum/`, `traces/`, `tutorial/`.
+
+### Internal Packages
+
+| Package            | Role in CaTune                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `@calab/core`      | Shared types, WASM adapter (`initWasm`, `Solver`), metrics, FFT, parameter ranges      |
+| `@calab/compute`   | Worker pool, warm-start cache, kernel math, downsampling, demo presets, synthetic data |
+| `@calab/io`        | .npy/.npz parsing, trace validation, cell ranking, JSON export                         |
+| `@calab/community` | Supabase client, CRUD operations, submission logic, field options                      |
+| `@calab/tutorials` | Tutorial types, progress persistence, tutorial engine                                  |
+| `@calab/ui`        | DashboardShell, DashboardPanel, VizLayout, CompactHeader, CardGrid                     |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # CaLab Architecture
 
+> For a project overview, quick start, and documentation index, see the [root README](../README.md).
+
 CaLab is a monorepo of calcium imaging analysis tools built with SolidJS, TypeScript, and a Rust/WASM solver.
 
 ## Monorepo Structure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,3 +59,9 @@ Versions correspond to git tags (`v*`) and apply to the entire monorepo.
 
 - Restructured repository into monorepo with `apps/` and `packages/`
 - Renamed Python package from catune to calab
+
+[2.0.4]: https://github.com/miniscope/CaLab/compare/v2.0.3...v2.0.4
+[2.0.3]: https://github.com/miniscope/CaLab/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/miniscope/CaLab/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/miniscope/CaLab/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/miniscope/CaLab/releases/tag/v2.0.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 ## Setup
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/miniscope/CaLab.git
 cd CaLab
 nvm use              # Node 22
 npm install          # JS dependencies (all workspaces)
@@ -109,3 +109,7 @@ The WASM package is committed to the repo, so CI does not require Rust.
 ## Architecture
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for module layout, dependency DAG, state management patterns, and boundary rules.
+
+## License
+
+CaLab is licensed under the [MIT License](../LICENSE).

--- a/packages/community/README.md
+++ b/packages/community/README.md
@@ -1,0 +1,31 @@
+# @calab/community
+
+Supabase data access layer for community parameter sharing in CaLab.
+
+This package is **optional** — the app works fully offline without it. When Supabase credentials are configured, users can submit and browse deconvolution parameters shared by others.
+
+Depends on `@calab/core`. External dependency: `@supabase/supabase-js`.
+
+```
+@calab/core
+  ↑
+@calab/community
+  ↑
+apps/catune
+```
+
+## Boundary Rule
+
+Only `supabase.ts` may import `@supabase/supabase-js` (~45 KB). The SDK is lazy-loaded on first use via dynamic import. The `supabaseEnabled` boolean is re-exported through the barrel so the app can conditionally render community UI. This boundary is enforced by ESLint `no-restricted-imports`.
+
+## Exports
+
+| Export                                                                                                         | Source                 | Description                                           |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| `getSupabase`, `supabaseEnabled`                                                                               | `supabase.ts`          | Lazy Supabase client singleton and availability flag  |
+| `submitParameters`, `fetchSubmissions`, `fetchFieldOptions`, `deleteSubmission`                                | `community-service.ts` | CRUD operations for community submissions             |
+| `INDICATOR_OPTIONS`, `SPECIES_OPTIONS`, `MICROSCOPE_TYPE_OPTIONS`, `CELL_TYPE_OPTIONS`, `BRAIN_REGION_OPTIONS` | `field-options.ts`     | Hardcoded option arrays for submission form dropdowns |
+| `buildFieldOptionRequestUrl`, `buildFeedbackUrl`, `buildFeatureRequestUrl`, `buildBugReportUrl`                | `github-issue-url.ts`  | GitHub issue URL builders for community feedback      |
+| `validateSubmission`                                                                                           | `quality-checks.ts`    | Submission quality validation                         |
+| `submitToSupabase`                                                                                             | `submit-action.ts`     | Form → payload → Supabase submission pipeline         |
+| `DataSource`, `CommunitySubmission`, `SubmissionPayload`, `FilterState`, ...                                   | `types.ts`             | Community data types                                  |

--- a/packages/compute/README.md
+++ b/packages/compute/README.md
@@ -1,0 +1,32 @@
+# @calab/compute
+
+Worker pool, warm-start caching, kernel math, downsampling, and synthetic data generation for the CaLab monorepo.
+
+Depends on `@calab/core`.
+
+```
+@calab/core
+  ↑
+@calab/compute
+  ↑
+apps/catune
+```
+
+## Exports
+
+| Export                                                                  | Source                | Description                                                                                                                    |
+| ----------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `createWorkerPool`, `WorkerPool`                                        | `worker-pool.ts`      | Generic worker pool with priority queue, cooperative cancellation via MessageChannel yields, and intermediate result callbacks |
+| `computePaddedWindow`, `computeSafeMargin`                              | `warm-start-cache.ts` | Windowed computation helpers — compute padded solve region with safety margins for overlap-and-discard                         |
+| `shouldWarmStart`, `WarmStartCache`                                     | `warm-start-cache.ts` | 3-tier warm-start cache (lambda-only change, kernel change with momentum reset, cold start)                                    |
+| `computeKernel`, `computeKernelAnnotations`                             | `kernel-math.ts`      | Double-exponential kernel computation and annotation helpers for chart display                                                 |
+| `downsampleMinMax`                                                      | `downsample.ts`       | Min-max downsampling for efficient chart rendering of large traces                                                             |
+| `makeTimeAxis`                                                          | `time-axis.ts`        | Time axis generation from sample count and sampling rate                                                                       |
+| `DEMO_PRESETS`, `DEFAULT_PRESET_ID`, `getPresetById`, `getPresetLabels` | `demo-presets.ts`     | 6 built-in synthetic demo presets with known ground truth                                                                      |
+| `generateSyntheticTrace`, `generateSyntheticDataset`                    | `mock-traces.ts`      | Synthetic calcium trace generation for demo data                                                                               |
+
+## Design Notes
+
+- **Worker factory injection** — `createWorkerPool(() => new Worker(...))` keeps the `new Worker(new URL(..., import.meta.url))` pattern in the app so Vite can detect and bundle the worker.
+- **Raw postMessage** (not Comlink) so the event loop can process cancel messages between solver batches.
+- **MessageChannel yields** (<1 ms) instead of `setTimeout(0)` (~4 ms) for cooperative multitasking.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,31 @@
+# @calab/core
+
+Shared types, pure utilities, domain math, and the WASM adapter for the CaLab monorepo.
+
+This is a **leaf package** with no local dependencies (`valibot` is the only external dependency). All other `@calab/*` packages and both apps depend on `@calab/core`.
+
+```
+@calab/core  ← leaf (no local deps)
+  ↑
+@calab/compute, @calab/io, @calab/community, apps/catune, apps/carank
+```
+
+## Boundary Rule
+
+Only `wasm-adapter.ts` may import from the WASM solver package (`wasm/catune-solver/pkg/`). All other code in the monorepo imports `{ initWasm, Solver }` from `@calab/core`. This boundary is enforced by ESLint `no-restricted-imports`.
+
+## Exports
+
+| Export                                                          | Source                      | Description                                                                                 |
+| --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------- |
+| `initWasm`, `Solver`                                            | `wasm-adapter.ts`           | WASM initialization and solver class                                                        |
+| `CaTuneExportSchema`                                            | `schemas/export-schema.ts`  | Valibot schema for JSON export validation                                                   |
+| `NpyResult`, `NpzResult`, `ValidationResult`, `ImportStep`, ... | `types.ts`                  | Shared data types                                                                           |
+| `SAMPLING_RATE_PRESETS`                                         | `types.ts`                  | Common sampling rate options                                                                |
+| `CellSolverStatus`, `SolverParams`, `WarmStartStrategy`, ...    | `solver-types.ts`           | Worker communication protocol types                                                         |
+| `computeAR2`                                                    | `ar2.ts`                    | AR(2) coefficient derivation from tau parameters                                            |
+| `PARAM_RANGES`                                                  | `param-config.ts`           | Scientifically reasonable parameter ranges (rise 1–500 ms, decay 50–3000 ms, sparsity 0–10) |
+| `formatDuration`                                                | `format-utils.ts`           | Duration formatting utility                                                                 |
+| `computePeakSNR`, `snrToQuality`                                | `metrics/snr.ts`            | Peak signal-to-noise ratio and quality tier classification                                  |
+| `computeSparsityRatio`, `computeResidualRMS`, `computeRSquared` | `metrics/solver-metrics.ts` | Solver quality metrics                                                                      |
+| `computePeriodogram`                                            | `spectrum/fft.ts`           | Power spectral density computation                                                          |

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -1,0 +1,24 @@
+# @calab/io
+
+File parsers, data validation, cell ranking, and JSON export for the CaLab monorepo.
+
+Depends on `@calab/core`. External dependencies: `fflate` (zip decompression for .npz), `valibot` (export schema validation).
+
+```
+@calab/core
+  ↑
+@calab/io
+  ↑
+apps/catune, apps/carank
+```
+
+## Exports
+
+| Export                                             | Source            | Description                                                          |
+| -------------------------------------------------- | ----------------- | -------------------------------------------------------------------- |
+| `parseNpy`                                         | `npy-parser.ts`   | Parse NumPy `.npy` binary format into typed arrays                   |
+| `parseNpz`                                         | `npz-parser.ts`   | Parse NumPy `.npz` archives (zip of .npy files) via fflate           |
+| `validateTraceData`                                | `validation.ts`   | Validate trace data (NaN/Inf checks, shape validation, statistics)   |
+| `extractCellTrace`, `processNpyResult`             | `array-utils.ts`  | Extract single-cell traces from multi-cell arrays, transpose support |
+| `rankCellsByActivity`, `sampleRandomCells`         | `cell-ranking.ts` | Rank cells by activity level (variance-based), random cell sampling  |
+| `buildExportData`, `downloadExport`, `parseExport` | `export.ts`       | Build, download, and parse CaTune JSON export files                  |

--- a/packages/tutorials/README.md
+++ b/packages/tutorials/README.md
@@ -1,0 +1,20 @@
+# @calab/tutorials
+
+Tutorial type definitions, progress persistence, and tutorial engine for the CaLab monorepo.
+
+This is a **leaf package** with no local `@calab/*` dependencies. External dependencies: `driver.js` (step-by-step UI highlighting), `solid-js` (reactive signals for tutorial state).
+
+```
+@calab/tutorials  ← leaf
+  ↑
+apps/catune
+```
+
+## Exports
+
+| Export                                                                                      | Source               | Description                                                                        |
+| ------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------- |
+| `TutorialStep`, `Tutorial`, `TutorialProgress`                                              | `types.ts`           | Type definitions for tutorial structure and progress                               |
+| `saveProgress`, `getProgress`, `getAllProgress`, `isCompleted`, `configureStorageKey`       | `progress.ts`        | localStorage-based progress persistence                                            |
+| `activeTutorial`, `currentStepIndex`, `isTutorialActive`, `tutorialActionFired` (+ setters) | `tutorial-store.ts`  | SolidJS signals for active tutorial state                                          |
+| `startTutorial`, `stopTutorial`, `notifyTutorialAction`, `configureTutorialEngine`          | `tutorial-engine.ts` | Tutorial lifecycle management — start, stop, advance steps, handle action triggers |

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,30 @@
+# @calab/ui
+
+Shared SolidJS layout components and CSS design tokens for the CaLab monorepo.
+
+Depends on `@calab/tutorials` (for TutorialPanel and TutorialLauncher components). External dependency: `solid-js`.
+
+```
+@calab/tutorials
+  ↑
+@calab/ui
+  ↑
+apps/catune, apps/carank
+```
+
+## Exports
+
+| Export             | Source                 | Description                                                           |
+| ------------------ | ---------------------- | --------------------------------------------------------------------- |
+| `DashboardShell`   | `DashboardShell.tsx`   | 3-section CSS grid layout (header / main / sidebar)                   |
+| `DashboardPanel`   | `DashboardPanel.tsx`   | Variant-based panel wrapper with `data-panel-id` for layout targeting |
+| `VizLayout`        | `VizLayout.tsx`        | Scroll/dashboard mode switcher for visualization content              |
+| `CompactHeader`    | `CompactHeader.tsx`    | Shared header component with app title, version, and action buttons   |
+| `CardGrid`         | `CardGrid.tsx`         | Responsive grid for multi-cell trace cards                            |
+| `TutorialPanel`    | `TutorialPanel.tsx`    | Tutorial selection and progress panel                                 |
+| `TutorialLauncher` | `TutorialLauncher.tsx` | Tutorial launch button component                                      |
+| `Card`             | `Card.tsx`             | Generic card wrapper component                                        |
+
+## CSS
+
+Layout styles are in `styles/layout.css`. Apps define their own design tokens (colors, spacing, shadows) in their `global.css` files, following the dark-theme scientific instrument aesthetic.

--- a/python/README.md
+++ b/python/README.md
@@ -2,6 +2,10 @@
 
 Calcium imaging analysis tools — deconvolution and data preparation. Python companion package for the [CaLab](https://github.com/miniscope/CaLab) tools.
 
+> **Note:** This package is under active development — major updates are planned.
+
+The `calab` Python package is the Python entrypoint to the CaLab ecosystem. It runs the same FISTA deconvolution algorithm used by the CaTune web app, and provides utilities for exchanging data with the browser tools — prepare traces for import, load tuned parameters from CaTune export JSON files, and run batch deconvolution from Python scripts.
+
 ## Installation
 
 ```bash

--- a/wasm/catune-solver/README.md
+++ b/wasm/catune-solver/README.md
@@ -1,0 +1,98 @@
+# catune-solver
+
+Rust FISTA deconvolution solver compiled to WebAssembly.
+
+## Overview
+
+This crate implements the FISTA (Fast Iterative Shrinkage-Thresholding Algorithm) solver used by CaTune for calcium trace deconvolution. It is compiled to WebAssembly via `wasm-pack` and runs in Web Workers in the browser. The compiled output in `pkg/` is committed to the repository so that CI and development do not require a Rust toolchain.
+
+## Algorithm
+
+The solver minimizes the following objective with a non-negativity constraint:
+
+```
+minimize  (1/2)||y - K·s - b||² + λ·G_dc·||s||₁   subject to  s ≥ 0
+```
+
+| Symbol | Meaning                                                                                    |
+| ------ | ------------------------------------------------------------------------------------------ |
+| `y`    | Input fluorescence trace                                                                   |
+| `K`    | Convolution matrix from double-exponential kernel                                          |
+| `s`    | Deconvolved activity (output)                                                              |
+| `b`    | Scalar baseline, estimated jointly as `mean(y - K·s)`                                      |
+| `λ`    | Sparsity penalty (user-adjustable)                                                         |
+| `G_dc` | Kernel DC gain `Σh`, scales λ so the sparsity slider is effective across all kernel shapes |
+
+**Kernel:** `h(t) = exp(-t/τ_decay) - exp(-t/τ_rise)`, normalized to peak = 1.0. Length extends until the decay envelope drops below 1e-6 of peak.
+
+**FISTA iteration:** Standard Beck & Teboulle (2009) with momentum extrapolation. Step size is `1/L` where `L` (Lipschitz constant) = max|H(ω)|² computed via DFT of the kernel.
+
+**Adaptive restart:** O'Donoghue & Candes (2015) gradient-mapping criterion — resets momentum to `t = 1` when the proximal step undoes the momentum direction.
+
+**Convergence:** Primal residual criterion `||x_{k+1} - x_k|| / ||x_k|| < 1e-6` after iteration 5. This avoids an expensive forward convolution + objective evaluation per iteration.
+
+## Modules
+
+| Module      | Description                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `lib.rs`    | `Solver` struct — public wasm-bindgen API, parameter management, state serialization, bandpass filter methods            |
+| `kernel.rs` | `build_kernel` (double-exponential), `compute_lipschitz` (spectral bound via DFT)                                        |
+| `fista.rs`  | `step_batch` — FISTA iteration loop with FFT convolutions, adaptive restart, convergence check                           |
+| `fft.rs`    | `FftConvolver` — self-contained FFT convolution engine with pre-computed kernel spectrum, forward and adjoint operations |
+| `filter.rs` | `BandpassFilter` — FFT-based bandpass filter derived from kernel time constants, cosine-tapered transitions              |
+
+## Public API
+
+Methods exposed to JavaScript via `wasm-bindgen`:
+
+| Method                                             | Description                                                                     |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `new()`                                            | Create solver with default parameters (τ_rise=0.02, τ_decay=0.4, λ=0.01, fs=30) |
+| `set_params(tau_rise, tau_decay, lambda, fs)`      | Update parameters and rebuild kernel                                            |
+| `set_trace(trace)`                                 | Load a trace, grow buffers if needed, reset iteration state                     |
+| `step_batch(n_steps)`                              | Run N FISTA iterations, return true if converged                                |
+| `get_solution()`                                   | Get deconvolved activity (owned copy)                                           |
+| `get_reconvolution()`                              | Get K·s (lazy-computed, owned copy)                                             |
+| `get_reconvolution_with_baseline()`                | Get K·s + b (owned copy)                                                        |
+| `get_baseline()`                                   | Get estimated scalar baseline                                                   |
+| `get_trace()`                                      | Get current trace (may be filtered)                                             |
+| `converged()`                                      | Check convergence flag                                                          |
+| `iteration_count()`                                | Get iteration count                                                             |
+| `reset_momentum()`                                 | Reset FISTA momentum for warm-start after kernel change                         |
+| `export_state()` / `load_state(state)`             | Serialize/restore solver state for warm-start cache                             |
+| `set_filter_enabled(enabled)` / `filter_enabled()` | Toggle bandpass filter                                                          |
+| `apply_filter()`                                   | Apply bandpass filter to loaded trace                                           |
+| `get_power_spectrum()`                             | Get \|FFT\|² of current trace                                                   |
+| `get_spectrum_frequencies()`                       | Get frequency axis in Hz                                                        |
+| `get_filter_cutoffs()`                             | Get [f_hp, f_lp] cutoff frequencies                                             |
+
+## Build
+
+```bash
+cd wasm/catune-solver
+wasm-pack build --target web --release
+```
+
+Output goes to `pkg/` which is committed to the repository. You only need to rebuild when modifying the solver Rust source.
+
+From the repo root:
+
+```bash
+npm run build:wasm
+```
+
+## Performance
+
+- **Pre-allocated buffers** — grow but never shrink to prevent WASM memory fragmentation
+- **f32 precision** — halves memory per worker compared to f64 (Lipschitz constant computed in f64 for step-size accuracy)
+- **FFT convolution** — O(n log n) via `realfft`/`rustfft` for both forward and adjoint operations
+- **Release profile** — `opt-level = 3`, LTO, single codegen unit, wasm-opt with bulk-memory
+
+## Dependencies
+
+| Crate                      | Purpose                                    |
+| -------------------------- | ------------------------------------------ |
+| `wasm-bindgen`             | JavaScript interop                         |
+| `console_error_panic_hook` | Readable panic messages in browser console |
+| `realfft`                  | Real-valued FFT (wraps rustfft)            |
+| `rustfft`                  | FFT computation                            |


### PR DESCRIPTION
## Summary

- Create root `README.md` as the project front door with badges, screenshot, overview, quick start guides (scientists + developers), monorepo structure, packages table, tech stack, and documentation index
- Create root `LICENSE` (MIT, matching `python/LICENSE`)
- Create `apps/catune/README.md` with features, solver overview (objective function, FISTA details), development guide, and internal packages table
- Create READMEs for all 6 `@calab/*` packages with dependency position, exports tables, and boundary rules
- Create `wasm/catune-solver/README.md` with algorithm description, module breakdown, full public API table, build instructions, and performance notes
- Update `docs/CONTRIBUTING.md` — replace `<repo-url>` placeholder, add License section
- Update `docs/ARCHITECTURE.md` — add cross-reference to root README
- Update `docs/CHANGELOG.md` — add version comparison links
- Update `python/README.md` — add active development note and general role paragraph

**10 new files, 4 updates, 537 lines added.**

## Test plan

- [ ] Verify `npm run format:check` passes (already formatted)
- [ ] Verify all internal doc links resolve (22 links verified)
- [ ] Confirm root README renders correctly on GitHub (badges, screenshot, tables)
- [ ] Confirm no CaRank-specific content in user-facing docs
- [ ] Confirm Python docs describe general role only

🤖 Generated with [Claude Code](https://claude.com/claude-code)