### PR TITLE
fix: tutorial terminology, accuracy & new theory content

### DIFF
--- a/apps/catune/src/components/controls/CellSelector.tsx
+++ b/apps/catune/src/components/controls/CellSelector.tsx
@@ -195,10 +195,11 @@ export function CellSelector(props: CellSelectorProps) {
               <strong>Filtered</strong> — Bandpass-filtered trace (drift + noise removed)
             </div>
             <div class="legend-info__row">
-              <strong>Fit</strong> — Reconvolved model fit (kernel * spikes + baseline)
+              <strong>Fit</strong> — Reconvolved model fit (kernel * deconvolved activity +
+              baseline)
             </div>
             <div class="legend-info__row">
-              <strong>Deconv</strong> — Estimated spike train (deconvolution result)
+              <strong>Deconv</strong> — Estimated neural activity (deconvolution result)
             </div>
             <div class="legend-info__row">
               <strong>Resid</strong> — Residuals (Raw minus Fit)

--- a/apps/catune/src/lib/tutorial/content/01-basics.ts
+++ b/apps/catune/src/lib/tutorial/content/01-basics.ts
@@ -95,7 +95,7 @@ export const basicsTutorial: Tutorial = {
       element: '[data-tutorial="slider-decay"]',
       title: 'Decay Time (tau_decay)',
       description:
-        'The most important parameter \u2014 start here. Controls how quickly calcium decays after a neural event. Too short: the solver re-fires spikes during the decay phase to explain lingering signal (overfitting). Too long: fit is sluggish and misses fast events. <b>Spikes should primarily occur during the rise, not spread across the whole decay.</b>',
+        'The most important parameter \u2014 start here. Controls how quickly calcium decays after a neural event. Too short: the solver places extra activity during the decay phase to explain lingering signal (overfitting). Too long: fit is sluggish and misses fast events. <b>Deconvolved activity should primarily appear during the rise, not spread across the whole decay.</b>',
       side: 'right',
     },
     // Step 12: Rise slider
@@ -111,7 +111,7 @@ export const basicsTutorial: Tutorial = {
       element: '[data-tutorial="slider-lambda"]',
       title: 'Sparsity Penalty (lambda)',
       description:
-        'Controls event count. Start low and increase until noise spikes disappear from the green trace without losing real events. <b>Prefer adjusting decay time over relying on high sparsity</b> to control overfitting. Increasing decay can help reduce dense deconvolved activity under big fluorescence events.',
+        'Controls event count. Start low and increase until noise artifacts disappear from the green trace without losing real events. A value of 1 is a good starting point. The green deconvolved trace should show clean, sharp peaks at real events with a quiet baseline between them. If the reconvolved fit peak starts decreasing away from the raw trace as you increase lambda, your sparsity is too high. <b>Prefer adjusting decay time over relying on high sparsity</b> to control overfitting. Increasing decay can help reduce dense deconvolved activity under big fluorescence events. Most cells will respond well to small sparsity values, but a small percentage of cells may be too noisy for reliable deconvolution \u2014 don\u2019t overfit noisy cells, focus on the average-looking cell.',
       side: 'right',
     },
     // Step 14: Kernel display
@@ -127,7 +127,7 @@ export const basicsTutorial: Tutorial = {
       element: '[data-tutorial="card-grid"]',
       title: 'Good Fit vs Bad Fit',
       description:
-        '<b>Good:</b> orange tracks blue peaks, green deconvolved events ride on the rise and decay of the calcium trace, red looks like noise. <b>Bad:</b> orange misses peaks, green has spikes spread beyond the actual transients, red shows structured patterns.',
+        '<b>Good:</b> orange tracks blue peaks, green deconvolved activity appears primarily during the rise of calcium events (activity during the decay suggests additional neural activity or an extended response), red looks like noise. <b>Bad:</b> orange misses or undershoots peaks, the orange tail overshoots the raw data, green has activity spread beyond the actual transients, red shows structured patterns.',
       side: 'left',
     },
     // Step 16: Pin for comparison

--- a/apps/catune/src/lib/tutorial/content/02-workflow.ts
+++ b/apps/catune/src/lib/tutorial/content/02-workflow.ts
@@ -117,7 +117,7 @@ export const workflowTutorial: Tutorial = {
       element: '[data-tutorial="slider-lambda"]',
       title: 'Step 5: Add Sparsity',
       description:
-        'Increase lambda to clean up the deconvolved trace. Start low and increase until noise spikes disappear from the green trace. Stop before real events start vanishing. Drag to adjust.',
+        'Increase lambda to clean up the deconvolved trace. Start low and increase until noise artifacts disappear from the green trace. Stop before real events start vanishing. Drag to adjust.',
       side: 'right',
       waitForAction: 'slider-change',
       disableActiveInteraction: false,

--- a/apps/catune/src/lib/tutorial/content/05-theory.ts
+++ b/apps/catune/src/lib/tutorial/content/05-theory.ts
@@ -122,22 +122,38 @@ export const theoryTutorial: Tutorial = {
     {
       title: 'What Deconvolved Activity Is',
       description:
-        'The deconvolved trace <b>s(t)</b> is, at best, a measure of underlying neural activity <b>scaled by an unknown factor</b>. The variable name <b>s</b> is a convention from the optimization literature — it does <b>not</b> stand for "spikes." The output is a continuous, graded signal, not a series of discrete events.<br><br>' +
-        'The absolute amplitude of s(t) depends on indicator expression, imaging conditions, cell depth, and many other variables. It has <b>no fixed physical meaning</b>. Only <b>relative differences</b> within the same cell under the same conditions are meaningful.',
+        'The deconvolved trace <b>s(t)</b> is, at best, a <b>probable neural activity rate</b> scaled by an <b>unknown factor</b>. The variable name <b>s</b> is a convention from the optimization literature — it does <b>not</b> stand for "spikes." The output is a continuous, graded signal, not a series of discrete events.<br><br>' +
+        'The absolute amplitude of s(t) depends on indicator expression, imaging conditions, cell depth, and many other variables. It has <b>no fixed physical meaning</b>. The unknown scalar factor can <b>differ between cells</b> and can <b>change over time</b> across sessions. Only <b>relative differences</b> within the same cell under the same conditions are meaningful.',
     },
     // Step 12: What deconvolved activity is NOT
     {
       title: 'What Deconvolved Activity Is NOT',
       description:
         'Critical limitations:<br><br>' +
-        '<b>1.</b> s(t) is <b>not a spike train</b> — do not threshold it into binary events<br>' +
+        '<b>1.</b> s(t) is <b>not a spike train</b> — binarizing (thresholding into 0/1) discards meaningful amplitude information and should be avoided in almost all cases<br>' +
         '<b>2.</b> You cannot derive <b>spikes-per-second</b> or firing rates from it<br>' +
         '<b>3.</b> It assumes neural activity is within the <b>linear response range</b> of the indicator<br>' +
         '<b>4.</b> It assumes calcium dynamics are not significantly driven by <b>non-neural factors</b> (glial activity, neuromodulation)<br>' +
         '<b>5.</b> It assumes a <b>single uniform kernel</b> applies to all events in the cell<br><br>' +
         'Treat s(t) as a <b>continuous, relative measure</b> of activity — not a direct readout of spiking.',
     },
-    // Step 13: Practical guidance
+    // Step 13: Comparing across cells and sessions
+    {
+      title: 'Comparing Across Cells and Sessions',
+      description:
+        'The unknown scalar factor that relates s(t) to true neural activity can <b>differ between cells</b> (due to indicator expression, optical path, cell depth) and can <b>evolve over time</b> across sessions (photobleaching, expression changes).<br><br>' +
+        '<b>Within a single cell in a single session</b>, the unknown scalar is generally stable — so within-trace comparisons of amplitude and timing are meaningful.<br><br>' +
+        '<b>Across cells or sessions</b>, direct amplitude comparison should generally <b>never</b> be done without careful normalization. Even with normalization, extreme caution is needed — clever normalization schemes can help but are very limited and cannot fully resolve the unknown scaling differences.',
+    },
+    // Step 14: Why you should not binarize
+    {
+      title: 'Why You Should Not Binarize',
+      description:
+        'Deconvolved output is a <b>continuous, graded signal</b>. Binarizing it (thresholding into 0/1 "event" vs "no event") discards meaningful amplitude information and should be <b>avoided in almost all cases</b>.<br><br>' +
+        'The deconvolved output should never be treated as "spikes" — it is at best a probable neural activity rate scaled by an unknown factor. Researchers often threshold out of habit from electrophysiology, but calcium deconvolution is <b>fundamentally different</b>: the temporal resolution and signal characteristics make binary discretization inappropriate.<br><br>' +
+        'If you need discrete events for a specific analysis, consider whether the continuous signal would serve your question better — in most cases, it will.',
+    },
+    // Step 15: Practical guidance
     {
       title: 'Practical Guidance',
       description:
@@ -147,7 +163,7 @@ export const theoryTutorial: Tutorial = {
         '<b>3.</b> Check the <b>Community Parameters</b> tab for values others use with your indicator and brain region<br>' +
         '<b>4.</b> When in doubt, trust the <b>residuals</b> — they reveal whether the model captures the signal structure or is fitting noise',
     },
-    // Step 14: Theory complete
+    // Step 16: Theory complete
     {
       title: 'Theory Complete',
       description:

--- a/packages/io/src/export.ts
+++ b/packages/io/src/export.ts
@@ -49,7 +49,8 @@ export function buildExportData(
       kernel: 'h(t) = exp(-t/tau_decay) - exp(-t/tau_rise), normalized to unit peak',
       ar2_relation:
         'c[t] = g1*c[t-1] + g2*c[t-2] + s[t], where g1 = decayRoot+riseRoot, g2 = -(decayRoot*riseRoot), decayRoot = exp(-dt/tau_decay), riseRoot = exp(-dt/tau_rise)',
-      lambda_definition: 'L1 penalty weight on spike train s in the FISTA objective function',
+      lambda_definition:
+        'L1 penalty weight on the activity signal s in the FISTA objective function',
       convergence: 'Relative objective change < 1e-6 or max 2000 iterations',
     },
     metadata: {


### PR DESCRIPTION
## Summary
- Replace "spike/spikes" with "activity/deconvolved activity" in all user-facing tutorial text and UI tooltips (retaining "spikes" only where it explicitly denies the spike interpretation)
- Fix Step 15 of Understanding Parameters: deconvolved activity appears primarily during the **rise**, not across rise AND decay
- Expand sparsity guidance in Step 13 (starting value, what good traces look like, detecting too-high lambda, noisy cell advice)
- Add two new Theory tutorial steps: **Comparing Across Cells and Sessions** (Step 13) and **Why You Should Not Binarize** (Step 14)
- Strengthen existing Theory steps 11–12 with "probable neural activity rate" framing and stronger anti-binarization language
- Fix export metadata: "spike train s" → "activity signal s"

## Files changed
- `apps/catune/src/lib/tutorial/content/01-basics.ts` — Steps 11, 13, 15
- `apps/catune/src/lib/tutorial/content/02-workflow.ts` — Step 12
- `apps/catune/src/lib/tutorial/content/05-theory.ts` — Steps 11–16 (expanded + 2 new)
- `apps/catune/src/components/controls/CellSelector.tsx` — Legend tooltips
- `packages/io/src/export.ts` — Lambda definition string

## Test plan
- [x] `npm run format` passes
- [x] `npm run build` succeeds for both apps
- [x] Step through Understanding Parameters tutorial (steps 11, 13, 15) to verify updated wording
- [x] Step through Theory tutorial to verify new steps 13–14 render correctly and flow is coherent
- [x] Check legend "?" popover for updated tooltip text

🤖 Generated with [Claude Code](https://claude.com/claude-code)