### PR TITLE
refactor: prune unused exports, internalize test-only surface

### DIFF
--- a/apps/cadecon/src/components/traces/TraceInspector.tsx
+++ b/apps/cadecon/src/components/traces/TraceInspector.tsx
@@ -64,7 +64,7 @@ const DECONV_SCALE = 0.35;
 const RESID_GAP_FRAC = 0.05;
 const RESID_SCALE = 0.25;
 const TRANSIENT_TAU_MULTIPLIER = 2;
-const DEFAULT_ZOOM_WINDOW_S = 60;
+const TRACE_INSPECTOR_ZOOM_WINDOW_S = 60;
 
 interface BandLayout {
   deconvTop: number;
@@ -218,7 +218,7 @@ export function TraceInspector(): JSX.Element {
   });
 
   const [zoomStart, setZoomStart] = createSignal(0);
-  const [zoomEnd, setZoomEnd] = createSignal(DEFAULT_ZOOM_WINDOW_S);
+  const [zoomEnd, setZoomEnd] = createSignal(TRACE_INSPECTOR_ZOOM_WINDOW_S);
 
   // Reset zoom only when the selected cell changes — NOT on iteration updates.
   // Uses `on()` with explicit deps to avoid tracking totalDuration/transientEnd
@@ -229,7 +229,7 @@ export function TraceInspector(): JSX.Element {
       if (dur <= 0) return;
       const te = transientEnd();
       setZoomStart(te);
-      setZoomEnd(Math.min(te + DEFAULT_ZOOM_WINDOW_S, dur));
+      setZoomEnd(Math.min(te + TRACE_INSPECTOR_ZOOM_WINDOW_S, dur));
     }),
   );
 

--- a/apps/catune/src/components/cards/CellCard.tsx
+++ b/apps/catune/src/components/cards/CellCard.tsx
@@ -12,7 +12,7 @@ import { computePeakSNR, snrToQuality } from '@calab/core';
 import { Card } from '@calab/ui';
 import { setHoveredCell } from '../../lib/multi-cell-store.ts';
 import { cardHeight, setCardHeight, currentTau } from '../../lib/viz-store.ts';
-import { DEFAULT_ZOOM_WINDOW_S } from '../../lib/cell-solve-manager.ts';
+import { CELL_CARD_ZOOM_WINDOW_S } from '../../lib/cell-solve-manager.ts';
 
 export interface CellCardProps {
   cellIndex: number;
@@ -54,14 +54,14 @@ export function CellCard(props: CellCardProps) {
   });
   const [zoomStart, setZoomStart] = createSignal(transientEnd());
   const [zoomEnd, setZoomEnd] = createSignal(
-    Math.min(transientEnd() + DEFAULT_ZOOM_WINDOW_S, totalDuration()),
+    Math.min(transientEnd() + CELL_CARD_ZOOM_WINDOW_S, totalDuration()),
   );
 
   // Sync zoom end when trace changes
   createEffect(() => {
     const dur = totalDuration();
     if (zoomEnd() > dur) setZoomEnd(dur);
-    if (zoomEnd() <= zoomStart()) setZoomEnd(Math.min(zoomStart() + DEFAULT_ZOOM_WINDOW_S, dur));
+    if (zoomEnd() <= zoomStart()) setZoomEnd(Math.min(zoomStart() + CELL_CARD_ZOOM_WINDOW_S, dur));
   });
 
   const handleZoomChange = (start: number, end: number) => {

--- a/apps/catune/src/lib/cell-solve-manager.ts
+++ b/apps/catune/src/lib/cell-solve-manager.ts
@@ -27,7 +27,7 @@ const DEBOUNCE_MS = 30;
 // starving the UI event loop. 200 iterations keeps quanta under ~40ms for typical traces while
 // reducing round-trip overhead by ~13×. Cancel responsiveness is still ~2ms via BATCH_SIZE yields.
 const QUANTUM_ITERATIONS = 200;
-export const DEFAULT_ZOOM_WINDOW_S = 20;
+export const CELL_CARD_ZOOM_WINDOW_S = 20;
 
 interface CellSolveState {
   cellIndex: number;
@@ -290,7 +290,7 @@ function ensureCellState(
       cellIndex,
       rawTrace,
       zoomStart: Math.min(zoomOffset, duration),
-      zoomEnd: Math.min(zoomOffset + DEFAULT_ZOOM_WINDOW_S, duration),
+      zoomEnd: Math.min(zoomOffset + CELL_CARD_ZOOM_WINDOW_S, duration),
       warmStartCache: new WarmStartCache(),
       activeJobId: null,
       debounceTimer: null,

--- a/packages/community/src/index.ts
+++ b/packages/community/src/index.ts
@@ -10,7 +10,6 @@ export { createSubmissionService } from './submission-service.ts';
 export type { SubmissionService } from './submission-service.ts';
 
 // Field options
-export { fetchFieldOptions } from './field-options-service.ts';
 export {
   INDICATOR_OPTIONS,
   SPECIES_OPTIONS,

--- a/packages/compute/src/__tests__/kernel-shape.test.ts
+++ b/packages/compute/src/__tests__/kernel-shape.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { tauToShape, shapeToTau, computeFWHM, isValidShapePair } from '@calab/compute';
-import { SIMULATION_PRESETS } from '@calab/compute';
+import { tauToShape, shapeToTau, computeFWHM, isValidShapePair } from '../kernel-shape.ts';
+import { SIMULATION_PRESETS } from '../simulation-presets.ts';
 
 describe('tauToShape', () => {
   it('returns null for degenerate inputs (tauDecay <= tauRise)', () => {

--- a/packages/compute/src/__tests__/warm-start-cache.test.ts
+++ b/packages/compute/src/__tests__/warm-start-cache.test.ts
@@ -4,7 +4,7 @@ import {
   shouldWarmStart,
   WarmStartCache,
   type WarmStartEntry,
-} from '@calab/compute';
+} from '../warm-start-cache.ts';
 import type { SolverParams } from '@calab/core';
 
 // ---------- computePaddedWindow ----------

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -3,41 +3,19 @@ export type { WorkerPool, BaseJob, MessageRouter } from './worker-pool.ts';
 export { createCaTuneWorkerPool } from './catune-pool.ts';
 export type { CaTunePoolJob } from './catune-pool.ts';
 export { resolveWorkerCount, getWorkersOverride, getDefaultWorkerCount } from './worker-sizing.ts';
-export {
-  computePaddedWindow,
-  computeSafeMargin,
-  shouldWarmStart,
-  WarmStartCache,
-} from './warm-start-cache.ts';
-export type { WarmStartEntry } from './warm-start-cache.ts';
+export { computePaddedWindow, computeSafeMargin, WarmStartCache } from './warm-start-cache.ts';
 export { computeKernel, computeKernelAnnotations } from './kernel-math.ts';
-export { tauToShape, shapeToTau, computeFWHM, isValidShapePair } from './kernel-shape.ts';
+export { tauToShape, shapeToTau, isValidShapePair } from './kernel-shape.ts';
 export { downsampleMinMax } from './downsample.ts';
 export { makeTimeAxis } from './time-axis.ts';
 export { generateSyntheticTrace } from './mock-traces.ts';
-// Simulation types
-export type {
-  SimulationConfig,
-  SimulationResult,
-  CellGroundTruth,
-  KernelConfig as SimKernelConfig,
-  NoiseConfig as SimNoiseConfig,
-  MarkovConfig,
-  PoissonConfig,
-  SpikeModel,
-  SinusoidalDrift,
-  RandomWalkDrift,
-  DriftModel,
-  PhotobleachingConfig,
-  SaturationConfig,
-} from './simulation-types.ts';
+// Simulation types consumed by apps' data-store. Internal shape
+// sub-types (MarkovConfig, SpikeModel, etc.) stay unexported — they're
+// reachable through SimulationConfig for type inference without leaking
+// into the public API.
+export type { SimulationConfig, SimulationResult } from './simulation-types.ts';
 export type { SimulationPreset } from './simulation-presets.ts';
-export {
-  SIMULATION_PRESETS,
-  DEFAULT_SIMULATION_PRESET_ID,
-  getSimulationPresetById,
-  getSimulationPresetLabels,
-} from './simulation-presets.ts';
+export { getSimulationPresetLabels } from './simulation-presets.ts';
 // Qualitative presets (per-step level selections for UI)
 export type { QualitativeSimConfig, IndicatorId } from './simulation-quality-presets.ts';
 export {

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -15,6 +15,5 @@ export {
   exportCaDeconToBridge,
   startBridgeHeartbeat,
   stopBridgeHeartbeat,
-  BRIDGE_CONFIG_KEYS,
 } from './bridge.ts';
 export type { BridgeMetadata, BridgeConfig, BridgeProgress } from './bridge.ts';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,8 +11,6 @@ export { TutorialLauncher } from './TutorialLauncher.tsx';
 export type { TutorialLauncherProps } from './TutorialLauncher.tsx';
 export { Card } from './Card.tsx';
 export type { CardProps } from './Card.tsx';
-export { AuthMenu } from './AuthMenu.tsx';
-export type { AuthMenuProps } from './AuthMenu.tsx';
 export { AuthCallback } from './AuthCallback.tsx';
 export type { AuthCallbackProps } from './AuthCallback.tsx';
 export { AuthMenuWrapper } from './AuthMenuWrapper.tsx';


### PR DESCRIPTION
## Summary

Closes **DEAD-M2, DEAD-M3, DEAD-M4, DEAD-M5, DEAD-2** from the audit — purely subtractive refactor across the four shared packages plus two constant renames.

## What changed

**`@calab/compute`** (DEAD-M2, DEAD-2)
- Dropped 15 unused public exports: `SimKernelConfig`, `SimNoiseConfig`, `MarkovConfig`, `PoissonConfig`, `SpikeModel`, `SinusoidalDrift`, `RandomWalkDrift`, `DriftModel`, `PhotobleachingConfig`, `SaturationConfig`, `CellGroundTruth`, `SIMULATION_PRESETS`, `DEFAULT_SIMULATION_PRESET_ID`, `getSimulationPresetById`, `computeFWHM`.
- Apps only named `SimulationConfig`, `SimulationResult`, `SimulationPreset`, `getSimulationPresetLabels` — those stay.
- Dropped `shouldWarmStart` / `WarmStartEntry` from the public surface (DEAD-2). They were exported only to satisfy one test that lived in `apps/catune`.
- **Moved that test** to the owning package:
  - `apps/catune/src/__tests__/job-scheduler.test.ts` → `packages/compute/src/__tests__/warm-start-cache.test.ts`
  - New name reflects what it actually tests (`warm-start-cache.ts` + `computePaddedWindow`), not catune job scheduling.
  - Imports switched to relative paths.
- Updated `packages/compute/src/__tests__/kernel-shape.test.ts` to use relative imports for now-internal `computeFWHM` / `SIMULATION_PRESETS`.

**`@calab/io`** (DEAD-2)
- Dropped `BRIDGE_CONFIG_KEYS`. The one consumer is the sibling `bridge-config.test.ts` which already imports from `'../bridge.ts'`.

**`@calab/ui`** (DEAD-M3)
- Dropped `AuthMenu` / `AuthMenuProps`. All apps use `AuthMenuWrapper`; `AuthMenu` is only used internally by the wrapper.

**`@calab/community`** (DEAD-M4)
- Dropped `fetchFieldOptions`. Only consumer is the sibling `community-store.ts`.

**`DEFAULT_ZOOM_WINDOW_S`** (DEAD-M5)
- `apps/catune`: `DEFAULT_ZOOM_WINDOW_S` (=20s) → `CELL_CARD_ZOOM_WINDOW_S`
- `apps/cadecon`: `DEFAULT_ZOOM_WINDOW_S` (=60s) → `TRACE_INSPECTOR_ZOOM_WINDOW_S`
- Renamed rather than consolidated into a shared config: both are per-app UI defaults for distinct views, and the prior identical names suggested a global default that didn't exist. Scoping the names to their component makes the divergence obvious instead of looking like accidental drift.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 25 pre-existing solid-reactivity warnings, unchanged
- [x] \`npm run format:check\` — clean (one prettier autofix on the rewritten compute/index.ts)
- [x] \`npm run test\` — all suites green (compute now has 59 tests including the 16 moved warm-start tests)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)