### PR TITLE
fix(catune): prevent minimap from pushing zoom window off-screen

### DIFF
--- a/apps/catune/src/components/cards/CellCard.tsx
+++ b/apps/catune/src/components/cards/CellCard.tsx
@@ -40,12 +40,9 @@ const ZOOM_SYNC_KEY = 'catune-card-zoom';
 export function CellCard(props: CellCardProps) {
   const totalDuration = createMemo(() => props.rawTrace.length / props.samplingRate);
 
-  // Auto-adjust card height so multi-row minimaps don't push the zoom window off-screen
+  // Grow the card to accommodate extra minimap rows beyond the first
   const numRows = createMemo(() => Math.max(1, Math.ceil(totalDuration() / ROW_DURATION_S)));
-  const effectiveHeight = createMemo(() => {
-    const minHeight = cardHeight() + (numRows() - 1) * ROW_HEIGHT;
-    return Math.max(cardHeight(), minHeight);
-  });
+  const effectiveHeight = createMemo(() => cardHeight() + (numRows() - 1) * ROW_HEIGHT);
 
   // Quality badge
   const snr = createMemo(() => computePeakSNR(props.rawTrace));

--- a/apps/catune/src/components/cards/TraceOverview.tsx
+++ b/apps/catune/src/components/cards/TraceOverview.tsx
@@ -92,12 +92,13 @@ export function TraceOverview(props: TraceOverviewProps) {
     }
     const yRange = globalMax - globalMin || 1;
 
+    // Single-row traces use the actual duration so the trace fills the width;
+    // multi-row traces use a fixed row duration for uniform x-axis scaling.
+    const rowDuration = rows.length === 1 ? duration : ROW_DURATION_S;
+
     for (let r = 0; r < rows.length; r++) {
       const row = rows[r];
       const rowY = r * ROW_HEIGHT;
-      const actualRowDuration =
-        r < rows.length - 1 ? ROW_DURATION_S : duration - r * ROW_DURATION_S;
-      const rowDuration = rows.length === 1 ? actualRowDuration : ROW_DURATION_S;
 
       // Draw zoom window highlight for this row
       const zoomStart = props.zoomStart;
@@ -168,9 +169,7 @@ export function TraceOverview(props: TraceOverviewProps) {
 
     const row = rows[rowIndex];
     const duration = totalDuration();
-    const actualRowDuration =
-      rowIndex < rows.length - 1 ? ROW_DURATION_S : duration - rowIndex * ROW_DURATION_S;
-    const rowDuration = rows.length === 1 ? actualRowDuration : ROW_DURATION_S;
+    const rowDuration = rows.length === 1 ? duration : ROW_DURATION_S;
 
     const tFraction = Math.max(0, Math.min(1, x / width));
     return row.timeOffset + tFraction * rowDuration;


### PR DESCRIPTION
## Summary
- Auto-adjust card height based on minimap row count so multi-row minimaps don't squeeze the zoom window off-screen
- Fix last-row stretching on multi-row minimaps — all rows now share a consistent timescale (`ROW_DURATION_S`), with the last row only filling a proportional portion of the canvas width
- Export `ROW_HEIGHT` and `ROW_DURATION_S` constants from `TraceOverview` so `CellCard` can compute row count without duplicating values

Closes #70

## Test plan
- [x] Load a long trace (>40 min) — multi-row minimap should not push zoom window off-screen
- [x] Card should be taller than default 280px when minimap has multiple rows
- [x] On multi-row minimap, last row should only fill a portion of the width (matching its actual duration)
- [x] On single-row traces, behavior should be unchanged (trace fills full width)
- [x] Click/drag on the last row of a multi-row minimap should navigate correctly
- [x] Card resize handle should still work; manually resizing should still be respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)