### PR TITLE
fix(headless): prevent resource leaks on browser start/close failures

### DIFF
--- a/python/src/calab/_bridge/_headless.py
+++ b/python/src/calab/_bridge/_headless.py
@@ -65,19 +65,30 @@ class HeadlessBrowser:
     # -- lifecycle ----------------------------------------------------------
 
     def start(self) -> None:
-        """Launch the browser. Called automatically by ``__enter__``."""
+        """Launch the browser. Called automatically by ``__enter__``.
+
+        If any initialization step raises after earlier steps succeeded,
+        ``close()`` runs before re-raising. This prevents partial-init
+        failures (e.g. Chromium launch fails after the Playwright driver
+        started) from leaking driver processes and Chromium instances
+        across retries.
+        """
         from playwright.sync_api import sync_playwright
 
-        self._pw = sync_playwright().start()
-        self._browser = self._pw.chromium.launch(
-            headless=self._headless,
-            # Allow the HTTPS-hosted page to fetch from the localhost bridge
-            # server. Headless Chromium enforces Private Network Access (PNA)
-            # restrictions that block HTTPS→localhost requests by default.
-            args=["--disable-web-security"],
-        )
-        self._context = self._browser.new_context()
-        self._page = self._context.new_page()
+        try:
+            self._pw = sync_playwright().start()
+            self._browser = self._pw.chromium.launch(
+                headless=self._headless,
+                # Allow the HTTPS-hosted page to fetch from the localhost bridge
+                # server. Headless Chromium enforces Private Network Access (PNA)
+                # restrictions that block HTTPS→localhost requests by default.
+                args=["--disable-web-security"],
+            )
+            self._context = self._browser.new_context()
+            self._page = self._context.new_page()
+        except Exception:
+            self.close()
+            raise
 
     def navigate(self, url: str) -> None:
         """Navigate the managed page to *url*.
@@ -92,15 +103,31 @@ class HeadlessBrowser:
         self._page.goto(url, wait_until="domcontentloaded")
 
     def close(self) -> None:
-        """Shut down page, context, browser, and Playwright."""
+        """Shut down page, context, browser, and Playwright.
+
+        Each teardown runs in its own try/except so a crashed browser
+        (where ``context.close()`` raises) still lets ``browser.close()``
+        and ``pw.stop()`` run. Without this, a single teardown error
+        would leak the remaining resources — most visibly an orphaned
+        Chromium process that lingers until the Python process exits.
+        """
         if self._context is not None:
-            self._context.close()
+            try:
+                self._context.close()
+            except Exception:
+                pass
             self._context = None
         if self._browser is not None:
-            self._browser.close()
+            try:
+                self._browser.close()
+            except Exception:
+                pass
             self._browser = None
         if self._pw is not None:
-            self._pw.stop()
+            try:
+                self._pw.stop()
+            except Exception:
+                pass
             self._pw = None
         self._page = None
 

--- a/python/tests/test_headless.py
+++ b/python/tests/test_headless.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -163,6 +164,126 @@ class TestHeadlessBrowserMocked:
             assert hb._page is None
         finally:
             headless_mod.HeadlessBrowser.start = original_start
+
+
+class TestHeadlessBrowserResourceSafety:
+    """Regression tests for start()/close() cleanup under failure.
+
+    Exercise the real ``start()`` and ``close()`` methods with the
+    ``playwright.sync_api`` module patched into ``sys.modules``. The
+    existing ``TestHeadlessBrowserMocked`` class replaces ``start()``
+    entirely, so it cannot catch leaks in the real cleanup logic.
+    """
+
+    def _install_fake_playwright(self, mock_sync_playwright: MagicMock) -> dict[str, object]:
+        """Return a sys.modules patch dict that routes the deferred import inside
+        ``start()`` to ``mock_sync_playwright``."""
+        fake_sync_api = MagicMock()
+        fake_sync_api.sync_playwright = mock_sync_playwright
+        fake_playwright = MagicMock()
+        fake_playwright.sync_api = fake_sync_api
+        return {
+            "playwright": fake_playwright,
+            "playwright.sync_api": fake_sync_api,
+        }
+
+    def test_start_cleans_up_when_launch_fails(self):
+        """If chromium.launch() raises, _pw is stopped and all refs are None."""
+        mock_pw = MagicMock()
+        mock_pw.chromium.launch.side_effect = RuntimeError("launch failed")
+
+        mock_entry = MagicMock()
+        mock_entry.start.return_value = mock_pw
+
+        mock_sync_playwright = MagicMock(return_value=mock_entry)
+
+        with patch("calab._bridge._headless._check_playwright"):
+            hb = HeadlessBrowser()
+
+        with patch.dict(sys.modules, self._install_fake_playwright(mock_sync_playwright)):
+            with pytest.raises(RuntimeError, match="launch failed"):
+                hb.start()
+
+        # All resources cleaned up after partial init failure.
+        assert hb._pw is None
+        assert hb._browser is None
+        assert hb._context is None
+        assert hb._page is None
+        # The Playwright driver we DID start must have been stopped, or a
+        # background node/driver process would linger across retries.
+        mock_pw.stop.assert_called_once()
+
+    def test_start_cleans_up_when_new_context_fails(self):
+        """If new_context() raises, both browser.close() and pw.stop() run."""
+        mock_browser = MagicMock()
+        mock_browser.new_context.side_effect = RuntimeError("context failed")
+
+        mock_pw = MagicMock()
+        mock_pw.chromium.launch.return_value = mock_browser
+
+        mock_entry = MagicMock()
+        mock_entry.start.return_value = mock_pw
+
+        mock_sync_playwright = MagicMock(return_value=mock_entry)
+
+        with patch("calab._bridge._headless._check_playwright"):
+            hb = HeadlessBrowser()
+
+        with patch.dict(sys.modules, self._install_fake_playwright(mock_sync_playwright)):
+            with pytest.raises(RuntimeError, match="context failed"):
+                hb.start()
+
+        assert hb._pw is None
+        assert hb._browser is None
+        assert hb._context is None
+        assert hb._page is None
+        mock_browser.close.assert_called_once()
+        mock_pw.stop.assert_called_once()
+
+    def test_close_continues_when_context_close_raises(self):
+        """Crashed context must not block browser.close() or pw.stop()."""
+        with patch("calab._bridge._headless._check_playwright"):
+            hb = HeadlessBrowser()
+
+        # Manually wire up started state with a context that raises on close.
+        mock_pw = MagicMock()
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_context.close.side_effect = RuntimeError("context crashed")
+        hb._pw = mock_pw
+        hb._browser = mock_browser
+        hb._context = mock_context
+        hb._page = MagicMock()
+
+        hb.close()  # Must not raise.
+
+        mock_context.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_pw.stop.assert_called_once()
+        assert hb._context is None
+        assert hb._browser is None
+        assert hb._pw is None
+        assert hb._page is None
+
+    def test_close_continues_when_browser_close_raises(self):
+        """Crashed browser.close() must not block pw.stop()."""
+        with patch("calab._bridge._headless._check_playwright"):
+            hb = HeadlessBrowser()
+
+        mock_pw = MagicMock()
+        mock_browser = MagicMock()
+        mock_browser.close.side_effect = RuntimeError("browser crashed")
+        hb._pw = mock_pw
+        hb._browser = mock_browser
+        hb._context = MagicMock()
+        hb._page = MagicMock()
+
+        hb.close()  # Must not raise.
+
+        mock_browser.close.assert_called_once()
+        mock_pw.stop.assert_called_once()
+        assert hb._browser is None
+        assert hb._pw is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves **LOGIC-1** and **LOGIC-2** from `.planning/CODEBASE_AUDIT.md`, and covers the \"headless bridge failure modes untested\" part of **TEST-M3**.

## The leaks

**LOGIC-1 — `HeadlessBrowser.start()` on partial init failure.** The method created `_pw`, `_browser`, `_context`, `_page` sequentially with no rollback. If `chromium.launch()` raised after `sync_playwright().start()` had already run, the Playwright driver process leaked. Batch runs that retry on failure accumulated orphaned Chromium + node processes that only cleared when the Python interpreter exited.

**LOGIC-2 — `HeadlessBrowser.close()` short-circuited on the first raise.** If `self._context.close()` raised (common after the browser has already crashed), `self._browser.close()` and `self._pw.stop()` never ran. `_managed_headless` then returned control with a leaked driver and orphaned Chromium.

## The fixes

- `start()` wraps the init sequence in `try/except` that calls `self.close()` and re-raises. `close()` is safe to call on a partially-initialized object because it checks each slot for `None`.
- `close()` wraps each of the three teardown calls in its own `try/except` so later steps always run, regardless of earlier raises.

## Regression tests

Added 4 tests in a new `TestHeadlessBrowserResourceSafety` class. Unlike the existing `TestHeadlessBrowserMocked` (which monkey-patches `start()` entirely — can't catch real-method bugs), these exercise the real `start()` / `close()` with `playwright.sync_api` stubbed into `sys.modules` and configured to raise at specific steps:

- `test_start_cleans_up_when_launch_fails` — `chromium.launch()` raises → `_pw.stop()` is called, all four slots are `None`.
- `test_start_cleans_up_when_new_context_fails` — `new_context()` raises → `browser.close()` AND `pw.stop()` both called.
- `test_close_continues_when_context_close_raises` — `context.close()` raises → `browser.close()` and `pw.stop()` still run.
- `test_close_continues_when_browser_close_raises` — `browser.close()` raises → `pw.stop()` still runs.

## Not in scope
- `--disable-web-security` replacement (SEC-1) — separate security PR.
- Browser-crash-mid-run + timeout regression tests (remainder of TEST-M3) — best added alongside the SEC-1 flag rework so the new tests exercise the tightened flag set.

## Test plan
- [x] `.venv/bin/pytest` in `python/` — **187 passed, 2 skipped** (the 2 skips are the real-browser integration tests that require Playwright+Chromium locally; CI's Python job should run the same subset unchanged).
- [x] 4 new regression tests all pass.
- [x] No changes to the public `HeadlessBrowser` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)