### PR TITLE
fix(catune): clamp rise/decay sliders to prevent negative kernel

### DIFF
--- a/apps/catune/src/components/controls/ParameterPanel.tsx
+++ b/apps/catune/src/components/controls/ParameterPanel.tsx
@@ -19,6 +19,17 @@ import { ParameterSlider } from './ParameterSlider.tsx';
 import '../../styles/controls.css';
 
 export function ParameterPanel() {
+  // Enforce tau_decay > tau_rise so the kernel never goes negative or zero.
+  const minGap = PARAM_RANGES.tauDecay.step;
+  const clampedSetTauRise = (v: number) => {
+    setTauRise(v);
+    if (tauDecay() < v + minGap) setTauDecay(v + minGap);
+  };
+  const clampedSetTauDecay = (v: number) => {
+    setTauDecay(v);
+    if (tauRise() > v - minGap) setTauRise(v - minGap);
+  };
+
   const trueRise = () => {
     if (!groundTruthVisible() || !isDemo() || !demoPreset()) return undefined;
     return demoPreset()!.params.tauRise;
@@ -35,7 +46,7 @@ export function ParameterPanel() {
         <ParameterSlider
           label="Rise Time"
           value={tauRise}
-          setValue={setTauRise}
+          setValue={clampedSetTauRise}
           min={PARAM_RANGES.tauRise.min}
           max={PARAM_RANGES.tauRise.max}
           step={PARAM_RANGES.tauRise.step}
@@ -47,7 +58,7 @@ export function ParameterPanel() {
         <ParameterSlider
           label="Decay Time"
           value={tauDecay}
-          setValue={setTauDecay}
+          setValue={clampedSetTauDecay}
           min={PARAM_RANGES.tauDecay.min}
           max={PARAM_RANGES.tauDecay.max}
           step={PARAM_RANGES.tauDecay.step}

--- a/apps/catune/src/components/controls/ParameterSlider.tsx
+++ b/apps/catune/src/components/controls/ParameterSlider.tsx
@@ -3,13 +3,13 @@
 // via optional fromSlider/toSlider transform functions.
 
 import { Show } from 'solid-js';
-import type { Accessor, Setter } from 'solid-js';
+import type { Accessor } from 'solid-js';
 import { notifyTutorialAction, isTutorialActive } from '@calab/tutorials';
 
 export interface ParameterSliderProps {
   label: string;
   value: Accessor<number>;
-  setValue: Setter<number>;
+  setValue: (value: number) => void;
   min: number;
   max: number;
   step: number;


### PR DESCRIPTION
## Summary
- Wraps the rise/decay time setters so that **decay always stays >= rise**, preventing the double-exponential kernel from going negative
- When rise is dragged above decay, decay snaps up to match (and vice versa)
- Fixes the infinite solver iteration that resulted from an ill-formed kernel

Closes #80

## Test plan
- [x] Load demo data, drag rise time above decay time — decay should snap up
- [x] Drag decay time below rise time — rise should snap down
- [x] Kernel display should never show negative values
- [x] Solver should always converge (no infinite spinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)