### PR TITLE
feat(compute): dynamic worker pool scaling with URL override

### DIFF
--- a/apps/catune/src/components/layout/CompactHeader.tsx
+++ b/apps/catune/src/components/layout/CompactHeader.tsx
@@ -1,5 +1,6 @@
 import { Show, type Accessor } from 'solid-js';
-import { CompactHeader } from '@calab/ui';
+import { CompactHeader, WorkerIndicator } from '@calab/ui';
+import { resolveWorkerCount } from '@calab/compute';
 import {
   rawFile,
   effectiveShape,
@@ -27,6 +28,8 @@ export function CaTuneHeader(props: CaTuneHeaderProps) {
     clearMultiCellState();
     resetImport();
   };
+
+  const workerCount = resolveWorkerCount();
 
   const durationDisplay = () => formatDuration(durationSeconds());
 
@@ -60,6 +63,8 @@ export function CaTuneHeader(props: CaTuneHeaderProps) {
             <span class="compact-header__sep">&middot;</span>
             <span>{durationDisplay()}</span>
           </Show>
+          <span class="compact-header__sep">&middot;</span>
+          <WorkerIndicator count={workerCount} />
         </>
       }
       actions={

--- a/packages/compute/src/__tests__/worker-sizing.test.ts
+++ b/packages/compute/src/__tests__/worker-sizing.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDefaultWorkerCount, getWorkersOverride, resolveWorkerCount } from '@calab/compute';
+
+describe('getDefaultWorkerCount', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns cores-1 for typical hardware', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: 8 });
+    expect(getDefaultWorkerCount()).toBe(7);
+  });
+
+  it('floors at 2 for low-core machines', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: 2 });
+    expect(getDefaultWorkerCount()).toBe(2);
+  });
+
+  it('caps at 8 for high-core machines', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: 20 });
+    expect(getDefaultWorkerCount()).toBe(8);
+  });
+
+  it('returns 3 when hardwareConcurrency is undefined', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: undefined });
+    expect(getDefaultWorkerCount()).toBe(3);
+  });
+});
+
+describe('getWorkersOverride', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when no workers param', () => {
+    vi.stubGlobal('window', { location: { search: '' } });
+    expect(getWorkersOverride()).toBe(null);
+  });
+
+  it('parses a valid integer', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=6' } });
+    expect(getWorkersOverride()).toBe(6);
+  });
+
+  it('returns null for zero', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=0' } });
+    expect(getWorkersOverride()).toBe(null);
+  });
+
+  it('clamps to 16 for large values', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=20' } });
+    expect(getWorkersOverride()).toBe(16);
+  });
+
+  it('returns null for non-numeric values', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=abc' } });
+    expect(getWorkersOverride()).toBe(null);
+  });
+
+  it('returns null for negative values', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=-2' } });
+    expect(getWorkersOverride()).toBe(null);
+  });
+
+  it('returns null for floating-point values', () => {
+    vi.stubGlobal('window', { location: { search: '?workers=3.5' } });
+    expect(getWorkersOverride()).toBe(null);
+  });
+});
+
+describe('resolveWorkerCount', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses URL override when present', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: 8 });
+    vi.stubGlobal('window', { location: { search: '?workers=3' } });
+    expect(resolveWorkerCount()).toBe(3);
+  });
+
+  it('falls back to hardware default when no override', () => {
+    vi.stubGlobal('navigator', { hardwareConcurrency: 8 });
+    vi.stubGlobal('window', { location: { search: '' } });
+    expect(resolveWorkerCount()).toBe(7);
+  });
+});

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -1,5 +1,6 @@
 export { createWorkerPool } from './worker-pool.ts';
 export type { WorkerPool } from './worker-pool.ts';
+export { resolveWorkerCount, getWorkersOverride, getDefaultWorkerCount } from './worker-sizing.ts';
 export {
   computePaddedWindow,
   computeSafeMargin,

--- a/packages/compute/src/worker-pool.ts
+++ b/packages/compute/src/worker-pool.ts
@@ -3,6 +3,7 @@
 // supports per-job cancellation and bulk cancelAll.
 
 import type { SolverParams, WarmStartStrategy, PoolWorkerOutbound } from '@calab/core';
+import { resolveWorkerCount } from './worker-sizing.ts';
 
 export interface PoolJob {
   jobId: number;
@@ -35,6 +36,7 @@ interface PoolEntry {
 }
 
 export interface WorkerPool {
+  readonly size: number;
   dispatch(job: PoolJob): void;
   cancel(jobId: number): void;
   cancelAll(): void;
@@ -42,7 +44,7 @@ export interface WorkerPool {
 }
 
 export function createWorkerPool(createWorker: () => Worker, poolSize?: number): WorkerPool {
-  const size = poolSize ?? Math.min(navigator.hardwareConcurrency ?? 4, 4);
+  const size = poolSize ?? resolveWorkerCount();
   const entries: PoolEntry[] = [];
   const queue: PoolJob[] = [];
   // Map jobId → PoolJob for in-flight jobs (needed for routing messages)
@@ -211,5 +213,5 @@ export function createWorkerPool(createWorker: () => Worker, poolSize?: number):
     inFlightJobs.clear();
   }
 
-  return { dispatch, cancel, cancelAll, dispose };
+  return { size, dispatch, cancel, cancelAll, dispose };
 }

--- a/packages/compute/src/worker-sizing.ts
+++ b/packages/compute/src/worker-sizing.ts
@@ -1,0 +1,23 @@
+/** Worker pool sizing logic.
+ *  Determines how many Web Workers to spawn for parallel solving. */
+
+/** Default worker count based on hardware concurrency.
+ *  Reserves 1 core for the main thread, floor 2, cap 8. */
+export function getDefaultWorkerCount(): number {
+  const cores = navigator.hardwareConcurrency ?? 4;
+  return Math.max(2, Math.min(cores - 1, 8));
+}
+
+/** Read `?workers=N` from the URL. Returns the clamped value or null. */
+export function getWorkersOverride(): number | null {
+  const raw = new URLSearchParams(window.location.search).get('workers');
+  if (raw == null) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return null;
+  return Math.min(n, 16);
+}
+
+/** Resolve the effective worker count: URL override > hardware default. */
+export function resolveWorkerCount(): number {
+  return getWorkersOverride() ?? getDefaultWorkerCount();
+}

--- a/packages/ui/src/WorkerIndicator.tsx
+++ b/packages/ui/src/WorkerIndicator.tsx
@@ -1,0 +1,14 @@
+export interface WorkerIndicatorProps {
+  count: number;
+}
+
+export function WorkerIndicator(props: WorkerIndicatorProps) {
+  return (
+    <span class="worker-indicator" title={`${props.count} solver workers allocated`}>
+      <span class="worker-indicator__icon" aria-hidden="true">
+        &#x2699;
+      </span>
+      <span class="worker-indicator__count">{props.count}w</span>
+    </span>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,3 +18,5 @@ export type { AuthCallbackProps } from './AuthCallback.tsx';
 export { AuthMenuWrapper } from './AuthMenuWrapper.tsx';
 export type { AuthMenuWrapperProps } from './AuthMenuWrapper.tsx';
 export { isAuthCallback } from './auth-utils.ts';
+export { WorkerIndicator } from './WorkerIndicator.tsx';
+export type { WorkerIndicatorProps } from './WorkerIndicator.tsx';

--- a/packages/ui/src/styles/compact-header.css
+++ b/packages/ui/src/styles/compact-header.css
@@ -68,3 +68,24 @@
   margin-left: auto;
   flex-shrink: 0;
 }
+
+/* Worker indicator — inline metadata badge */
+.worker-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
+}
+
+.worker-indicator__icon {
+  font-size: 0.9em;
+  line-height: 1;
+}
+
+.worker-indicator__count {
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- Scale worker pool with hardware concurrency (`cores - 1`, floor 2, cap 8) instead of hard-capping at 4 workers
- Add `?workers=N` URL parameter for power users to override pool size (clamped 1–16)
- Add shared `WorkerIndicator` component (`⚙ Nw`) in the CaTune header, always visible
- Expose `readonly size` on `WorkerPool` interface

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run test` — 13 new worker-sizing tests pass (168 total)
- [x] `npm run dev` in `apps/catune/` — header shows worker indicator (e.g., "⚙ 7w") before and after data import
- [x] Append `?workers=3` to URL — indicator shows "⚙ 3w"
- [x] Verify invalid overrides (`?workers=abc`, `?workers=0`, `?workers=-1`) fall back to hardware default

🤖 Generated with [Claude Code](https://claude.com/claude-code)