### PR TITLE
fix: codebase-wide quality sweep (26 fixes)

### DIFF
--- a/apps/_template/vite.config.ts
+++ b/apps/_template/vite.config.ts
@@ -3,9 +3,9 @@ import path from 'node:path';
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
-const repoRoot = path.resolve(__dirname, '../..');
-const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
-const displayName = pkg.calab?.displayName ?? path.basename(__dirname);
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, 'package.json'), 'utf-8'));
+const displayName = pkg.calab?.displayName ?? path.basename(import.meta.dirname);
 
 export default defineConfig({
   resolve: {

--- a/apps/admin/src/components/ExportPanel.tsx
+++ b/apps/admin/src/components/ExportPanel.tsx
@@ -13,7 +13,7 @@ import { dateRange } from '../lib/admin-store.ts';
 export function ExportPanel(): JSX.Element {
   const [sessions] = createResource(dateRange, fetchSessions);
   const [events] = createResource(dateRange, fetchEvents);
-  const [submissions] = createResource(fetchSubmissions);
+  const [submissions] = createResource(dateRange, fetchSubmissions);
 
   const filenameSuffix = () => `${dateRange().start}_to_${dateRange().end}`;
 

--- a/apps/admin/src/components/OverviewView.tsx
+++ b/apps/admin/src/components/OverviewView.tsx
@@ -1,13 +1,13 @@
-import { type JSX, createResource } from 'solid-js';
+import { type JSX, createMemo, createResource } from 'solid-js';
 import { MetricCard } from './MetricCard.tsx';
 import { fetchSessions, fetchSubmissions, computeMetrics } from '../lib/analytics-queries.ts';
 import { dateRange } from '../lib/admin-store.ts';
 
 export function OverviewView(): JSX.Element {
   const [sessions] = createResource(dateRange, fetchSessions);
-  const [submissions] = createResource(fetchSubmissions);
+  const [submissions] = createResource(dateRange, fetchSubmissions);
 
-  const metrics = () => computeMetrics(sessions() ?? [], submissions() ?? []);
+  const metrics = createMemo(() => computeMetrics(sessions() ?? [], submissions() ?? []));
 
   return (
     <div class="view">

--- a/apps/admin/src/components/SubmissionsView.tsx
+++ b/apps/admin/src/components/SubmissionsView.tsx
@@ -1,9 +1,10 @@
 import { type JSX, createResource, createSignal, createMemo } from 'solid-js';
 import { DataTable } from './DataTable.tsx';
 import { fetchSubmissions, deleteSubmission } from '../lib/analytics-queries.ts';
+import { dateRange } from '../lib/admin-store.ts';
 
 export function SubmissionsView(): JSX.Element {
-  const [submissions, { refetch }] = createResource(fetchSubmissions);
+  const [submissions, { refetch }] = createResource(dateRange, fetchSubmissions);
   const [filterIndicator, setFilterIndicator] = createSignal('');
   const [filterSpecies, setFilterSpecies] = createSignal('');
   const [filterRegion, setFilterRegion] = createSignal('');

--- a/apps/admin/src/lib/analytics-queries.ts
+++ b/apps/admin/src/lib/analytics-queries.ts
@@ -48,13 +48,15 @@ export async function fetchEvents(range: DateRange): Promise<EventRow[]> {
   return (data ?? []) as EventRow[];
 }
 
-export async function fetchSubmissions(): Promise<SubmissionRow[]> {
+export async function fetchSubmissions(range: DateRange): Promise<SubmissionRow[]> {
   const supabase = await getSupabase();
   if (!supabase) return [];
 
   const { data, error } = await supabase
     .from('catune_submissions')
     .select('id, created_at, user_id, indicator, species, brain_region, data_source, app_version')
+    .gte('created_at', range.start)
+    .lte('created_at', endOfDay(range.end))
     .order('created_at', { ascending: false });
 
   if (error) throw new Error(error.message);

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
-const repoRoot = path.resolve(__dirname, '../..');
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, 'package.json'), 'utf-8'));
+const displayName = pkg.calab?.displayName ?? path.basename(import.meta.dirname);
 
 export default defineConfig({
   resolve: {
@@ -12,7 +15,11 @@ export default defineConfig({
     },
   },
   envDir: repoRoot,
-  base: process.env.GITHUB_ACTIONS ? '/CaLab/Admin/' : process.env.CALAB_PAGES ? '/Admin/' : '/',
+  base: process.env.GITHUB_ACTIONS
+    ? `/CaLab/${displayName}/`
+    : process.env.CALAB_PAGES
+      ? `/${displayName}/`
+      : '/',
   plugins: [solidPlugin()],
   build: {
     target: 'esnext',

--- a/apps/carank/src/components/FileImport.tsx
+++ b/apps/carank/src/components/FileImport.tsx
@@ -1,5 +1,5 @@
 import { type JSX, createSignal } from 'solid-js';
-import { parseNpy } from '@calab/io';
+import { parseNpy, processNpyResult } from '@calab/io';
 import { trackEvent } from '@calab/community';
 import type { CnmfData } from '../types.ts';
 
@@ -16,7 +16,8 @@ export function FileImport(props: FileImportProps): JSX.Element {
     setError(null);
     try {
       const buffer = await file.arrayBuffer();
-      const result = parseNpy(buffer);
+      const raw = parseNpy(buffer);
+      const result = processNpyResult(raw);
 
       if (result.shape.length !== 2) {
         setError(`Expected 2D array (cells x timepoints), got ${result.shape.length}D`);
@@ -42,7 +43,7 @@ export function FileImport(props: FileImportProps): JSX.Element {
     e.preventDefault();
     setDragging(false);
     const file = e.dataTransfer?.files[0];
-    if (file) processFile(file);
+    if (file) void processFile(file);
   };
 
   const handleDragOver: JSX.EventHandler<HTMLDivElement, DragEvent> = (e) => {
@@ -90,7 +91,7 @@ export function FileImport(props: FileImportProps): JSX.Element {
         style={{ display: 'none' }}
         onChange={(e) => {
           const file = e.currentTarget.files?.[0];
-          if (file) processFile(file);
+          if (file) void processFile(file);
         }}
       />
     </div>

--- a/apps/carank/src/components/Header.tsx
+++ b/apps/carank/src/components/Header.tsx
@@ -12,12 +12,12 @@ interface HeaderProps {
 }
 
 export function Header(props: HeaderProps): JSX.Element {
-  const version = () => `CaLab ${import.meta.env.VITE_APP_VERSION || 'dev'}`;
+  const version = `CaLab ${import.meta.env.VITE_APP_VERSION || 'dev'}`;
 
   return (
     <CompactHeader
       title="CaRank"
-      version={version()}
+      version={version}
       info={
         <>
           <span class="compact-header__file">{props.fileName}</span>

--- a/apps/carank/src/styles/global.css
+++ b/apps/carank/src/styles/global.css
@@ -2,6 +2,9 @@
 
 :root {
   --header-bg: var(--bg-primary);
+  --tier-good: #2e7d32;
+  --tier-fair: #e09800;
+  --tier-poor: #d32f2f;
 }
 
 /* App-specific overrides for shared components */

--- a/apps/carank/vite.config.ts
+++ b/apps/carank/vite.config.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
-const repoRoot = path.resolve(__dirname, '../..');
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, 'package.json'), 'utf-8'));
+const displayName = pkg.calab?.displayName ?? path.basename(import.meta.dirname);
 
 export default defineConfig({
   resolve: {
@@ -15,7 +18,11 @@ export default defineConfig({
     },
   },
   envDir: repoRoot,
-  base: process.env.GITHUB_ACTIONS ? '/CaLab/CaRank/' : process.env.CALAB_PAGES ? '/CaRank/' : '/',
+  base: process.env.GITHUB_ACTIONS
+    ? `/CaLab/${displayName}/`
+    : process.env.CALAB_PAGES
+      ? `/${displayName}/`
+      : '/',
   plugins: [solidPlugin()],
   build: {
     target: 'esnext',

--- a/apps/catune/src/components/cards/CardGrid.tsx
+++ b/apps/catune/src/components/cards/CardGrid.tsx
@@ -83,6 +83,12 @@ export function CardGrid(props: CardGridProps) {
       <CardGridLayout columns={gridColumns()} data-tutorial="card-grid">
         <For each={cells()}>
           {(cellIndex) => {
+            onCleanup(() => {
+              const el = cardRefs.get(cellIndex);
+              if (el) observer?.unobserve(el);
+              cardRefs.delete(cellIndex);
+              visibleSet.delete(cellIndex);
+            });
             const traces = createMemo(() => multiCellResults[cellIndex]);
             const pinnedTraces = createMemo(() => pinnedMultiCellResults[cellIndex]);
             const gt = createMemo(() => {

--- a/apps/catune/src/components/cards/TraceOverview.tsx
+++ b/apps/catune/src/components/cards/TraceOverview.tsx
@@ -5,7 +5,7 @@
  * Click/drag to reposition the zoom window.
  */
 
-import { createEffect, createMemo, onCleanup, onMount } from 'solid-js';
+import { createEffect, createMemo, on, onCleanup, onMount } from 'solid-js';
 import { downsampleMinMax, makeTimeAxis } from '@calab/compute';
 
 export interface TraceOverviewProps {
@@ -131,16 +131,12 @@ export function TraceOverview(props: TraceOverviewProps) {
     }
   }
 
-  createEffect(() => {
-    // Track reactive dependencies (SolidJS signal access pattern)
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    props.trace;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    props.zoomStart;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    props.zoomEnd;
-    draw();
-  });
+  createEffect(
+    on(
+      () => [props.trace, props.zoomStart, props.zoomEnd],
+      () => draw(),
+    ),
+  );
 
   // ResizeObserver for container width changes
   let resizeRaf: number | undefined;

--- a/apps/catune/src/components/controls/CellSelector.tsx
+++ b/apps/catune/src/components/controls/CellSelector.tsx
@@ -36,11 +36,6 @@ import {
 } from '../../lib/viz-store.ts';
 import '../../styles/multi-trace.css';
 
-export interface CellSelectorProps {
-  /** Called when selection changes (triggers batch re-solve). */
-  onSelectionChange?: () => void;
-}
-
 interface LegendItemProps {
   color: string;
   label: string;
@@ -70,12 +65,11 @@ function LegendItem(props: LegendItemProps) {
   );
 }
 
-export function CellSelector(props: CellSelectorProps) {
+export function CellSelector() {
   const handleModeChange = (e: Event) => {
     const value = (e.target as HTMLSelectElement).value as SelectionMode;
     setSelectionMode(value);
     updateCellSelection();
-    props.onSelectionChange?.();
   };
 
   const handleCountChange = (e: Event) => {
@@ -83,7 +77,6 @@ export function CellSelector(props: CellSelectorProps) {
     if (!isNaN(value) && value >= 1) {
       setDisplayCount(Math.min(value, Math.min(20, numCells())));
       updateCellSelection();
-      props.onSelectionChange?.();
     }
   };
 
@@ -99,12 +92,10 @@ export function CellSelector(props: CellSelectorProps) {
     // Deduplicate
     const unique = [...new Set(indices)];
     setSelectedCells(unique);
-    props.onSelectionChange?.();
   };
 
   const handleReshuffle = () => {
     updateCellSelection();
-    props.onSelectionChange?.();
   };
 
   const maxCount = () => Math.min(20, numCells());

--- a/apps/catune/src/components/import/DimensionConfirmation.tsx
+++ b/apps/catune/src/components/import/DimensionConfirmation.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../lib/data-store.ts';
 
 export function DimensionConfirmation() {
-  const shape = () => effectiveShape();
+  const shape = effectiveShape;
 
   const handleSwap = () => {
     setSwapped(!swapped());

--- a/apps/catune/src/lib/community/submit-action.ts
+++ b/apps/catune/src/lib/community/submit-action.ts
@@ -92,7 +92,7 @@ export async function submitToSupabase(
     fps: ctx.samplingRate,
     dataset_hash: datasetHash,
     filter_enabled: ctx.filterEnabled,
-    data_source: ctx.rawFileName ? 'user' : 'demo',
+    data_source: ctx.isDemo ? 'demo' : 'user',
     app_version: version,
     extra_metadata: ctx.isDemo && ctx.demoPresetId ? { demo_preset: ctx.demoPresetId } : undefined,
   };

--- a/apps/catune/src/lib/data-store.ts
+++ b/apps/catune/src/lib/data-store.ts
@@ -91,9 +91,9 @@ function loadDemoData(opts?: {
   seed?: number | 'random';
 }): void {
   const fs = opts?.fps ?? 30;
-  const numCells = opts?.numCells ?? 20;
+  const cellCount = opts?.numCells ?? 20;
   const durationMin = opts?.durationMinutes ?? 5;
-  const numTimepoints = Math.round(durationMin * 60 * fs);
+  const timepointCount = Math.round(durationMin * 60 * fs);
 
   const preset = getPresetById(opts?.presetId ?? DEFAULT_PRESET_ID);
   if (!preset) return;
@@ -106,7 +106,7 @@ function loadDemoData(opts?: {
     shape,
     groundTruthSpikes: gtSpikes,
     groundTruthCalcium: gtCalcium,
-  } = generateSyntheticDataset(numCells, numTimepoints, preset.params, fs, resolvedSeed);
+  } = generateSyntheticDataset(cellCount, timepointCount, preset.params, fs, resolvedSeed);
 
   setGroundTruthSpikes(gtSpikes);
   setGroundTruthCalcium(gtCalcium);
@@ -128,7 +128,7 @@ function loadDemoData(opts?: {
       nanCount: 0,
       infCount: 0,
       negativeCount: 0,
-      totalElements: numCells * numTimepoints,
+      totalElements: cellCount * timepointCount,
     },
   });
 }

--- a/apps/catune/vite.config.ts
+++ b/apps/catune/vite.config.ts
@@ -1,9 +1,12 @@
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import wasm from 'vite-plugin-wasm';
 
-const repoRoot = path.resolve(__dirname, '../..');
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, 'package.json'), 'utf-8'));
+const displayName = pkg.calab?.displayName ?? path.basename(import.meta.dirname);
 
 export default defineConfig({
   resolve: {
@@ -17,7 +20,11 @@ export default defineConfig({
     },
   },
   envDir: repoRoot,
-  base: process.env.GITHUB_ACTIONS ? '/CaLab/CaTune/' : process.env.CALAB_PAGES ? '/CaTune/' : '/',
+  base: process.env.GITHUB_ACTIONS
+    ? `/CaLab/${displayName}/`
+    : process.env.CALAB_PAGES
+      ? `/${displayName}/`
+      : '/',
   plugins: [solidPlugin(), wasm()],
   worker: {
     plugins: () => [wasm()],

--- a/packages/community/src/field-options-service.ts
+++ b/packages/community/src/field-options-service.ts
@@ -30,7 +30,7 @@ export async function fetchFieldOptions(): Promise<FieldOptions> {
     cell_type: [],
   };
   for (const row of rows) {
-    grouped[row.field_name].push(row.value);
+    if (row.field_name in grouped) grouped[row.field_name].push(row.value);
   }
 
   return {

--- a/packages/community/src/index.ts
+++ b/packages/community/src/index.ts
@@ -20,7 +20,7 @@ export {
 } from './field-options.ts';
 
 // Analytics
-export { initSession, trackEvent, endSession, registerSessionEndListeners } from './analytics.ts';
+export { initSession, trackEvent, registerSessionEndListeners } from './analytics.ts';
 export type { AnalyticsEventName } from './analytics.ts';
 
 // Utilities
@@ -37,7 +37,6 @@ export {
 // Types
 export type {
   BaseSubmission,
-  BaseSubmissionPayload,
   BaseFilterState,
   DataSource,
   SubmissionValidationResult,

--- a/packages/community/src/supabase.ts
+++ b/packages/community/src/supabase.ts
@@ -8,8 +8,8 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+export const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+export const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn('Supabase credentials not configured. Community features will be disabled.');

--- a/packages/community/src/types.ts
+++ b/packages/community/src/types.ts
@@ -65,7 +65,6 @@ export interface SubmissionValidationResult {
 
 /** Row from the field_options lookup table. */
 export interface FieldOption {
-  id: number;
   field_name: 'indicator' | 'species' | 'brain_region' | 'microscope_type' | 'cell_type';
   value: string;
   display_order: number;

--- a/packages/compute/src/worker-pool.ts
+++ b/packages/compute/src/worker-pool.ts
@@ -190,7 +190,6 @@ export function createWorkerPool(createWorker: () => Worker, poolSize?: number):
     // Cancel all queued jobs
     while (queue.length > 0) {
       const job = queue.shift()!;
-      inFlightJobs.delete(job.jobId);
       job.onCancelled();
     }
 

--- a/packages/core/src/solver-types.ts
+++ b/packages/core/src/solver-types.ts
@@ -21,33 +21,8 @@ export interface SolverParams {
   filterEnabled: boolean; // bandpass filter derived from kernel
 }
 
-/** Intermediate result emitted during solver iteration for live visualization. */
-export interface IntermediateResult {
-  solution: Float32Array;
-  reconvolution: Float32Array;
-  iteration: number;
-}
-
-/** Final result returned after solver convergence or termination. */
-export interface SolveResult {
-  solution: Float32Array;
-  reconvolution: Float32Array;
-  state: Uint8Array; // serialized warm-start state
-  iterations: number;
-  converged: boolean;
-}
-
 /** Strategy for initializing the solver on a new solve request. */
 export type WarmStartStrategy = 'warm' | 'warm-no-momentum' | 'cold';
-
-/** Full solve request message sent to the worker. */
-export interface SolveRequest {
-  trace: Float32Array;
-  params: SolverParams;
-  warmStartState: Uint8Array | null;
-  warmStartStrategy: WarmStartStrategy;
-  jobId: number;
-}
 
 // --- Pool worker message protocol ---
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,8 +68,7 @@ export type ImportStep = 'drop' | 'confirm-dims' | 'sampling-rate' | 'validation
 // --- Sampling Rate Presets ---
 
 export const SAMPLING_RATE_PRESETS = [
-  { label: '30 Hz (miniscope)', value: 30 },
-  { label: '30 Hz (2-photon)', value: 30 },
+  { label: '30 Hz (miniscope / 2-photon)', value: 30 },
   { label: '15 Hz (slow 2-photon)', value: 15 },
   { label: '10 Hz (widefield)', value: 10 },
   { label: '60 Hz (fast miniscope)', value: 60 },

--- a/packages/core/src/wasm-adapter.ts
+++ b/packages/core/src/wasm-adapter.ts
@@ -8,7 +8,6 @@
 
 import init, { Solver } from '../../../wasm/catune-solver/pkg/catune_solver';
 export { Solver };
-export type { InitInput, InitOutput } from '../../../wasm/catune-solver/pkg/catune_solver';
 
 let wasmReady: Promise<void> | null = null;
 

--- a/packages/tutorials/src/index.ts
+++ b/packages/tutorials/src/index.ts
@@ -8,13 +8,9 @@ export {
 } from './progress.ts';
 export {
   activeTutorial,
-  setActiveTutorial,
   currentStepIndex,
-  setCurrentStepIndex,
   isTutorialActive,
-  setIsTutorialActive,
   tutorialActionFired,
-  setTutorialActionFired,
 } from './tutorial-store.ts';
 export {
   startTutorial,

--- a/packages/tutorials/src/tutorial-engine.ts
+++ b/packages/tutorials/src/tutorial-engine.ts
@@ -73,11 +73,12 @@ function mapSteps(tutorial: Tutorial): DriveStep[] {
 
     // Interactive steps: block next button until user performs required action
     if (step.waitForAction) {
-      // Allow interaction with the highlighted element
-      driveStep.disableActiveInteraction = false;
+      // Allow interaction with the highlighted element (unless explicitly overridden)
+      if (step.disableActiveInteraction === undefined) {
+        driveStep.disableActiveInteraction = false;
+      }
 
       driveStep.onHighlighted = () => {
-        setCurrentStepIndex(index);
         // Reset action flag when entering an interactive step
         setTutorialActionFired(false);
       };

--- a/packages/ui/src/AuthMenu.tsx
+++ b/packages/ui/src/AuthMenu.tsx
@@ -13,7 +13,10 @@ export function AuthMenu(props: AuthMenuProps) {
   const [open, setOpen] = createSignal(false);
   let containerRef!: HTMLDivElement;
 
-  const close = () => setOpen(false);
+  const close = () => {
+    setOpen(false);
+    detach();
+  };
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') close();

--- a/packages/ui/src/AuthMenuWrapper.tsx
+++ b/packages/ui/src/AuthMenuWrapper.tsx
@@ -1,5 +1,5 @@
 import type { Accessor } from 'solid-js';
-import { createSignal, Show } from 'solid-js';
+import { createEffect, createSignal, Show } from 'solid-js';
 import { AuthMenu } from './AuthMenu.tsx';
 
 export interface AuthMenuWrapperProps {
@@ -15,6 +15,15 @@ export function AuthMenuWrapper(props: AuthMenuWrapperProps) {
   const [sending, setSending] = createSignal(false);
   const [sent, setSent] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+
+  // Reset form state when user signs out
+  createEffect(() => {
+    if (!props.user()) {
+      setSent(false);
+      setError(null);
+      setEmail('');
+    }
+  });
 
   async function handleSubmit(e: Event) {
     e.preventDefault();


### PR DESCRIPTION
## Summary

- **26 fixes** across bugs, security, performance, dead code, and fragility identified by parallel code review of the entire codebase
- Touches 35 files across all packages and apps (community, ui, tutorials, core, compute, io, catune, carank, admin, build scripts)

### Bug Fixes (17)
- Fix `subscribeAuth` race condition with `disposed` flag
- Guard `field-options-service` against unknown `field_name`
- Fix AuthMenu event listener leak (call `detach()` on close)
- Reset AuthMenuWrapper state on sign-out
- Fix tutorial engine `disableActiveInteraction` override + remove redundant `setCurrentStepIndex`
- Unexport tutorial setter functions from public API
- Remove dead `endSession` export, deduplicate env vars in analytics
- Remove unused `BaseSubmissionPayload` export
- Remove phantom `FieldOption.id` type field
- Add Fortran-order `.npy` handling to CaRank
- Use `<For>` + single-pass tier counting in CaRank
- Add `void` prefix to fire-and-forget async calls in CaRank
- Fix CaTune `data_source` derivation to use `ctx.isDemo`
- Fix admin `fetchSubmissions` ignoring date range (3 call sites)
- Wrap admin `OverviewView` metrics in `createMemo`
- Make CaRank `version` a plain constant (not reactive)
- Move CaRank tier colors to CSS custom properties

### Security (2)
- Escape HTML/JS interpolations in `combine-dist.mjs` landing page (XSS prevention)
- Harden `.env` parser for quoted values and inline comments

### Performance (2)
- Memoize deconv min/max in ZoomWindow (avoids O(N) scan per zoom frame)
- Cache per-cell PSD in spectrum-store (reduces cell-switch from N FFTs to 1)

### Build Modernization (1)
- Replace `__dirname` with `import.meta.dirname` in all 4 vite configs; dynamic `base` from `package.json`

### Dead Code & Cleanups (4)
- Remove dead `IntermediateResult`, `SolveResult`, `SolveRequest` types and WASM type exports
- Remove dead `onSelectionChange` prop from CellSelector
- Fix variable shadowing in `loadDemoData`, redundant wrapper in DimensionConfirmation
- Add `onCleanup` in CardGrid `<For>`, explicit `on()` deps in TraceOverview, merge duplicate 30 Hz presets, remove worker-pool no-op

## Test plan

- [x] `npm run build` — all 3 apps build successfully
- [x] `npm run format` — no formatting violations
- [ ] Manually test CaRank: load a Fortran-ordered `.npy` file and verify traces
- [x] Manually test CaTune: open auth menu, press Escape, verify no listener leak
- [x] Manually test CaTune: sign in → sign out → reopen auth menu — verify fresh email form
- [ ] Manually test admin: change date range and verify submissions metric updates
- [ ] Run `node scripts/combine-dist.mjs` and inspect output HTML for proper escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)