### PR TITLE
feat(admin): add CaDecon tracking and submissions

### DIFF
--- a/apps/admin/src/components/ExportPanel.tsx
+++ b/apps/admin/src/components/ExportPanel.tsx
@@ -4,6 +4,7 @@ import {
   fetchSessions,
   fetchEvents,
   fetchSubmissions,
+  fetchCadeconSubmissions,
   computeGeoBreakdown,
   computeEventBreakdown,
   computeWeeklySessions,
@@ -14,6 +15,7 @@ export function ExportPanel(): JSX.Element {
   const [sessions] = createResource(dateRange, fetchSessions);
   const [events] = createResource(dateRange, fetchEvents);
   const [submissions] = createResource(dateRange, fetchSubmissions);
+  const [cadeconSubmissions] = createResource(dateRange, fetchCadeconSubmissions);
 
   const filenameSuffix = () => `${dateRange().start}_to_${dateRange().end}`;
 
@@ -44,20 +46,74 @@ export function ExportPanel(): JSX.Element {
     downloadCSV(csv, `calab-geography-${filenameSuffix()}.csv`);
   };
 
-  const exportSubmissions = () => {
+  const exportCatuneSubmissions = () => {
     const subs = submissions() ?? [];
     const csv = toCSV(
-      ['Date', 'Indicator', 'Species', 'Brain Region', 'Source', 'Version'],
+      [
+        'Date',
+        'Indicator',
+        'Species',
+        'Brain Region',
+        'Source',
+        'Tau Rise',
+        'Tau Decay',
+        'Lambda',
+        'Samp. Rate',
+        'Version',
+      ],
       subs.map((s) => [
         s.created_at,
         s.indicator,
         s.species,
         s.brain_region,
         s.data_source,
+        s.tau_rise,
+        s.tau_decay,
+        s.lambda,
+        s.sampling_rate,
         s.app_version ?? '',
       ]),
     );
-    downloadCSV(csv, `calab-submissions-${filenameSuffix()}.csv`);
+    downloadCSV(csv, `calab-catune-submissions-${filenameSuffix()}.csv`);
+  };
+
+  const exportCadeconSubmissions = () => {
+    const subs = cadeconSubmissions() ?? [];
+    const csv = toCSV(
+      [
+        'Date',
+        'Indicator',
+        'Species',
+        'Brain Region',
+        'Source',
+        'Tau Rise',
+        'Tau Decay',
+        'Samp. Rate',
+        'Med. Alpha',
+        'Med. PVE',
+        'Event Rate',
+        'Iterations',
+        'Converged',
+        'Version',
+      ],
+      subs.map((s) => [
+        s.created_at,
+        s.indicator,
+        s.species,
+        s.brain_region,
+        s.data_source,
+        s.tau_rise,
+        s.tau_decay,
+        s.sampling_rate,
+        s.median_alpha ?? '',
+        s.median_pve ?? '',
+        s.mean_event_rate ?? '',
+        s.num_iterations,
+        s.converged,
+        s.app_version ?? '',
+      ]),
+    );
+    downloadCSV(csv, `calab-cadecon-submissions-${filenameSuffix()}.csv`);
   };
 
   return (
@@ -77,8 +133,11 @@ export function ExportPanel(): JSX.Element {
         <button class="btn-secondary" onClick={exportGeography}>
           Geographic Breakdown
         </button>
-        <button class="btn-secondary" onClick={exportSubmissions}>
-          Submissions List
+        <button class="btn-secondary" onClick={exportCatuneSubmissions}>
+          CaTune Submissions
+        </button>
+        <button class="btn-secondary" onClick={exportCadeconSubmissions}>
+          CaDecon Submissions
         </button>
       </div>
     </div>

--- a/apps/admin/src/components/OverviewView.tsx
+++ b/apps/admin/src/components/OverviewView.tsx
@@ -4,6 +4,7 @@ import { DataTable } from './DataTable.tsx';
 import {
   fetchSessions,
   fetchSubmissions,
+  fetchCadeconSubmissions,
   computeMetrics,
   computeSourceBreakdown,
 } from '../lib/analytics-queries.ts';
@@ -11,10 +12,16 @@ import { dateRange } from '../lib/admin-store.ts';
 
 export function OverviewView(): JSX.Element {
   const [sessions] = createResource(dateRange, fetchSessions);
-  const [submissions] = createResource(dateRange, fetchSubmissions);
+  const [catuneSubmissions] = createResource(dateRange, fetchSubmissions);
+  const [cadeconSubmissions] = createResource(dateRange, fetchCadeconSubmissions);
 
-  const metrics = createMemo(() => computeMetrics(sessions() ?? [], submissions() ?? []));
-  const sourceBreakdown = createMemo(() => computeSourceBreakdown(submissions() ?? []));
+  const allSubmissions = createMemo(() => [
+    ...(catuneSubmissions() ?? []),
+    ...(cadeconSubmissions() ?? []),
+  ]);
+
+  const metrics = createMemo(() => computeMetrics(sessions() ?? [], allSubmissions()));
+  const sourceBreakdown = createMemo(() => computeSourceBreakdown(allSubmissions()));
 
   return (
     <div class="view">
@@ -24,6 +31,8 @@ export function OverviewView(): JSX.Element {
         <MetricCard label="Unique Users" value={metrics().uniqueUsers} />
         <MetricCard label="Anonymous Sessions" value={metrics().anonymousSessions} />
         <MetricCard label="Community Submissions" value={metrics().totalSubmissions} />
+        <MetricCard label="CaTune Submissions" value={(catuneSubmissions() ?? []).length} />
+        <MetricCard label="CaDecon Submissions" value={(cadeconSubmissions() ?? []).length} />
         <MetricCard label="Avg Session Duration" value={metrics().avgDurationMinutes} />
         <MetricCard label="Top Referrer" value={metrics().topReferrer} />
       </div>

--- a/apps/admin/src/components/SubmissionsView.tsx
+++ b/apps/admin/src/components/SubmissionsView.tsx
@@ -1,10 +1,32 @@
-import { type JSX, createResource, createSignal, createMemo, Show } from 'solid-js';
+import { type JSX, createResource, createSignal, createMemo, Show, Switch, Match } from 'solid-js';
 import { DataTable } from './DataTable.tsx';
-import { fetchSubmissions, deleteSubmission, computeOutliers } from '../lib/analytics-queries.ts';
+import {
+  fetchSubmissions,
+  deleteSubmission,
+  computeOutliers,
+  fetchCadeconSubmissions,
+  deleteCadeconSubmission,
+  computeCadeconOutliers,
+} from '../lib/analytics-queries.ts';
 import { dateRange } from '../lib/admin-store.ts';
 
+type SubmissionApp = 'catune' | 'cadecon';
+
 export function SubmissionsView(): JSX.Element {
-  const [submissions, { refetch }] = createResource(dateRange, fetchSubmissions);
+  const [activeApp, setActiveApp] = createSignal<SubmissionApp>('catune');
+
+  // CaTune resources
+  const [catuneSubmissions, { refetch: refetchCatune }] = createResource(
+    dateRange,
+    fetchSubmissions,
+  );
+  // CaDecon resources
+  const [cadeconSubmissions, { refetch: refetchCadecon }] = createResource(
+    dateRange,
+    fetchCadeconSubmissions,
+  );
+
+  // Shared filter state
   const [filterIndicator, setFilterIndicator] = createSignal('');
   const [filterSpecies, setFilterSpecies] = createSignal('');
   const [filterRegion, setFilterRegion] = createSignal('');
@@ -12,10 +34,16 @@ export function SubmissionsView(): JSX.Element {
   const [showOutliersOnly, setShowOutliersOnly] = createSignal(false);
   const [selectedIds, setSelectedIds] = createSignal<Set<string>>(new Set());
 
-  const outlierIds = createMemo(() => computeOutliers(submissions() ?? []));
+  // Reset selection when switching apps
+  const switchApp = (app: SubmissionApp) => {
+    setSelectedIds(new Set<string>());
+    setActiveApp(app);
+  };
 
-  const filtered = createMemo(() => {
-    let rows = submissions() ?? [];
+  // CaTune filtering
+  const catuneOutlierIds = createMemo(() => computeOutliers(catuneSubmissions() ?? []));
+  const filteredCatune = createMemo(() => {
+    let rows = catuneSubmissions() ?? [];
     const ind = filterIndicator().toLowerCase();
     const sp = filterSpecies().toLowerCase();
     const reg = filterRegion().toLowerCase();
@@ -24,35 +52,74 @@ export function SubmissionsView(): JSX.Element {
     if (sp) rows = rows.filter((r) => r.species.toLowerCase().includes(sp));
     if (reg) rows = rows.filter((r) => r.brain_region.toLowerCase().includes(reg));
     if (src) rows = rows.filter((r) => r.data_source === src);
-    if (showOutliersOnly()) rows = rows.filter((r) => outlierIds().has(r.id));
+    if (showOutliersOnly()) rows = rows.filter((r) => catuneOutlierIds().has(r.id));
+    return rows;
+  });
+
+  // CaDecon filtering
+  const cadeconOutlierIds = createMemo(() => computeCadeconOutliers(cadeconSubmissions() ?? []));
+  const filteredCadecon = createMemo(() => {
+    let rows = cadeconSubmissions() ?? [];
+    const ind = filterIndicator().toLowerCase();
+    const sp = filterSpecies().toLowerCase();
+    const reg = filterRegion().toLowerCase();
+    const src = filterSource();
+    if (ind) rows = rows.filter((r) => r.indicator.toLowerCase().includes(ind));
+    if (sp) rows = rows.filter((r) => r.species.toLowerCase().includes(sp));
+    if (reg) rows = rows.filter((r) => r.brain_region.toLowerCase().includes(reg));
+    if (src) rows = rows.filter((r) => r.data_source === src);
+    if (showOutliersOnly()) rows = rows.filter((r) => cadeconOutlierIds().has(r.id));
     return rows;
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleDelete = async (row: Record<string, any>) => {
     if (!confirm(`Delete submission ${String(row.id).slice(0, 8)}...?`)) return;
-    await deleteSubmission(row.id as string);
-    refetch();
+    if (activeApp() === 'catune') {
+      await deleteSubmission(row.id as string);
+      refetchCatune();
+    } else {
+      await deleteCadeconSubmission(row.id as string);
+      refetchCadecon();
+    }
   };
 
   const handleBulkDelete = async () => {
     const ids = Array.from(selectedIds());
     if (ids.length === 0) return;
     if (!confirm(`Delete ${ids.length} selected submission(s)?`)) return;
+    const deleteFn = activeApp() === 'catune' ? deleteSubmission : deleteCadeconSubmission;
     for (const id of ids) {
-      await deleteSubmission(id);
+      await deleteFn(id);
     }
     setSelectedIds(new Set<string>());
-    refetch();
+    if (activeApp() === 'catune') refetchCatune();
+    else refetchCadecon();
   };
 
   const rowClass = (row: Record<string, unknown>) => {
-    return outlierIds().has(row.id as string) ? 'outlier-row' : undefined;
+    const ids = activeApp() === 'catune' ? catuneOutlierIds() : cadeconOutlierIds();
+    return ids.has(row.id as string) ? 'outlier-row' : undefined;
   };
 
   return (
     <div class="view">
       <h2 class="view__title">Community Submissions</h2>
+
+      <div class="app-toggle">
+        <button
+          class={`app-toggle__btn${activeApp() === 'catune' ? ' app-toggle__btn--active' : ''}`}
+          onClick={() => switchApp('catune')}
+        >
+          CaTune ({(catuneSubmissions() ?? []).length})
+        </button>
+        <button
+          class={`app-toggle__btn${activeApp() === 'cadecon' ? ' app-toggle__btn--active' : ''}`}
+          onClick={() => switchApp('cadecon')}
+        >
+          CaDecon ({(cadeconSubmissions() ?? []).length})
+        </button>
+      </div>
 
       <div class="filter-bar">
         <input
@@ -103,26 +170,54 @@ export function SubmissionsView(): JSX.Element {
         </div>
       </Show>
 
-      <DataTable
-        columns={[
-          { key: 'created_at', label: 'Date' },
-          { key: 'indicator', label: 'Indicator' },
-          { key: 'species', label: 'Species' },
-          { key: 'brain_region', label: 'Brain Region' },
-          { key: 'data_source', label: 'Source' },
-          { key: 'tau_rise', label: 'Tau Rise' },
-          { key: 'tau_decay', label: 'Tau Decay' },
-          { key: 'lambda', label: 'Lambda' },
-          { key: 'sampling_rate', label: 'Samp. Rate' },
-          { key: 'app_version', label: 'Version' },
-        ]}
-        rows={filtered()}
-        onDeleteRow={handleDelete}
-        selectable
-        selectedIds={selectedIds}
-        onSelectionChange={setSelectedIds}
-        rowClass={rowClass}
-      />
+      <Switch>
+        <Match when={activeApp() === 'catune'}>
+          <DataTable
+            columns={[
+              { key: 'created_at', label: 'Date' },
+              { key: 'indicator', label: 'Indicator' },
+              { key: 'species', label: 'Species' },
+              { key: 'brain_region', label: 'Brain Region' },
+              { key: 'data_source', label: 'Source' },
+              { key: 'tau_rise', label: 'Tau Rise' },
+              { key: 'tau_decay', label: 'Tau Decay' },
+              { key: 'lambda', label: 'Lambda' },
+              { key: 'sampling_rate', label: 'Samp. Rate' },
+              { key: 'app_version', label: 'Version' },
+            ]}
+            rows={filteredCatune()}
+            onDeleteRow={handleDelete}
+            selectable
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
+            rowClass={rowClass}
+          />
+        </Match>
+        <Match when={activeApp() === 'cadecon'}>
+          <DataTable
+            columns={[
+              { key: 'created_at', label: 'Date' },
+              { key: 'indicator', label: 'Indicator' },
+              { key: 'species', label: 'Species' },
+              { key: 'brain_region', label: 'Brain Region' },
+              { key: 'data_source', label: 'Source' },
+              { key: 'tau_rise', label: 'Tau Rise' },
+              { key: 'tau_decay', label: 'Tau Decay' },
+              { key: 'sampling_rate', label: 'Samp. Rate' },
+              { key: 'median_alpha', label: 'Med. Alpha' },
+              { key: 'median_pve', label: 'Med. PVE' },
+              { key: 'converged', label: 'Converged' },
+              { key: 'app_version', label: 'Version' },
+            ]}
+            rows={filteredCadecon()}
+            onDeleteRow={handleDelete}
+            selectable
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
+            rowClass={rowClass}
+          />
+        </Match>
+      </Switch>
     </div>
   );
 }

--- a/apps/admin/src/lib/types.ts
+++ b/apps/admin/src/lib/types.ts
@@ -37,6 +37,25 @@ export interface SubmissionRow {
   sampling_rate: number;
 }
 
+export interface CadeconSubmissionRow {
+  id: string;
+  created_at: string;
+  user_id: string;
+  indicator: string;
+  species: string;
+  brain_region: string;
+  data_source: string;
+  app_version: string;
+  tau_rise: number;
+  tau_decay: number;
+  sampling_rate: number;
+  median_alpha: number | null;
+  median_pve: number | null;
+  mean_event_rate: number | null;
+  num_iterations: number;
+  converged: boolean;
+}
+
 export interface AdminMetrics {
   totalSessions: number;
   uniqueUsers: number;

--- a/apps/admin/src/styles/global.css
+++ b/apps/admin/src/styles/global.css
@@ -213,6 +213,42 @@ body {
   color: var(--text-secondary);
 }
 
+/* App toggle (CaTune / CaDecon switcher) */
+.app-toggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  width: fit-content;
+}
+
+.app-toggle__btn {
+  padding: 6px 16px;
+  border: none;
+  background: var(--bg-primary);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.app-toggle__btn:not(:last-child) {
+  border-right: 1px solid var(--border-subtle);
+}
+
+.app-toggle__btn:hover {
+  color: var(--text-primary);
+}
+
+.app-toggle__btn--active {
+  background: var(--accent);
+  color: #fff;
+  font-weight: var(--font-weight-medium);
+}
+
 /* Filter bar */
 .filter-bar {
   display: flex;

--- a/supabase/functions/geo-session/index.ts
+++ b/supabase/functions/geo-session/index.ts
@@ -13,7 +13,7 @@ const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' };
 
 interface SessionPayload {
   anonymous_id: string;
-  app_name: 'catune' | 'carank';
+  app_name: 'catune' | 'carank' | 'cadecon';
   app_version?: string;
   screen_width?: number;
   screen_height?: number;

--- a/supabase/migrations/007_analytics_add_cadecon.sql
+++ b/supabase/migrations/007_analytics_add_cadecon.sql
@@ -1,0 +1,8 @@
+-- Add 'cadecon' to the analytics_sessions app_name CHECK constraint
+
+ALTER TABLE analytics_sessions
+  DROP CONSTRAINT analytics_sessions_app_name_check;
+
+ALTER TABLE analytics_sessions
+  ADD CONSTRAINT analytics_sessions_app_name_check
+  CHECK (app_name IN ('catune', 'carank', 'cadecon'));


### PR DESCRIPTION
## Summary
- Fix silent CaDecon session tracking failure by adding `'cadecon'` to the `analytics_sessions` CHECK constraint (new migration 007) and the geo-session Edge Function type
- Add CaDecon submissions support to Admin dashboard — queries, types, outlier detection, CaTune/CaDecon toggle in SubmissionsView, per-app metric cards in Overview, and separate CSV exports

## Test plan
- [x] Apply migration 007 to Supabase instance
- [x] Deploy updated geo-session Edge Function
- [x] Open CaDecon app and verify session appears in `analytics_sessions` with `app_name = 'cadecon'`
- [x] Open Admin dashboard → Overview and confirm CaDecon Submissions metric card shows
- [x] Admin → Submissions → toggle to CaDecon tab and verify columns (Med. Alpha, Med. PVE, Converged)
- [x] Admin → Export → verify separate CaTune/CaDecon CSV download buttons work
- [x] Verify CaTune tracking still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)