### PR TITLE
fix: logic + UX polish — tau constraints, bridge errors, reactivity

### DIFF
--- a/apps/cadecon/src/components/community/GroundTruthControls.tsx
+++ b/apps/cadecon/src/components/community/GroundTruthControls.tsx
@@ -9,6 +9,8 @@ import {
   toggleGroundTruthVisibility,
   bridgeUrl,
   bridgeExportDone,
+  bridgeExportError,
+  setBridgeExportError,
 } from '../../lib/data-store.ts';
 import { runState } from '../../lib/iteration-store.ts';
 import { isBridgeAutorun, runBridgeExport } from '../../lib/bridge-effects.ts';
@@ -50,7 +52,9 @@ export function GroundTruthNotices(): JSX.Element {
 
 export function ExportButton(): JSX.Element {
   const [exporting, setExporting] = createSignal(false);
-  const [error, setError] = createSignal<string | null>(null);
+  // Manual-export errors route through the shared bridgeExportError signal
+  // so both manual- and autorun-path failures surface in the same place.
+  const error = bridgeExportError;
 
   const isComplete = () => runState() === 'complete';
   const isBridge = () => !!bridgeUrl();
@@ -61,11 +65,11 @@ export function ExportButton(): JSX.Element {
     if (!url) return;
 
     setExporting(true);
-    setError(null);
+    setBridgeExportError(null);
     try {
       await runBridgeExport(url);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Export failed');
+      setBridgeExportError(e instanceof Error ? e.message : 'Export failed');
     } finally {
       setExporting(false);
     }

--- a/apps/cadecon/src/lib/bridge-effects.ts
+++ b/apps/cadecon/src/lib/bridge-effects.ts
@@ -26,7 +26,12 @@ import {
   currentTauDecay,
 } from './iteration-store.ts';
 import { maxIterations } from './algorithm-store.ts';
-import { bridgeUrl, setBridgeExportDone, bridgeExportDone } from './data-store.ts';
+import {
+  bridgeUrl,
+  setBridgeExportDone,
+  bridgeExportDone,
+  setBridgeExportError,
+} from './data-store.ts';
 import { startRun } from './iteration-manager.ts';
 import { buildCaDeconActivityMatrix, buildCaDeconResultsPayload } from './export-utils.ts';
 
@@ -126,7 +131,11 @@ export function setupBridgeEffects(): void {
       const url = bridgeUrl();
       if (!url) return;
 
-      void runBridgeExport(url).catch((err) => console.error('Auto-export failed:', err));
+      void runBridgeExport(url).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Auto-export failed';
+        console.error('Auto-export failed:', err);
+        setBridgeExportError(message);
+      });
     }),
   );
 }

--- a/apps/cadecon/src/lib/data-store.ts
+++ b/apps/cadecon/src/lib/data-store.ts
@@ -26,6 +26,7 @@ const [dataSource, setDataSource] = createSignal<DataSource>(null);
 
 const [demoConfig, setDemoConfig] = createSignal<SimulationConfig | null>(null);
 const [bridgeExportDone, setBridgeExportDone] = createSignal(false);
+const [bridgeExportError, setBridgeExportError] = createSignal<string | null>(null);
 const [groundTruthSpikes, setGroundTruthSpikes] = createSignal<Float64Array | null>(null);
 const [groundTruthCalcium, setGroundTruthCalcium] = createSignal<Float64Array | null>(null);
 const [groundTruthVisible, setGroundTruthVisible] = createSignal(false);
@@ -246,6 +247,8 @@ export {
   demoConfig,
   bridgeExportDone,
   setBridgeExportDone,
+  bridgeExportError,
+  setBridgeExportError,
   groundTruthSpikes,
   groundTruthCalcium,
   groundTruthVisible,

--- a/apps/catune/src/components/cards/CellCard.tsx
+++ b/apps/catune/src/components/cards/CellCard.tsx
@@ -3,7 +3,7 @@
  * Self-contained visualization for one cell in the card grid.
  */
 
-import { createSignal, createMemo, createEffect, Show } from 'solid-js';
+import { createSignal, createMemo, createEffect, untrack, Show } from 'solid-js';
 import { TraceOverview, ROW_HEIGHT, ROW_DURATION_S } from '@calab/ui/chart';
 import { CaTuneZoomWindow } from './CaTuneZoomWindow.tsx';
 import { QualityBadge } from '../metrics/QualityBadge.tsx';
@@ -52,16 +52,31 @@ export function CellCard(props: CellCardProps) {
   const transientEnd = createMemo(() => {
     return Math.min(2 * currentTau().tauDecay, totalDuration());
   });
-  const [zoomStart, setZoomStart] = createSignal(transientEnd());
+  // Initial zoom snapshot via `untrack` — the signals below aren't derived
+  // from `transientEnd`, they're *seeded* from it. Subsequent tau or trace
+  // changes are handled by the effects that follow.
+  const [zoomStart, setZoomStart] = createSignal(untrack(transientEnd));
   const [zoomEnd, setZoomEnd] = createSignal(
-    Math.min(transientEnd() + CELL_CARD_ZOOM_WINDOW_S, totalDuration()),
+    untrack(() => Math.min(transientEnd() + CELL_CARD_ZOOM_WINDOW_S, totalDuration())),
   );
 
-  // Sync zoom end when trace changes
+  // Clamp zoom to duration when trace length changes.
   createEffect(() => {
     const dur = totalDuration();
     if (zoomEnd() > dur) setZoomEnd(dur);
     if (zoomEnd() <= zoomStart()) setZoomEnd(Math.min(zoomStart() + CELL_CARD_ZOOM_WINDOW_S, dur));
+  });
+
+  // When tau_decay grows, the convolution transient grows with it — push
+  // zoomStart past the new transient so the user isn't staring at a region
+  // dominated by edge effects. Without this the initial snapshot goes stale
+  // on tuning changes.
+  createEffect(() => {
+    const te = transientEnd();
+    if (zoomStart() < te) {
+      setZoomStart(te);
+      if (zoomEnd() <= te) setZoomEnd(Math.min(te + CELL_CARD_ZOOM_WINDOW_S, totalDuration()));
+    }
   });
 
   const handleZoomChange = (start: number, end: number) => {

--- a/apps/catune/src/components/community/SubmissionSummary.tsx
+++ b/apps/catune/src/components/community/SubmissionSummary.tsx
@@ -13,6 +13,15 @@ interface SubmissionSummaryProps {
 }
 
 export function SubmissionSummary(props: SubmissionSummaryProps) {
+  // Extracting the async handler out of the JSX props avoids the
+  // `solid/reactivity` lint rule flagging an inline async arrow as a
+  // tracked scope — it isn't a tracked scope, but the rule can't tell
+  // once the handler is bound to a prop named `onDelete`.
+  async function handleDelete(id: string): Promise<void> {
+    await deleteSubmission(id);
+    props.onDelete();
+  }
+
   return (
     <SharedSubmissionSummary
       submission={props.submission}
@@ -24,10 +33,7 @@ export function SubmissionSummary(props: SubmissionSummaryProps) {
         </>
       )}
       onDismiss={props.onDismiss}
-      onDelete={async (id: string) => {
-        await deleteSubmission(id);
-        props.onDelete();
-      }}
+      onDelete={handleDelete}
     />
   );
 }

--- a/apps/catune/src/components/community/SubmitPanel.tsx
+++ b/apps/catune/src/components/community/SubmitPanel.tsx
@@ -20,6 +20,8 @@ import {
   bridgeUrl,
   bridgeExportDone,
   setBridgeExportDone,
+  bridgeExportError,
+  setBridgeExportError,
 } from '../../lib/data-store.ts';
 import { buildExportData, downloadExport, postParamsToBridge } from '@calab/io';
 import type { CaTuneExport } from '@calab/io';
@@ -92,9 +94,12 @@ export function SubmitPanel() {
   function handleBridgeExport(): void {
     const url = bridgeUrl();
     if (!url) return;
+    setBridgeExportError(null);
     postParamsToBridge(url, buildCurrentExport())
       .then(() => setBridgeExportDone(true))
-      .catch(() => {});
+      .catch((err: unknown) => {
+        setBridgeExportError(err instanceof Error ? err.message : 'Bridge export failed');
+      });
   }
 
   async function handleSubmit(): Promise<void> {
@@ -202,6 +207,12 @@ export function SubmitPanel() {
               Export to Python
             </button>
           </Show>
+        </Show>
+
+        <Show when={bridgeExportError()}>
+          <span class="submit-panel__error" role="alert">
+            {bridgeExportError()}
+          </span>
         </Show>
 
         <GroundTruthControls />

--- a/apps/catune/src/lib/data-store.ts
+++ b/apps/catune/src/lib/data-store.ts
@@ -23,6 +23,7 @@ const [importError, setImportError] = createSignal<string | null>(null);
 const [demoConfig, setDemoConfig] = createSignal<SimulationConfig | null>(null);
 const [bridgeUrl, setBridgeUrl] = createSignal<string | null>(null);
 const [bridgeExportDone, setBridgeExportDone] = createSignal(false);
+const [bridgeExportError, setBridgeExportError] = createSignal<string | null>(null);
 
 /** Tracks how data was loaded: 'file' (user upload), 'demo' (generated), 'bridge' (Python calab.tune). */
 export type DataSource = 'file' | 'demo' | 'bridge' | null;
@@ -247,6 +248,8 @@ export {
   bridgeUrl,
   bridgeExportDone,
   setBridgeExportDone,
+  bridgeExportError,
+  setBridgeExportError,
   // Data source tracking
   dataSource,
   setDataSource,

--- a/packages/community/src/community-store.ts
+++ b/packages/community/src/community-store.ts
@@ -42,26 +42,35 @@ const [fieldOptions, setFieldOptions] = createSignal<FieldOptions>({
   cellTypes: CELL_TYPE_OPTIONS,
 });
 const [fieldOptionsLoading, setFieldOptionsLoading] = createSignal(false);
-let fieldOptionsLoaded = false;
+// Cached in-flight fetch. Collapsing the "already loading" and "already
+// loaded" gates into a single promise avoids a race where two concurrent
+// callers both see the boolean flags as false and issue duplicate
+// requests. Subsequent calls re-await the cached promise.
+let fieldOptionsPromise: Promise<void> | null = null;
 
 /**
  * Load canonical field options from Supabase.
- * Idempotent — only fetches once. Falls back to hardcoded arrays on failure.
+ * Idempotent — concurrent / repeated callers share a single fetch.
+ * Falls back to hardcoded arrays on failure.
  */
 async function loadFieldOptions(): Promise<void> {
-  if (fieldOptionsLoaded || fieldOptionsLoading()) return;
   if (!supabaseEnabled) return; // Keep fallback arrays
+  if (fieldOptionsPromise) return fieldOptionsPromise;
 
   setFieldOptionsLoading(true);
-  try {
-    const opts = await fetchFieldOptions();
-    setFieldOptions(opts);
-    fieldOptionsLoaded = true;
-  } catch (err) {
-    console.warn('Failed to load field options from DB, using fallback:', err);
-  } finally {
-    setFieldOptionsLoading(false);
-  }
+  fieldOptionsPromise = (async () => {
+    try {
+      const opts = await fetchFieldOptions();
+      setFieldOptions(opts);
+    } catch (err) {
+      console.warn('Failed to load field options from DB, using fallback:', err);
+      // On failure, drop the cached promise so a later call can retry.
+      fieldOptionsPromise = null;
+    } finally {
+      setFieldOptionsLoading(false);
+    }
+  })();
+  return fieldOptionsPromise;
 }
 
 // --- Exports ---

--- a/packages/compute/src/warm-start-cache.ts
+++ b/packages/compute/src/warm-start-cache.ts
@@ -20,9 +20,22 @@ export interface WarmStartEntry {
 /**
  * Compute the overlap-and-discard padded window for artifact-free windowed computation.
  *
- * Adds >= 5 * tauDecay * fs padding samples on each side of the visible region
- * (per research Pattern 3) to prevent edge artifacts from kernel truncation.
- * The padding is clamped to trace bounds.
+ * Adds padding samples on each side of the visible region (per research
+ * Pattern 3) to prevent edge artifacts from kernel truncation. The padding
+ * target is ``max(visibleSamples, tauPadding)`` — wide enough to cover one
+ * full visible window of overlap OR the ``5 * tauDecay * fs`` artifact
+ * horizon, whichever is larger. The result is capped at ``MAX_PADDING_SECONDS``
+ * (5 min) so extreme-duration windows don't inflate solver cost without
+ * bound.
+ *
+ * **Contract: padding can be smaller than the visible window.** When the
+ * visible window is longer than 5 minutes, ``paddingSamples`` = ``maxPadding``
+ * which is less than ``visibleSamples``. Callers that assumed
+ * ``paddingSamples >= visibleSamples`` (e.g. for symmetric overlap) are
+ * wrong. The artifact-safety invariant still holds as long as
+ * ``maxPadding >= tauPadding`` — i.e. for any tauDecay with fs such that
+ * ``5 * tauDecay <= MAX_PADDING_SECONDS`` (60 s at fs=30Hz, up to tauDecay
+ * = 60 s which exceeds any physical indicator).
  *
  * @returns paddedStart/paddedEnd (solver input range), resultOffset (where visible
  *          region starts in solver output), resultLength (how many samples to extract).

--- a/supabase/migrations/009_tighten_catune_tau_constraints.sql
+++ b/supabase/migrations/009_tighten_catune_tau_constraints.sql
@@ -1,0 +1,35 @@
+-- Tighten catune_submissions tau CHECK constraints to match cadecon (LOGIC-M1).
+--
+-- Before:
+--   tau_rise  > 0  AND tau_rise  < 1
+--   tau_decay > 0  AND tau_decay < 10
+-- After (matching 006_cadecon_submissions.sql:62-63):
+--   tau_rise  >= 0.001 AND tau_rise  <= 0.5
+--   tau_decay >= 0.01  AND tau_decay <= 10
+--
+-- Same parameter semantically — calcium indicator decay kinetics — so the
+-- two tables shouldn't disagree on what's plausible. cadecon's range is
+-- the more realistic one (no GCaMP variant has tau_rise > 0.5 s).
+--
+-- Safety: any existing row in catune_submissions violating the new bounds
+-- will block the ALTER TABLE and the whole migration rolls back (Supabase
+-- runs each migration in a transaction; the explicit BEGIN/COMMIT here
+-- documents that intent and keeps the behaviour consistent if the file
+-- is ever applied manually via psql). Audit production data first if
+-- the migration fails; clean up outliers before retrying.
+
+BEGIN;
+
+ALTER TABLE catune_submissions
+  DROP CONSTRAINT valid_tau_rise;
+
+ALTER TABLE catune_submissions
+  ADD CONSTRAINT valid_tau_rise CHECK (tau_rise >= 0.001 AND tau_rise <= 0.5);
+
+ALTER TABLE catune_submissions
+  DROP CONSTRAINT valid_tau_decay;
+
+ALTER TABLE catune_submissions
+  ADD CONSTRAINT valid_tau_decay CHECK (tau_decay >= 0.01 AND tau_decay <= 10);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Addresses **LOGIC-M1, LOGIC-M2, LOGIC-M3, LOGIC-M4, DEAD-M7** from the audit.

## LOGIC-M1 — tighten catune tau CHECK constraints (new migration 009)

catune_submissions and cadecon_submissions disagreed on plausible ranges for the same physical parameter. Aligned catune to cadecon's bounds:

| | before | after |
|---|---|---|
| `tau_rise` | `(0, 1)` | `[0.001, 0.5]` |
| `tau_decay` | `(0, 10)` | `[0.01, 10]` |

Wrapped in `BEGIN/COMMIT` so a pre-existing out-of-bounds row rolls back the whole migration instead of leaving the table without either constraint.

**Verified locally against Postgres 16:**
- Blocker row present → atomic rollback; both constraints still intact at the old bounds.
- In-range data → new bounds applied.
- Post-migration INSERT at `tau_rise=0.8` → rejected.

## LOGIC-M2 — surface bridge-export failures in the UI

**catune:** `SubmitPanel.handleBridgeExport` was doing `.catch(() => {})` — every bridge failure silently dropped. Added `bridgeExportError` signal to the catune data-store, displayed inline next to the Export button; cleared on each attempt.

**cadecon:** the autorun path (`bridge-effects.ts:129`) only `console.error`-ed. Routed its error through the same new `bridgeExportError` signal in the cadecon data-store. `ExportButton`'s local error state collapsed onto the shared signal so manual- and autorun-path failures surface in the same place.

## LOGIC-M3 — document `computePaddedWindow`'s padding contract

When `visibleSamples > MAX_PADDING_SECONDS * fs`, padding caps at `maxPadding`, which is *less than* `visibleSamples`. Not a bug — the artifact-safety invariant still holds as long as `maxPadding >= tauPadding` (satisfied for any physical indicator). But callers that assumed `paddingSamples >= visibleSamples` would be wrong. Docstring now states the contract explicitly.

## LOGIC-M4 — cache the `loadFieldOptions` fetch

Previous implementation had a two-flag gate (`fieldOptionsLoaded` boolean + `fieldOptionsLoading` signal). Two concurrent callers could both read both as false and issue duplicate fetches. Collapsed to a cached in-flight `Promise` — first caller primes it, subsequent callers share it. On failure the cached promise is dropped so a retry can succeed.

## DEAD-M7 — the two reactivity warnings that were actually bugs

**`apps/catune/src/components/cards/CellCard.tsx`:** `zoomStart` / `zoomEnd` were seeded from `transientEnd()` and `totalDuration()` but never re-synced when `tau_decay` grew mid-tuning. The initial snapshot went stale and users could end up zoomed into a region dominated by the convolution transient. Wrapped the seeds in `untrack(...)` to make \"initial value, reactive elsewhere\" explicit, and added a \`createEffect\` that pushes \`zoomStart\` past the new \`transientEnd\` when \`tau_decay\` grows.

**`apps/catune/src/components/community/SubmissionSummary.tsx`:** Inline `async (id) => { ... }` on the `onDelete` prop triggered `solid/reactivity`'s async-tracked-scope warning. Extracted to a named async function so the rule sees an event-handler shape.

Lint count: **25 → 21** warnings (4 real reactivity fixes).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 21 pre-existing warnings (down from 25), no new
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — all vitest suites green
- [x] Local Postgres 16: migration 009 atomic-rollback on blocker + happy-path + post-migration rejection
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)