### PR TITLE
docs: move CaDecon to stable, update root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,49 +6,93 @@ Calcium imaging analysis tools
 [![CI](https://github.com/miniscope/CaLab/actions/workflows/ci.yml/badge.svg)](https://github.com/miniscope/CaLab/actions/workflows/ci.yml)
 [![GitHub Pages](https://github.com/miniscope/CaLab/actions/workflows/deploy.yml/badge.svg)](https://miniscope.github.io/CaLab/)
 [![PyPI](https://img.shields.io/pypi/v/calab)](https://pypi.org/project/calab/)
-
-![CaTune screenshot](apps/catune/screenshot.png)
+[![Documentation](https://readthedocs.org/projects/calab/badge/?version=latest)](https://calab.readthedocs.io)
 
 ## What is CaLab?
 
-CaLab is a suite of browser-based tools for calcium imaging analysis. The tools run entirely in the browser — no installation, no server, no data upload. Load your fluorescence traces, tune deconvolution parameters with real-time visual feedback, and export the results.
+CaLab is a suite of tools for calcium imaging deconvolution — recovering neural spiking activity from fluorescence traces. The tools run entirely in the browser (no installation, no server, no data upload) and are backed by a fast FISTA solver written in Rust.
 
-The flagship app, **CaTune**, lets you interactively adjust deconvolution parameters (rise time, decay time, sparsity) while watching the solver update in real time. The deconvolution engine is a FISTA solver written in Rust and compiled to WebAssembly, running in Web Workers for parallel multi-cell processing.
+CaLab provides two deconvolution approaches:
 
-A companion **Python package** (`calab`) provides the same deconvolution algorithm in Python, with data exchange utilities for round-tripping parameters between the browser tools and analysis scripts. An optional **community sharing** feature (powered by Supabase) lets users share and browse deconvolution parameters across datasets and indicators.
+- **[CaTune](https://miniscope.github.io/CaLab/CaTune/)** — interactive parameter tuning. You choose the deconvolution parameters (rise time, decay time, sparsity) while watching the solver update in real time, then export them for batch processing.
+- **[CaDecon](https://miniscope.github.io/CaLab/CaDecon/)** — automated deconvolution. Estimates the calcium kernel and deconvolution parameters directly from your data using the InDeCa algorithm — no manual tuning needed.
 
-## Quick Start (Scientists)
+A companion **[Python package](https://calab.readthedocs.io)** (`calab`) provides the same solver as a native Python extension, plus utilities for loading data from CaImAn and Minian, synthetic trace simulation, and batch processing from scripts.
 
-1. Open **[CaTune](https://miniscope.github.io/CaLab/CaTune/)** in your browser
+An optional **community sharing** feature (powered by Supabase) lets users share and browse deconvolution parameters across datasets and indicators.
+
+|                                                  |                                                    |
+| ------------------------------------------------ | -------------------------------------------------- |
+| ![CaTune screenshot](apps/catune/screenshot.png) | ![CaDecon screenshot](apps/cadecon/screenshot.png) |
+| **CaTune** — interactive parameter tuning        | **CaDecon** — automated deconvolution              |
+
+## Quick Start
+
+### Browser (no install)
+
+1. Open **[CaTune](https://miniscope.github.io/CaLab/CaTune/)** or **[CaDecon](https://miniscope.github.io/CaLab/CaDecon/)** in your browser
 2. Try the built-in demo data to explore the interface
 3. Drag and drop your own `.npy` or `.npz` file containing calcium traces
-4. Adjust parameters with the sliders and observe real-time deconvolution
-5. Export your tuned parameters as JSON for use in analysis pipelines
+4. **CaTune:** adjust parameters with the sliders, then export as JSON
+5. **CaDecon:** configure and run — results are computed automatically
 
-## Python Package
+### Python
 
 ```bash
 pip install calab
 ```
 
-The `calab` Python package is the Python entrypoint to CaLab. It runs the same FISTA deconvolution algorithm in Python, and provides utilities for exchanging data with the web apps — load CaTune export JSON files, prepare traces for the browser tool, and run batch deconvolution with tuned parameters.
+```python
+import numpy as np
+import calab
 
-> **Note:** The Python package is under active development — major updates are planned.
+traces = np.load("my_traces.npy")
 
-See [`python/README.md`](python/README.md) for full API documentation.
+# CaTune: interactive tuning in the browser
+params = calab.tune(traces, fs=30.0)
+
+# CaDecon: automated deconvolution
+result = calab.decon(traces, fs=30.0, autorun=True)
+
+# Batch deconvolution with known parameters
+activity = calab.run_deconvolution(traces, fs=30.0, tau_r=0.02, tau_d=0.4, lam=0.5)
+```
+
+See the **[Python documentation](https://calab.readthedocs.io)** for the full API, guides, and CLI reference.
 
 ## Apps
 
-| App                    | Description                                        | Status |
-| ---------------------- | -------------------------------------------------- | ------ |
-| [CaTune](apps/catune/) | Interactive calcium deconvolution parameter tuning | Stable |
+| App                                                   | Description                                    | Status      |
+| ----------------------------------------------------- | ---------------------------------------------- | ----------- |
+| [CaTune](https://miniscope.github.io/CaLab/CaTune/)   | Interactive deconvolution parameter tuning     | Stable      |
+| [CaDecon](https://miniscope.github.io/CaLab/CaDecon/) | Automated deconvolution with kernel estimation | Stable      |
+| [CaRank](apps/carank/)                                | Trace quality ranking                          | Coming soon |
+
+## Python Package
+
+The `calab` Python package runs the same Rust FISTA solver (compiled to a native extension via PyO3) and provides:
+
+- **CaTune workflow** — `tune()` for interactive parameter selection, `run_deconvolution()` for batch processing
+- **CaDecon workflow** — `decon()` for automated deconvolution, with headless mode for scripting/CI
+- **Data loaders** — load traces from CaImAn (HDF5) and Minian (Zarr) pipelines
+- **Simulation** — generate synthetic traces with ground truth for benchmarking
+- **CLI** — `calab tune`, `calab cadecon`, `calab deconvolve`, `calab convert`, `calab info`
+
+```bash
+pip install calab                # core package
+pip install calab[loaders]       # + CaImAn/Minian support
+pip install calab[headless]      # + headless browser for CaDecon
+```
+
+> **Full documentation:** [calab.readthedocs.io](https://calab.readthedocs.io)
 
 ## Monorepo Structure
 
 ```
 .
 ├── apps/
-│   ├── catune/                  # SolidJS SPA — deconvolution parameter tuning
+│   ├── catune/                  # SolidJS SPA — interactive parameter tuning
+│   ├── cadecon/                 # SolidJS SPA — automated deconvolution
 │   └── carank/                  # SolidJS SPA — trace quality ranking
 ├── packages/
 │   ├── core/                    # @calab/core — shared types, pure math, WASM adapter
@@ -58,7 +102,7 @@ See [`python/README.md`](python/README.md) for full API documentation.
 │   ├── tutorials/               # @calab/tutorials — tutorial types, progress persistence
 │   └── ui/                      # @calab/ui — shared layout components
 ├── crates/
-│   └── solver/                  # Rust FISTA solver crate (compiled to WASM + PyO3)
+│   └── solver/                  # Rust FISTA solver crate (WASM + PyO3)
 ├── python/                      # Python companion package
 ├── docs/                        # Documentation
 ├── scripts/                     # Build and deploy scripts
@@ -76,7 +120,7 @@ See [`python/README.md`](python/README.md) for full API documentation.
 | [`@calab/tutorials`](packages/tutorials/) | Tutorial type definitions, progress persistence (localStorage)       |
 | [`@calab/ui`](packages/ui/)               | Shared SolidJS layout components (DashboardShell, panels, cards)     |
 
-## Development Quick Start
+## Development
 
 ### Prerequisites
 
@@ -98,7 +142,7 @@ npm run dev
 
 | Script                | Description                            |
 | --------------------- | -------------------------------------- |
-| `npm run dev`         | Start CaTune dev server                |
+| `npm run dev`         | Start dev server                       |
 | `npm run build`       | Build WASM + all apps                  |
 | `npm run build:pages` | Build + combine dist for GitHub Pages  |
 | `npm run build:wasm`  | Compile Rust solver to WASM            |
@@ -111,25 +155,24 @@ See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for the full development guid
 
 ## Documentation
 
+- **[Python Package (ReadTheDocs)](https://calab.readthedocs.io)** — API reference, guides, CLI
 - [Architecture](docs/ARCHITECTURE.md) — module layout, dependency DAG, state management, boundaries
 - [Contributing](docs/CONTRIBUTING.md) — setup, scripts, code style, CI
 - [Changelog](docs/CHANGELOG.md) — release history
 - [New App Guide](docs/NEW_APP.md) — adding a new app to the monorepo
-- [CaTune](apps/catune/README.md) — CaTune app documentation
 - [WASM Solver](crates/solver/README.md) — Rust FISTA solver documentation
-- [Python Package](python/README.md) — Python companion package
 
 ## Tech Stack
 
 - **Frontend:** SolidJS + TypeScript + Vite
-- **Solver:** Rust + wasm-pack (WebAssembly)
+- **Solver:** Rust → WebAssembly (browser) + PyO3 (Python)
 - **Charts:** uPlot
 - **Community:** Supabase (optional)
 - **Styling:** Pure CSS with custom properties
 
 ## Versioning
 
-The monorepo uses a single `v*` tag for all web apps and packages (e.g., `v2.0.4`). The Python package has a separate `py/v*` tag series. See the [Changelog](docs/CHANGELOG.md) for release history.
+The monorepo uses a single `v*` tag for all web apps and packages (e.g., `v2.0.6`). The Python package has a separate `py/v*` tag series. See the [Changelog](docs/CHANGELOG.md) for release history.
 
 ## License
 

--- a/apps/cadecon/package.json
+++ b/apps/cadecon/package.json
@@ -13,7 +13,7 @@
       "TxN raster heatmap visualization",
       "Configurable algorithm parameters"
     ],
-    "status": "beta",
+    "status": "stable",
     "screenshot": "screenshot.png"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Mark CaDecon as **Stable** (was Beta) in `apps/cadecon/package.json`
- Rewrite root `README.md` to reflect the current state of the project

### Key changes to README

- **Two approaches front and center** — CaTune and CaDecon are presented as the two deconvolution approaches, each with a description and link
- **Side-by-side screenshots** — CaTune and CaDecon screenshots in a 2-column layout
- **ReadTheDocs badge** — added to badge row, links to [calab.readthedocs.io](https://calab.readthedocs.io)
- **Apps table** — CaDecon added as Stable, CaRank listed as Coming Soon
- **Python section** — restructured around CaTune/CaDecon workflows, links to RTD
- **Quick Start** — covers both browser (no-install) and Python paths
- **Documentation section** — RTD listed first with bold emphasis
- **Removed** — "under active development" note (no longer accurate)
- **Updated** — Tech Stack (Rust → WASM + PyO3), monorepo structure (includes CaDecon)

## Test plan

- [x] Verify README renders correctly on GitHub (screenshots, tables, badges)
- [ ] Verify CaDecon landing page card shows "Stable" after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)