### PR TITLE
Add visual indicator for convolution transient zone

### DIFF
--- a/apps/catune/src/components/cards/ZoomWindow.tsx
+++ b/apps/catune/src/components/cards/ZoomWindow.tsx
@@ -27,6 +27,7 @@ import {
   showGTSpikes,
   tauDecay,
 } from '../../lib/viz-store.ts';
+import { transientZonePlugin } from '../../lib/chart/transient-zone-plugin.ts';
 
 export interface ZoomWindowProps {
   rawTrace: Float64Array;
@@ -581,6 +582,7 @@ export function ZoomWindow(props: ZoomWindowProps) {
         yRange={globalYRange()}
         hideYValues
         xLabel="Time (s)"
+        plugins={[transientZonePlugin(() => TRANSIENT_TAU_MULTIPLIER * tauDecay())]}
       />
       <Show when={showHint()}>
         <div class="zoom-hint">Hold Ctrl to zoom</div>

--- a/apps/catune/src/lib/chart/transient-zone-plugin.ts
+++ b/apps/catune/src/lib/chart/transient-zone-plugin.ts
@@ -1,0 +1,84 @@
+/**
+ * uPlot plugin that draws a shaded overlay over the convolution transient zone
+ * at the start of the trace, so users understand the fit is intentionally masked.
+ */
+
+import type uPlot from 'uplot';
+
+const FILL_COLOR = 'rgba(0, 0, 0, 0.06)';
+const STRIPE_COLOR = 'rgba(0, 0, 0, 0.04)';
+const LABEL_COLOR = '#444444';
+const STRIPE_SPACING = 8; // px between diagonal stripes
+
+/**
+ * Create a uPlot plugin that shades the convolution transient region.
+ *
+ * @param getTransientEnd - Accessor returning the transient cutoff time in seconds
+ */
+export function transientZonePlugin(getTransientEnd: () => number): uPlot.Plugin {
+  return {
+    hooks: {
+      draw(u: uPlot) {
+        const transientEnd = getTransientEnd();
+        if (transientEnd <= 0) return;
+
+        const xMin = u.scales.x.min!;
+        const xMax = u.scales.x.max!;
+
+        // Skip if the transient zone is entirely off-screen
+        if (transientEnd <= xMin) return;
+
+        const ctx = u.ctx;
+        const dpr = devicePixelRatio;
+        const { left, top, width, height } = u.bbox;
+
+        // Convert transient boundary to canvas pixel position
+        const rightPx = u.valToPos(Math.min(transientEnd, xMax), 'x', true);
+        const leftPx = left;
+        const zoneWidth = rightPx - leftPx;
+
+        if (zoneWidth <= 0) return;
+
+        ctx.save();
+
+        // Solid tinted background
+        ctx.fillStyle = FILL_COLOR;
+        ctx.fillRect(leftPx, top, zoneWidth, height);
+
+        // Diagonal stripe pattern for visual distinction
+        ctx.beginPath();
+        ctx.rect(leftPx, top, zoneWidth, height);
+        ctx.clip();
+
+        ctx.strokeStyle = STRIPE_COLOR;
+        ctx.lineWidth = 1 * dpr;
+        const spacing = STRIPE_SPACING * dpr;
+        const diag = width + height;
+        for (let d = -diag; d < diag; d += spacing) {
+          ctx.beginPath();
+          ctx.moveTo(leftPx + d, top);
+          ctx.lineTo(leftPx + d + height, top + height);
+          ctx.stroke();
+        }
+
+        // Label (only if the zone is wide enough to fit text)
+        const labelFontSize = 9 * dpr;
+        ctx.font = `${labelFontSize}px sans-serif`;
+        const label = 'No fit near t = 0';
+        const textWidth = ctx.measureText(label).width;
+        const minWidth = textWidth + 12 * dpr;
+
+        if (zoneWidth >= minWidth) {
+          const cx = leftPx + zoneWidth / 2;
+          const cy = top + labelFontSize + 6 * dpr;
+          ctx.fillStyle = LABEL_COLOR;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(label, cx, cy);
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a subtle hatched overlay with a "No fit near t = 0" label over the masked region at the start of the trace where the causal kernel has no history
- Implemented as a uPlot draw-hook plugin (`transient-zone-plugin.ts`) wired into ZoomWindow
- The zone width tracks `2 × tauDecay` (same as the existing null-masking logic)

Closes #71

## Test plan
- [x] Load a trace and scroll/zoom back to t = 0 — verify the shaded zone with label appears
- [x] Adjust tauDecay slider — verify the zone width updates reactively
- [x] Zoom far enough right that t = 0 is off-screen — verify no overlay is drawn
- [x] Check the zone looks reasonable on both small and wide chart widths (label hides when too narrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)