### PR TITLE
security: harden bridge URL, localhost bridge auth, and geo-session edge function

### DIFF
--- a/packages/io/src/__tests__/bridge-url.test.ts
+++ b/packages/io/src/__tests__/bridge-url.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { getBridgeUrl } from '../bridge.ts';
+
+function withLocationSearch(search: string): void {
+  vi.stubGlobal('window', { location: { search } });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getBridgeUrl', () => {
+  it('returns null when ?bridge= is not present', () => {
+    withLocationSearch('');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('accepts an http://127.0.0.1:PORT URL', () => {
+    withLocationSearch('?bridge=http://127.0.0.1:8765');
+    expect(getBridgeUrl()).toBe('http://127.0.0.1:8765');
+  });
+
+  it('accepts localhost', () => {
+    withLocationSearch('?bridge=http://localhost:8765');
+    expect(getBridgeUrl()).toBe('http://localhost:8765');
+  });
+
+  it('accepts IPv6 loopback', () => {
+    withLocationSearch('?bridge=http://[::1]:8765');
+    expect(getBridgeUrl()).toBe('http://[::1]:8765');
+  });
+
+  it('accepts bare host:port (assumed http://)', () => {
+    withLocationSearch('?bridge=127.0.0.1:8765');
+    expect(getBridgeUrl()).toBe('http://127.0.0.1:8765');
+  });
+
+  it('rejects a non-loopback target — exfiltration vector', () => {
+    // The primary CRIT-3 concern: an attacker who controls the link
+    // must not be able to point the bridge mechanism at their own host.
+    withLocationSearch('?bridge=http://evil.example/collect');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('rejects an https:// target', () => {
+    // Bridge traffic is local + plain http. An https target is either
+    // a typo or an attempt to smuggle the bridge through a third party.
+    withLocationSearch('?bridge=https://127.0.0.1:8765');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('rejects javascript: pseudo-protocol', () => {
+    withLocationSearch('?bridge=javascript:alert(1)');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('rejects a public IP that looks loopback-ish', () => {
+    withLocationSearch('?bridge=http://127.0.0.1.evil.example/');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('rejects a URL that fails to parse', () => {
+    withLocationSearch('?bridge=http:///');
+    expect(getBridgeUrl()).toBeNull();
+  });
+
+  it('normalizes trailing slash to origin', () => {
+    withLocationSearch('?bridge=http://127.0.0.1:8765/');
+    expect(getBridgeUrl()).toBe('http://127.0.0.1:8765');
+  });
+
+  it('ignores the bridge_secret parameter in the returned URL', () => {
+    withLocationSearch('?bridge=http://127.0.0.1:8765&bridge_secret=abc123');
+    expect(getBridgeUrl()).toBe('http://127.0.0.1:8765');
+  });
+});

--- a/packages/io/src/bridge.ts
+++ b/packages/io/src/bridge.ts
@@ -55,20 +55,59 @@ export interface BridgeProgress {
   status: string;
 }
 
+/** Per-run secret extracted from `?bridge_secret=`, sent back on every bridge call. */
+let cachedBridgeSecret: string | null = null;
+
+/** Loopback hostnames the bridge URL is allowed to target. */
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
+
 /**
  * Read the `?bridge=` URL parameter to get the bridge server base URL.
- * Returns null if not present.
+ *
+ * The value must be an `http://` URL pointing at a loopback host. A
+ * non-loopback or non-http target is rejected — if an attacker can
+ * influence the page URL (e.g. phishing link to the hosted app), the
+ * bridge mechanism must not forward traces / params to an arbitrary
+ * origin.
+ *
+ * Also caches the optional `?bridge_secret=` value so subsequent
+ * bridge requests can include it in the `X-Bridge-Secret` header.
+ *
+ * Returns null if the parameter is missing or fails validation.
  */
 export function getBridgeUrl(): string | null {
+  if (typeof window === 'undefined') return null;
   const params = new URLSearchParams(window.location.search);
   const bridge = params.get('bridge');
   if (!bridge) return null;
 
-  // Ensure it has a protocol prefix
-  if (bridge.startsWith('http://') || bridge.startsWith('https://')) {
-    return bridge;
+  const raw = bridge.includes('://') ? bridge : `http://${bridge}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
   }
-  return `http://${bridge}`;
+
+  if (parsed.protocol !== 'http:') return null;
+  if (!LOOPBACK_HOSTS.has(parsed.hostname)) return null;
+
+  cachedBridgeSecret = params.get('bridge_secret');
+  // Normalize: strip trailing slash so callers can safely append paths.
+  return parsed.origin;
+}
+
+/** Return bridge-specific fetch headers (includes the secret if one was set). */
+function bridgeHeaders(base?: HeadersInit): Headers {
+  const h = new Headers(base);
+  if (cachedBridgeSecret) h.set('X-Bridge-Secret', cachedBridgeSecret);
+  return h;
+}
+
+/** Wrapper around fetch() that automatically adds the bridge secret header. */
+function bridgeFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(url, { ...init, headers: bridgeHeaders(init.headers) });
 }
 
 /**
@@ -79,7 +118,7 @@ export async function fetchBridgeData(
   bridgeUrl: string,
 ): Promise<{ traces: NpyResult; metadata: BridgeMetadata }> {
   // Fetch traces as .npy binary
-  const tracesResp = await fetch(`${bridgeUrl}/api/v1/traces`);
+  const tracesResp = await bridgeFetch(`${bridgeUrl}/api/v1/traces`);
   if (!tracesResp.ok) {
     throw new Error(`Bridge: failed to fetch traces (${tracesResp.status})`);
   }
@@ -88,7 +127,7 @@ export async function fetchBridgeData(
   const traces = processNpyResult(rawResult);
 
   // Fetch metadata JSON
-  const metaResp = await fetch(`${bridgeUrl}/api/v1/metadata`);
+  const metaResp = await bridgeFetch(`${bridgeUrl}/api/v1/metadata`);
   if (!metaResp.ok) {
     throw new Error(`Bridge: failed to fetch metadata (${metaResp.status})`);
   }
@@ -103,7 +142,7 @@ export async function fetchBridgeData(
  */
 export async function postParamsToBridge(bridgeUrl: string, exportData: unknown): Promise<void> {
   stopBridgeHeartbeat();
-  const resp = await fetch(`${bridgeUrl}/api/v1/params`, {
+  const resp = await bridgeFetch(`${bridgeUrl}/api/v1/params`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(exportData),
@@ -119,7 +158,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 export function startBridgeHeartbeat(bridgeUrl: string, intervalMs = 3000): void {
   stopBridgeHeartbeat();
   heartbeatTimer = setInterval(() => {
-    fetch(`${bridgeUrl}/api/v1/heartbeat`, { method: 'POST' }).catch(() => {
+    bridgeFetch(`${bridgeUrl}/api/v1/heartbeat`, { method: 'POST' }).catch(() => {
       stopBridgeHeartbeat();
     });
   }, intervalMs);
@@ -143,7 +182,7 @@ export async function postActivityToBridge(
   shape: [number, number],
 ): Promise<void> {
   const npyBuffer = writeNpy(activity, shape);
-  const resp = await fetch(`${bridgeUrl}/api/v1/results/activity`, {
+  const resp = await bridgeFetch(`${bridgeUrl}/api/v1/results/activity`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/octet-stream' },
     body: npyBuffer,
@@ -161,7 +200,7 @@ export async function postResultsToBridge(
   bridgeUrl: string,
   results: Record<string, unknown>,
 ): Promise<void> {
-  const resp = await fetch(`${bridgeUrl}/api/v1/results`, {
+  const resp = await bridgeFetch(`${bridgeUrl}/api/v1/results`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(results),
@@ -192,7 +231,7 @@ export async function exportCaDeconToBridge(
  * Returns the parsed BridgeConfig (autorun + optional algorithm overrides).
  */
 export async function fetchBridgeConfig(bridgeUrl: string): Promise<BridgeConfig> {
-  const resp = await fetch(`${bridgeUrl}/api/v1/config`);
+  const resp = await bridgeFetch(`${bridgeUrl}/api/v1/config`);
   if (!resp.ok) {
     throw new Error(`Bridge: failed to fetch config (${resp.status})`);
   }
@@ -204,7 +243,7 @@ export async function fetchBridgeConfig(bridgeUrl: string): Promise<BridgeConfig
  * Errors are silently swallowed — progress is informational, not critical.
  */
 export function postProgressToBridge(bridgeUrl: string, progress: BridgeProgress): void {
-  fetch(`${bridgeUrl}/api/v1/progress`, {
+  bridgeFetch(`${bridgeUrl}/api/v1/progress`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(progress),

--- a/python/src/calab/_bridge/_apps.py
+++ b/python/src/calab/_bridge/_apps.py
@@ -85,7 +85,7 @@ def _run_bridge(
     server_thread.start()
 
     bridge_param = f"http://127.0.0.1:{actual_port}"
-    full_url = f"{app_url}?bridge={bridge_param}"
+    full_url = f"{app_url}?bridge={bridge_param}&bridge_secret={server.secret}"
 
     print(f"Bridge server running on http://127.0.0.1:{actual_port}")
     print(f"Opening {app_name}: {full_url}")

--- a/python/src/calab/_bridge/_headless.py
+++ b/python/src/calab/_bridge/_headless.py
@@ -77,13 +77,11 @@ class HeadlessBrowser:
 
         try:
             self._pw = sync_playwright().start()
-            self._browser = self._pw.chromium.launch(
-                headless=self._headless,
-                # Allow the HTTPS-hosted page to fetch from the localhost bridge
-                # server. Headless Chromium enforces Private Network Access (PNA)
-                # restrictions that block HTTPS→localhost requests by default.
-                args=["--disable-web-security"],
-            )
+            # No --disable-web-security: the bridge server answers PNA
+            # preflights with `Access-Control-Allow-Private-Network: true`,
+            # so Chromium allows the HTTPS→localhost fetch without needing
+            # SOP disabled globally. See `_server.py` OPTIONS handler.
+            self._browser = self._pw.chromium.launch(headless=self._headless)
             self._context = self._browser.new_context()
             self._page = self._context.new_page()
         except Exception:

--- a/python/src/calab/_bridge/_server.py
+++ b/python/src/calab/_bridge/_server.py
@@ -1,14 +1,20 @@
 """Localhost HTTP bridge server for CaLab <-> Python communication.
 
 Serves traces as .npy binary and receives exported params/results.
-Binds to 127.0.0.1 only (not network-reachable). CORS enabled for
-HTTPS->localhost mixed-content requests.
+Binds to 127.0.0.1 only (not network-reachable). Every request must
+include an ``X-Bridge-Secret`` header matching the server's per-run
+secret — prevents other local tabs/processes from reading the served
+trace data or spoofing results. CORS + Private Network Access
+preflights are handled so an HTTPS page can reach the localhost
+server without needing ``--disable-web-security`` on the browser.
 """
 
 from __future__ import annotations
 
+import hmac
 import io
 import json
+import secrets
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -25,14 +31,21 @@ class BridgeHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: Any) -> None:
         """Suppress default stderr logging."""
 
+    def _cors_headers(self) -> dict[str, str]:
+        """Headers common to every CORS response."""
+        return {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, X-Bridge-Secret",
+        }
+
     def _send_cors_response(
         self, data: bytes, content_type: str = "application/json",
     ) -> None:
         """Send a 200 response with CORS headers and body."""
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        for k, v in self._cors_headers().items():
+            self.send_header(k, v)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(data)))
         self.end_headers()
@@ -46,19 +59,54 @@ class BridgeHandler(BaseHTTPRequestHandler):
         """Send an error response with CORS headers."""
         body = json.dumps({"error": message}).encode()
         self.send_response(code)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        for k, v in self._cors_headers().items():
+            self.send_header(k, v)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
+    def _check_secret(self) -> bool:
+        """Constant-time check of the X-Bridge-Secret header.
+
+        Returns True when the header matches the server's secret. On
+        mismatch, responds with 401 and returns False — callers should
+        short-circuit any further work.
+        """
+        presented = self.headers.get("X-Bridge-Secret", "")
+        if hmac.compare_digest(presented, self.server.secret):
+            return True
+        self._send_error_cors(401, "invalid or missing bridge secret")
+        return False
+
     def do_OPTIONS(self) -> None:
-        """Handle CORS preflight."""
-        self._send_cors_response(b"", content_type="text/plain")
+        """Handle CORS + Private Network Access preflight.
+
+        Preflights carry no request body and no X-Bridge-Secret header
+        (the browser issues them automatically before the real request),
+        so they must be answered without the secret check. The real
+        request that follows is secret-checked like any other.
+        """
+        headers = self._cors_headers()
+        # Private Network Access: browsers (Chrome 124+) send
+        # `Access-Control-Request-Private-Network: true` when a
+        # public-origin page tries to reach a private network (e.g.
+        # HTTPS page → 127.0.0.1). The server must opt in by echoing
+        # `Access-Control-Allow-Private-Network: true`, otherwise the
+        # request is blocked.
+        if self.headers.get("Access-Control-Request-Private-Network", "").lower() == "true":
+            headers["Access-Control-Allow-Private-Network"] = "true"
+
+        self.send_response(200)
+        for k, v in headers.items():
+            self.send_header(k, v)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
 
     def do_GET(self) -> None:
+        if not self._check_secret():
+            return
         if self.path == "/api/v1/traces":
             self._serve_traces()
         elif self.path == "/api/v1/metadata":
@@ -73,6 +121,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self.send_error(404, "Not Found")
 
     def do_POST(self) -> None:
+        if not self._check_secret():
+            return
         if self.path == "/api/v1/params":
             self._receive_params()
         elif self.path == "/api/v1/heartbeat":
@@ -170,6 +220,7 @@ class BridgeServer(HTTPServer):
         port: int = 0,
         app: str = "catune",
         config: dict | None = None,
+        secret: str | None = None,
     ) -> None:
         self.traces = np.atleast_2d(np.asarray(traces, dtype=np.float64))
         self.fs = fs
@@ -183,6 +234,12 @@ class BridgeServer(HTTPServer):
         self.received_activity: np.ndarray | None = None
         self.received_results: dict | None = None
         self.results_event = threading.Event()
+        # Per-run secret. Each BridgeServer gets a fresh 32-byte token that
+        # the opened URL passes to the browser via ?bridge_secret=...; every
+        # bridge HTTP request must echo it back in the X-Bridge-Secret
+        # header. Prevents other tabs/processes on the same machine from
+        # reading the served trace data or spoofing results.
+        self.secret: str = secret if secret is not None else secrets.token_hex(32)
 
         super().__init__(("127.0.0.1", port), BridgeHandler)
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -44,10 +44,16 @@ def cadecon_server():
     server.shutdown()
 
 
-def _get(server: BridgeServer, path: str) -> tuple[int, bytes]:
-    """Make a GET request to the bridge server."""
+def _get(server: BridgeServer, path: str, *, secret: bool = True) -> tuple[int, bytes]:
+    """Make a GET request to the bridge server.
+
+    ``secret=False`` omits the X-Bridge-Secret header, for tests that
+    assert the server rejects unauthenticated requests.
+    """
     url = f"http://127.0.0.1:{server.port}{path}"
     req = urllib.request.Request(url)
+    if secret:
+        req.add_header("X-Bridge-Secret", server.secret)
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status, resp.read()
@@ -55,12 +61,16 @@ def _get(server: BridgeServer, path: str) -> tuple[int, bytes]:
         return e.code, e.read()
 
 
-def _post(server: BridgeServer, path: str, data: dict) -> tuple[int, bytes]:
+def _post(
+    server: BridgeServer, path: str, data: dict, *, secret: bool = True,
+) -> tuple[int, bytes]:
     """Make a POST request to the bridge server."""
     url = f"http://127.0.0.1:{server.port}{path}"
     body = json.dumps(data).encode()
     req = urllib.request.Request(url, data=body, method="POST")
     req.add_header("Content-Type", "application/json")
+    if secret:
+        req.add_header("X-Bridge-Secret", server.secret)
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status, resp.read()
@@ -68,11 +78,15 @@ def _post(server: BridgeServer, path: str, data: dict) -> tuple[int, bytes]:
         return e.code, e.read()
 
 
-def _post_binary(server: BridgeServer, path: str, data: bytes) -> tuple[int, bytes]:
+def _post_binary(
+    server: BridgeServer, path: str, data: bytes, *, secret: bool = True,
+) -> tuple[int, bytes]:
     """Make a POST request with binary data."""
     url = f"http://127.0.0.1:{server.port}{path}"
     req = urllib.request.Request(url, data=data, method="POST")
     req.add_header("Content-Type", "application/octet-stream")
+    if secret:
+        req.add_header("X-Bridge-Secret", server.secret)
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status, resp.read()
@@ -167,6 +181,7 @@ def test_cors_headers(bridge_server: BridgeServer) -> None:
     """Responses include CORS headers."""
     url = f"http://127.0.0.1:{bridge_server.port}/api/v1/health"
     req = urllib.request.Request(url)
+    req.add_header("X-Bridge-Secret", bridge_server.secret)
     with urllib.request.urlopen(req, timeout=5) as resp:
         assert resp.headers["Access-Control-Allow-Origin"] == "*"
 
@@ -330,6 +345,7 @@ def test_progress_invalid_json(cadecon_server: BridgeServer) -> None:
     url = f"http://127.0.0.1:{cadecon_server.port}/api/v1/progress"
     req = urllib.request.Request(url, data=b"not json", method="POST")
     req.add_header("Content-Type", "application/json")
+    req.add_header("X-Bridge-Secret", cadecon_server.secret)
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             status = resp.status
@@ -370,6 +386,101 @@ def test_decon_config_serialization() -> None:
     assert dumped == {"autorun": True, "max_iterations": 10}
     assert "upsample_target" not in dumped
     assert "seed" not in dumped
+
+
+# --- Auth (X-Bridge-Secret) and PNA preflight tests ---
+
+
+def test_secret_is_generated_and_not_trivial() -> None:
+    """Every BridgeServer gets a fresh, non-guessable secret."""
+    s1 = _make_server()
+    s2 = _make_server()
+    try:
+        assert s1.secret != s2.secret
+        assert len(s1.secret) >= 32  # hex-encoded, at least 16 random bytes
+        assert set(s1.secret).issubset(set("0123456789abcdef"))
+    finally:
+        s1.server_close()
+        s2.server_close()
+
+
+def test_get_without_secret_returns_401(bridge_server: BridgeServer) -> None:
+    """Requests lacking X-Bridge-Secret are rejected with 401."""
+    status, body = _get(bridge_server, "/api/v1/health", secret=False)
+    assert status == 401
+    assert b"invalid or missing bridge secret" in body
+
+
+def test_get_with_wrong_secret_returns_401(bridge_server: BridgeServer) -> None:
+    """Requests with the wrong X-Bridge-Secret are rejected with 401."""
+    url = f"http://127.0.0.1:{bridge_server.port}/api/v1/health"
+    req = urllib.request.Request(url)
+    req.add_header("X-Bridge-Secret", "deadbeef" * 8)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            status = resp.status
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        status = e.code
+        body = e.read()
+    assert status == 401
+    assert b"invalid or missing bridge secret" in body
+
+
+def test_post_without_secret_returns_401(bridge_server: BridgeServer) -> None:
+    """POST endpoints also enforce the secret."""
+    status, _ = _post(bridge_server, "/api/v1/params", {"foo": "bar"}, secret=False)
+    assert status == 401
+    # Payload must NOT have been recorded on a rejected request.
+    assert bridge_server.received_params is None
+
+
+def test_traces_without_secret_returns_401(bridge_server: BridgeServer) -> None:
+    """Sensitive trace data is guarded by the secret too."""
+    status, _ = _get(bridge_server, "/api/v1/traces", secret=False)
+    assert status == 401
+
+
+def test_options_preflight_exempt_from_secret(bridge_server: BridgeServer) -> None:
+    """CORS preflights have no way to carry custom headers and must be allowed."""
+    url = f"http://127.0.0.1:{bridge_server.port}/api/v1/traces"
+    req = urllib.request.Request(url, method="OPTIONS")
+    req.add_header("Origin", "https://miniscope.github.io")
+    req.add_header("Access-Control-Request-Method", "GET")
+    req.add_header("Access-Control-Request-Headers", "x-bridge-secret")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.status == 200
+        allow_headers = resp.headers.get("Access-Control-Allow-Headers", "")
+        assert "X-Bridge-Secret" in allow_headers
+
+
+def test_options_preflight_echoes_private_network_when_requested(
+    bridge_server: BridgeServer,
+) -> None:
+    """PNA preflights (Chrome 124+) must be answered affirmatively.
+
+    Without this, an HTTPS-hosted page cannot reach the localhost
+    bridge server — the SEC-1 workaround of launching headless Chromium
+    with --disable-web-security would still be required. This test
+    pins the PNA behavior so the flag can stay off.
+    """
+    url = f"http://127.0.0.1:{bridge_server.port}/api/v1/traces"
+    req = urllib.request.Request(url, method="OPTIONS")
+    req.add_header("Origin", "https://miniscope.github.io")
+    req.add_header("Access-Control-Request-Method", "GET")
+    req.add_header("Access-Control-Request-Private-Network", "true")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.headers.get("Access-Control-Allow-Private-Network") == "true"
+
+
+def test_options_without_pna_request_omits_pna_header(bridge_server: BridgeServer) -> None:
+    """Don't opt into PNA when the client isn't asking for it."""
+    url = f"http://127.0.0.1:{bridge_server.port}/api/v1/traces"
+    req = urllib.request.Request(url, method="OPTIONS")
+    req.add_header("Origin", "https://miniscope.github.io")
+    req.add_header("Access-Control-Request-Method", "GET")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.headers.get("Access-Control-Allow-Private-Network") is None
 
 
 # --- Cross-language schema consistency tests ---

--- a/supabase/functions/geo-session/index.ts
+++ b/supabase/functions/geo-session/index.ts
@@ -1,15 +1,53 @@
 // Supabase Edge Function: geo-session
-// Receives session start data from client, resolves IP -> country/region
-// server-side (IP is never stored), inserts session, returns session_id.
+// Receives session start data from client, resolves client country/region
+// from the Cloudflare edge headers (no outbound IP lookup, IP never stored),
+// inserts session, returns session_id.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+/**
+ * Origins allowed to call this function. Additional origins (e.g. preview
+ * deploys) can be added via the `GEO_SESSION_EXTRA_ORIGINS` env var as a
+ * comma-separated list.
+ */
+const DEFAULT_ALLOWED_ORIGINS = [
+  'https://miniscope.github.io',
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+];
 
-const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' };
+function allowedOrigins(): Set<string> {
+  const extra = Deno.env.get('GEO_SESSION_EXTRA_ORIGINS') ?? '';
+  const extras = extra
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return new Set([...DEFAULT_ALLOWED_ORIGINS, ...extras]);
+}
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  // Echo the request origin only when it's on the allowlist — prevents the
+  // previous `*` from letting arbitrary third-party pages trigger sessions
+  // via a victim's browser.
+  const allow = origin && allowedOrigins().has(origin) ? origin : '';
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    Vary: 'Origin',
+  };
+}
+
+function jsonResponse(
+  body: Record<string, unknown>,
+  status: number,
+  origin: string | null,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders(origin), 'Content-Type': 'application/json' },
+  });
+}
 
 interface SessionPayload {
   anonymous_id: string;
@@ -21,64 +59,74 @@ interface SessionPayload {
   referrer_domain?: string;
 }
 
-interface GeoResult {
-  countryCode?: string;
-  regionName?: string;
+/**
+ * Read the client's country/region from Cloudflare edge headers. Supabase's
+ * function gateway sits behind CF, so cf-ipcountry is always populated for
+ * real requests. Falls back to empty if the header is missing (local dev,
+ * non-CF deployment).
+ *
+ * Previously this made an outbound `http://ip-api.com/json/...` call over
+ * plaintext HTTP — an unnecessary dependency and a MITM-poisonable channel.
+ */
+function resolveGeo(req: Request): { countryCode: string | null; regionName: string | null } {
+  const country = req.headers.get('cf-ipcountry');
+  const region = req.headers.get('cf-region');
+  return {
+    countryCode: country && country !== 'XX' && country !== 'T1' ? country : null,
+    regionName: region ?? null,
+  };
 }
 
-function jsonResponse(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
-}
-
-async function resolveGeo(ip: string): Promise<GeoResult> {
+/**
+ * Resolve the authenticated user via a verified Supabase session, not by
+ * parsing the JWT payload directly. The previous implementation did
+ * `JSON.parse(atob(...))` on the bearer token body — if the gateway ever
+ * shipped with verify_jwt disabled (or a future config flip), `sub` could
+ * be forged by any caller.
+ */
+async function resolveUserId(authHeader: string | null): Promise<string | null> {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  const token = authHeader.slice('Bearer '.length);
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(`http://ip-api.com/json/${ip}?fields=status,countryCode,regionName`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    if (!res.ok) return {};
-    const data = await res.json();
-    if (data.status !== 'success') return {};
-    return { countryCode: data.countryCode, regionName: data.regionName };
-  } catch {
-    return {};
-  }
-}
-
-function extractUserIdFromJWT(authHeader: string): string | null {
-  if (!authHeader.startsWith('Bearer ')) return null;
-  try {
-    const payload = JSON.parse(atob(authHeader.split('.')[1]));
-    return payload.sub ?? null;
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } },
+    );
+    const { data } = await userClient.auth.getUser();
+    return data.user?.id ?? null;
   } catch {
     return null;
   }
 }
 
 Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+    return new Response('ok', { headers: corsHeaders(origin) });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'method not allowed' }, 405, origin);
+  }
+
+  // Reject disallowed origins early so we don't do any work for an origin
+  // the browser will refuse to read the response from anyway.
+  if (origin && !allowedOrigins().has(origin)) {
+    return jsonResponse({ error: 'origin not allowed' }, 403, origin);
   }
 
   try {
     const body: SessionPayload = await req.json();
 
     if (!body.anonymous_id || !body.app_name) {
-      return jsonResponse({ error: 'anonymous_id and app_name are required' }, 400);
+      return jsonResponse({ error: 'anonymous_id and app_name are required' }, 400, origin);
     }
 
-    // Resolve IP -> country/region (IP never stored)
-    const ip =
-      req.headers.get('cf-connecting-ip') ||
-      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-      '';
-    const geo = ip ? await resolveGeo(ip) : {};
+    const geo = resolveGeo(req);
+    const userId = await resolveUserId(req.headers.get('authorization'));
 
-    const userId = extractUserIdFromJWT(req.headers.get('authorization') ?? '');
-
-    // Insert session using service_role client
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
@@ -91,8 +139,8 @@ Deno.serve(async (req) => {
         user_id: userId,
         app_name: body.app_name,
         app_version: body.app_version ?? null,
-        country_code: geo.countryCode ?? null,
-        region: geo.regionName ?? null,
+        country_code: geo.countryCode,
+        region: geo.regionName,
         screen_width: body.screen_width ?? null,
         screen_height: body.screen_height ?? null,
         user_agent_family: body.user_agent_family ?? null,
@@ -102,11 +150,15 @@ Deno.serve(async (req) => {
       .single();
 
     if (error) {
-      return jsonResponse({ error: error.message }, 500);
+      return jsonResponse({ error: error.message }, 500, origin);
     }
 
-    return jsonResponse({ session_id: data.id }, 200);
+    return jsonResponse({ session_id: data.id }, 200, origin);
   } catch (err) {
-    return jsonResponse({ error: err instanceof Error ? err.message : 'Internal error' }, 500);
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : 'Internal error' },
+      500,
+      origin,
+    );
   }
 });


### PR DESCRIPTION
## Summary

Third PR from the 2026-04-16 audit, focused on the security-sensitive surface. Three independent hardening areas, one per commit:

Resolves: **CRIT-3, SEC-1, SEC-2, SEC-M2, SEC-M3, SEC-M4**, plus the PNA-handling piece of **TEST-M3**.

## Changes by commit

### `fix(bridge): validate ?bridge= URL and plumb per-run secret header` (TS)

- `getBridgeUrl()` now parses via `URL()`, requires `http://`, requires a loopback hostname. A phishing link like `https://miniscope.github.io/CaLab/CaTune/?bridge=https://evil.example` no longer turns the hosted app into an exfil channel.
- New `?bridge_secret=` param captured into module state; all bridge `fetch()` calls go through a `bridgeFetch()` helper that attaches `X-Bridge-Secret` automatically.
- **12 new tests** in `bridge-url.test.ts` covering accept cases (loopback variants, IPv6, bare host:port) and reject cases (non-loopback exfil, https, javascript:, subdomain spoofing, parse failures).

### `security(bridge): enforce per-run secret and drop --disable-web-security` (Python)

- `BridgeServer` generates a fresh 32-byte hex token (`secrets.token_hex`) per instance.
- Every `GET` / `POST` is 401'd without a matching `X-Bridge-Secret` header (constant-time `hmac.compare_digest`).
- `OPTIONS` preflights are exempt (browsers can't carry custom headers on preflight), and echo `Access-Control-Allow-Private-Network: true` when the client sends `Access-Control-Request-Private-Network: true` — Chrome 124+ PNA enforcement now succeeds.
- `_apps.py` appends `&bridge_secret=<hex>` to the opened URL.
- **`_headless.py` drops `--disable-web-security`.** With PNA handled correctly on the server, SOP stays on globally.
- **8 new tests** verify secret generation, rejection paths, OPTIONS exemption, and PNA preflight echo (present only when requested).

### `security(geo-session): tighten CORS, verify JWT via getUser(), drop IP lookup` (Supabase edge)

- **CORS** locked to an allowlist (`miniscope.github.io` + local dev), with `GEO_SESSION_EXTRA_ORIGINS` env var escape hatch. `Vary: Origin` added. Disallowed cross-origin POST → 403.
- **JWT** now validated via `supabase.auth.getUser()` against a per-request client scoped to the caller's token. The previous `JSON.parse(atob(...))` trusted the gateway implicitly — defense in depth against a future `verify_jwt=false` flip.
- **Geo** lookup now reads `cf-ipcountry` / `cf-region` from the Cloudflare edge headers Supabase already exposes. Drops the outbound plaintext HTTP call to `ip-api.com` (MITM-poisonable, unnecessary service dependency).
- Method gate: POST handled, OPTIONS returns CORS, everything else → 405.

## Not in scope
- `CRIT-2` (analytics RLS): separate migration PR, next.
- `SEC-M1` (pin actions to SHAs): bundled into the CI PR.
- Remaining TEST-M3 work (browser-crash-mid-run, timeout regression): follow-up test PR.

## Test plan
- [x] TS: `npm run lint`, `format:check`, `typecheck`, `test` — all green (0 errors, 25 deferred solid/reactivity warnings).
- [x] Python: `.venv/bin/pytest` — **195 passed, 2 skipped** (integration tests).
- [x] New TS tests: 12 new in `bridge-url.test.ts`, all pass.
- [x] New Python tests: 8 new in `test_bridge.py`, all pass; 2 existing tests updated to pass the secret header.
- [ ] Supabase edge function has no local test harness. Will need manual smoke test against a preview deploy to confirm CORS / auth behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)