### PR TITLE
security: lock down analytics RLS (CRIT-2)

### DIFF
--- a/apps/admin/src/lib/analytics-queries.ts
+++ b/apps/admin/src/lib/analytics-queries.ts
@@ -108,7 +108,12 @@ export function computeMetrics(
   sessions: SessionRow[],
   submissions: Pick<SubmissionRow, 'data_source'>[],
 ): AdminMetrics {
-  const uniqueUserIds = new Set(sessions.filter((s) => s.user_id).map((s) => s.user_id));
+  // "Unique users" = distinct real (non-anonymous) accounts. After the
+  // 008 RLS lockdown every session has a non-null user_id (anonymous sign-in
+  // users too), so we key on the is_anonymous flag instead of user_id null.
+  const uniqueUserIds = new Set(
+    sessions.filter((s) => !s.is_anonymous && s.user_id).map((s) => s.user_id),
+  );
 
   // Average session duration derived from ended_at - created_at
   const durations = sessions
@@ -141,7 +146,7 @@ export function computeMetrics(
   return {
     totalSessions: sessions.length,
     uniqueUsers: uniqueUserIds.size,
-    anonymousSessions: sessions.filter((s) => !s.user_id).length,
+    anonymousSessions: sessions.filter((s) => s.is_anonymous).length,
     totalSubmissions: submissions.length,
     avgDurationMinutes,
     topReferrer,

--- a/apps/admin/src/lib/types.ts
+++ b/apps/admin/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface SessionRow {
   created_at: string;
   anonymous_id: string;
   user_id: string | null;
+  is_anonymous: boolean;
   app_name: string;
   app_version: string | null;
   country_code: string | null;

--- a/packages/community/src/analytics.ts
+++ b/packages/community/src/analytics.ts
@@ -1,6 +1,11 @@
 // Lightweight usage analytics.
 // All calls no-op if Supabase is not configured or session init failed.
 // Analytics never throws — all errors are silently caught.
+//
+// After the 008 RLS lockdown, writes require a verified auth.uid(). We
+// sign in anonymously (Supabase's built-in anonymous auth) before the
+// first session write so every insert / update carries a JWT whose `sub`
+// matches the session's owner column.
 
 import { getSupabase, supabaseEnabled, supabaseUrl, supabaseAnonKey } from './supabase.ts';
 
@@ -19,6 +24,11 @@ export type AnalyticsEventName =
 
 let sessionId: string | null = null;
 let sessionEndRegistered = false;
+// Cached access token for the raw-fetch heartbeat / pagehide paths. Kept
+// in module state so the pagehide handler (which can't await) has a
+// current token to send. Refreshed via `onAuthStateChange` below.
+let cachedAccessToken: string | null = null;
+let authStateSubscribed = false;
 
 function getAnonymousId(): string {
   let id = sessionStorage.getItem('calab_anon_id');
@@ -47,6 +57,38 @@ function extractDomain(url: string): string | null {
 }
 
 /**
+ * Ensure a Supabase auth session exists (real user or anonymous) and
+ * cache the access token. Returns the access token, or null if auth is
+ * unavailable / sign-in fails.
+ *
+ * If the user is already signed in (real account), reuse that session.
+ * Otherwise call `signInAnonymously` to get a short-lived anon user.
+ */
+async function ensureAuth(): Promise<string | null> {
+  if (!supabaseEnabled) return null;
+  const supabase = await getSupabase();
+  if (!supabase) return null;
+
+  if (!authStateSubscribed) {
+    authStateSubscribed = true;
+    supabase.auth.onAuthStateChange((_event, session) => {
+      cachedAccessToken = session?.access_token ?? null;
+    });
+  }
+
+  const { data: existing } = await supabase.auth.getSession();
+  if (existing.session) {
+    cachedAccessToken = existing.session.access_token;
+    return cachedAccessToken;
+  }
+
+  const { data, error } = await supabase.auth.signInAnonymously();
+  if (error || !data.session) return null;
+  cachedAccessToken = data.session.access_token;
+  return cachedAccessToken;
+}
+
+/**
  * Initialize an analytics session by calling the geo-session Edge Function.
  * Stores the returned session_id for subsequent trackEvent calls.
  */
@@ -57,6 +99,9 @@ export async function initSession(
   if (!supabaseEnabled) return;
 
   try {
+    const token = await ensureAuth();
+    if (!token) return;
+
     const supabase = await getSupabase();
     if (!supabase) return;
 
@@ -119,13 +164,15 @@ function startHeartbeat(): void {
 
   const tick = () => {
     if (!sessionId || document.visibilityState === 'hidden') return;
+    const token = cachedAccessToken;
+    if (!token) return;
     try {
       fetch(`${supabaseUrl}/rest/v1/analytics_sessions?id=eq.${sessionId}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           apikey: supabaseAnonKey!,
-          Authorization: `Bearer ${supabaseAnonKey}`,
+          Authorization: `Bearer ${token}`,
           Prefer: 'return=minimal',
         },
         body: JSON.stringify({ ended_at: new Date().toISOString() }),
@@ -155,6 +202,8 @@ function registerSessionEndListeners(): void {
 
   const handleEnd = () => {
     if (ended || !sessionId || !supabaseUrl || !supabaseAnonKey) return;
+    const token = cachedAccessToken;
+    if (!token) return;
     ended = true;
 
     try {
@@ -163,7 +212,7 @@ function registerSessionEndListeners(): void {
         headers: {
           'Content-Type': 'application/json',
           apikey: supabaseAnonKey,
-          Authorization: `Bearer ${supabaseAnonKey}`,
+          Authorization: `Bearer ${token}`,
           Prefer: 'return=minimal',
         },
         body: JSON.stringify({ ended_at: new Date().toISOString() }),

--- a/supabase/functions/geo-session/index.ts
+++ b/supabase/functions/geo-session/index.ts
@@ -77,15 +77,28 @@ function resolveGeo(req: Request): { countryCode: string | null; regionName: str
   };
 }
 
+interface ResolvedUser {
+  id: string | null;
+  isAnonymous: boolean;
+}
+
 /**
  * Resolve the authenticated user via a verified Supabase session, not by
  * parsing the JWT payload directly. The previous implementation did
  * `JSON.parse(atob(...))` on the bearer token body — if the gateway ever
  * shipped with verify_jwt disabled (or a future config flip), `sub` could
  * be forged by any caller.
+ *
+ * Returns both the user id and whether the account is anonymous (Supabase
+ * sets `is_anonymous: true` on accounts created via `signInAnonymously`).
+ * The flag is stored on the session row so the admin UI can distinguish
+ * anonymous visitors from logged-in users even though both now carry a
+ * non-null `user_id`.
  */
-async function resolveUserId(authHeader: string | null): Promise<string | null> {
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+async function resolveUser(authHeader: string | null): Promise<ResolvedUser> {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { id: null, isAnonymous: false };
+  }
   const token = authHeader.slice('Bearer '.length);
   try {
     const userClient = createClient(
@@ -94,9 +107,12 @@ async function resolveUserId(authHeader: string | null): Promise<string | null> 
       { global: { headers: { Authorization: `Bearer ${token}` } } },
     );
     const { data } = await userClient.auth.getUser();
-    return data.user?.id ?? null;
+    return {
+      id: data.user?.id ?? null,
+      isAnonymous: data.user?.is_anonymous ?? false,
+    };
   } catch {
-    return null;
+    return { id: null, isAnonymous: false };
   }
 }
 
@@ -125,7 +141,15 @@ Deno.serve(async (req) => {
     }
 
     const geo = resolveGeo(req);
-    const userId = await resolveUserId(req.headers.get('authorization'));
+    const user = await resolveUser(req.headers.get('authorization'));
+
+    // Require a verified user (anonymous or real). Without one, RLS on
+    // the sessions table would block every subsequent client write
+    // (heartbeat, event inserts, pagehide), so creating a bare session
+    // row would just produce silent orphans.
+    if (!user.id) {
+      return jsonResponse({ error: 'authentication required' }, 401, origin);
+    }
 
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
@@ -136,7 +160,8 @@ Deno.serve(async (req) => {
       .from('analytics_sessions')
       .insert({
         anonymous_id: body.anonymous_id,
-        user_id: userId,
+        user_id: user.id,
+        is_anonymous: user.isAnonymous,
         app_name: body.app_name,
         app_version: body.app_version ?? null,
         country_code: geo.countryCode,

--- a/supabase/migrations/008_analytics_rls_lockdown.sql
+++ b/supabase/migrations/008_analytics_rls_lockdown.sql
@@ -1,0 +1,96 @@
+-- Tighten analytics RLS (CRIT-2).
+--
+-- The 003 policies let any anon caller with the publishable key forge
+-- `user_id`, inject events against any `session_id`, and mutate any session
+-- row by UUID. This migration:
+--
+-- 1. Adds an `is_anonymous` column so the admin UI can still distinguish
+--    anonymous visitors from logged-in users now that every session carries
+--    a `user_id` (anon or real).
+-- 2. Adds data-integrity CHECK constraints (duration bounds, ended_at
+--    ordering, event_data size cap) that were missing.
+-- 3. Replaces the permissive policies with ownership-based ones keyed to
+--    `auth.uid()`. Writes require a signed-in user (anonymous or real) so
+--    the JWT identifies the owner.
+--
+-- Client flow after this migration: the client calls
+-- `supabase.auth.signInAnonymously()` before `initSession`, then all writes
+-- carry a verified JWT whose `sub` matches the session's `user_id`.
+
+-- 1. is_anonymous column.
+-- Backfill: before this migration, the pre-existing "anonymous" sessions
+-- were the ones with `user_id IS NULL`. New-schema anon sessions will
+-- carry an anonymous-auth user id, so we default the column to true and
+-- then flip pre-existing logged-in sessions to false.
+ALTER TABLE analytics_sessions
+  ADD COLUMN is_anonymous BOOLEAN NOT NULL DEFAULT true;
+
+UPDATE analytics_sessions
+  SET is_anonymous = false
+  WHERE user_id IS NOT NULL;
+
+-- 2. CHECK constraints
+ALTER TABLE analytics_sessions
+  ADD CONSTRAINT analytics_sessions_ended_at_order_check
+    CHECK (ended_at IS NULL OR ended_at >= created_at);
+
+ALTER TABLE analytics_sessions
+  ADD CONSTRAINT analytics_sessions_duration_bounds_check
+    CHECK (
+      duration_seconds IS NULL
+      OR (duration_seconds >= 0 AND duration_seconds <= 86400)
+    );
+
+-- Event payloads are intentionally free-form JSON but should not be used as
+-- free storage. 4 KB is enough for any legitimate high-level event.
+ALTER TABLE analytics_events
+  ADD CONSTRAINT analytics_events_event_data_size_check
+    CHECK (length(event_data::text) <= 4096);
+
+-- 3. Replace permissive policies with ownership-based ones.
+DROP POLICY IF EXISTS "Anyone can insert sessions" ON analytics_sessions;
+DROP POLICY IF EXISTS "Anyone can update session end" ON analytics_sessions;
+DROP POLICY IF EXISTS "Anyone can insert events" ON analytics_events;
+
+-- Sessions: caller's auth.uid() must match the inserted/updated row.
+-- `authenticated` in Supabase includes both real users and anonymous
+-- sign-in users — both paths get a verified JWT.
+CREATE POLICY "Users insert own sessions"
+  ON analytics_sessions FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users update own sessions"
+  ON analytics_sessions FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Callers can read their own session rows. Needed so the events INSERT
+-- policy's EXISTS subquery (below) can see the caller's session — RLS
+-- subqueries run with the caller's privileges, so without this policy
+-- the subquery would find nothing and the events INSERT would be denied
+-- for everyone except admins.
+CREATE POLICY "Users read own sessions"
+  ON analytics_sessions FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- Events: session_id must reference a session the caller owns.
+CREATE POLICY "Users insert events for own sessions"
+  ON analytics_events FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM analytics_sessions
+      WHERE analytics_sessions.id = analytics_events.session_id
+        AND analytics_sessions.user_id = auth.uid()
+    )
+  );
+
+-- 4. Revoke any lingering anon-role writes. RLS already blocks anon
+-- (no `TO anon` policy exists), but revoking the table-level grants
+-- makes the intent explicit and belts-and-suspenders against a future
+-- accidental `CREATE POLICY ... TO anon`.
+REVOKE INSERT, UPDATE ON analytics_sessions FROM anon;
+REVOKE INSERT ON analytics_events FROM anon;


### PR DESCRIPTION
## Summary

Closes **CRIT-2** from the audit. The `003_analytics.sql` policies let any anon caller with the publishable key:

- Forge `user_id` attribution on new session rows
- Inject events against any `session_id` UUID
- Mutate `ended_at` / `duration_seconds` on any session row by UUID

The `geo-session` edge function was meant to be the controlled entry point, but the permissive RLS policies let clients bypass it via the REST API.

## What changed

**Migration** (`supabase/migrations/008_analytics_rls_lockdown.sql`)
- Adds `is_anonymous` column (backfilled from prior `user_id` null/non-null split) so the admin UI can still distinguish anon visitors from logged-in users now that every session carries a `user_id`.
- Adds CHECK constraints: `duration_seconds ∈ [0, 86400]`, `ended_at >= created_at`, `event_data` ≤ 4 KB.
- Replaces permissive policies with ownership-based ones keyed to `auth.uid()`.
- `REVOKE INSERT, UPDATE` from `anon` on both tables as a belt-and-suspenders.

**Client** (`packages/community/src/analytics.ts`)
- Calls `supabase.auth.signInAnonymously()` before the first session write so every insert/update carries a verified JWT.
- Caches `access_token` in module state (refreshed via `onAuthStateChange`) so the `pagehide` handler — which can't await — can attach a current `Bearer` token to the `keepalive` PATCH.

**Edge function** (`supabase/functions/geo-session/index.ts`)
- `resolveUser()` returns `is_anonymous` (from the verified JWT) alongside the user id; inserted row carries the flag.
- Rejects requests without a verified user — an RLS-incompatible session row would produce silent orphans on every subsequent client write.

**Admin** (`apps/admin/src/lib/*.ts`)
- `SessionRow` gains `is_anonymous`; the "Anonymous Sessions" and "Unique Users" tiles switch from `user_id` null-check to the new flag.

## Deployment coordination

The migration and the client change must ship together — applying the migration without the client deploy will break analytics (old clients won't have a JWT attached to their heartbeat/pagehide PATCHes). Recommended order:

1. Merge this PR.
2. Deploy the edge function (`supabase functions deploy geo-session`).
3. Apply the migration (`supabase db push` or the SQL editor).
4. Deploy the Pages build (catune/carank/cadecon/admin).

Step 3 before step 4 is fine: the migration only breaks old clients' heartbeat/pagehide (which already silently-catch errors), and step 4 lands minutes later.

**Prereq:** anonymous sign-ins enabled in the Supabase dashboard (Auth → Providers → Email → "Allow anonymous sign-ins"). Already done.

## Test plan

- [x] Typecheck: `npm run typecheck` — clean
- [x] Lint: `npm run lint` — no new warnings
- [x] Unit tests: `npm run test` — all passing
- [x] Local migration test against throwaway Postgres 16:
  - Backfill: pre-existing rows with `user_id IS NULL` → `is_anonymous=true`, non-null → `false`
  - Own-session INSERT passes under authenticated JWT
  - Forged `user_id` INSERT rejected (`new row violates row-level security policy`)
  - Cross-user UPDATE returns 0 rows (RLS `USING` filter)
  - Own-session event INSERT passes
  - Cross-user event INSERT with a hardcoded leaked UUID rejected by RLS
  - `duration_seconds` out-of-bounds (`999999999`, `-1`) rejected by CHECK
  - `ended_at < created_at` rejected by CHECK
  - `event_data > 4 KB` rejected by CHECK
  - `anon` role cannot INSERT/UPDATE on either table (REVOKE effective)
- [ ] Post-deploy: verify analytics flow in devtools (anon sign-in, session created, events tracked, heartbeat + pagehide both 204)
- [ ] Post-deploy: curl attack from `bash` with just the publishable key — confirm 401/403/PGRST-level denial on INSERT/UPDATE against both tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)