### PR TITLE
test: quick-wins suite — smoke, export roundtrip, sub-frame timing, warm-start gaps

### DIFF
--- a/apps/catune/src/__tests__/smoke.test.ts
+++ b/apps/catune/src/__tests__/smoke.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import { shapeToTau, tauToShape } from '@calab/compute';
 
-describe('smoke test', () => {
-  it('should pass a trivial assertion', () => {
-    expect(1 + 1).toBe(2);
+// App-level smoke: the kernel shape ↔ tau transforms that the CaTune UI
+// round-trips on every slider change are importable and invertible.
+describe('catune smoke', () => {
+  it('round-trips tau ↔ shape through @calab/compute', () => {
+    const tauIn = { tauRise: 0.02, tauDecay: 0.4 };
+    const shape = tauToShape(tauIn.tauRise, tauIn.tauDecay);
+    expect(shape).not.toBeNull();
+    const tauOut = shapeToTau(shape!.tPeak, shape!.fwhm);
+    expect(tauOut).not.toBeNull();
+    // The shape ↔ tau mapping is table-interpolated, so tolerate small drift.
+    expect(Math.abs(tauOut!.tauRise - tauIn.tauRise) / tauIn.tauRise).toBeLessThan(1e-3);
+    expect(Math.abs(tauOut!.tauDecay - tauIn.tauDecay) / tauIn.tauDecay).toBeLessThan(1e-3);
   });
 });

--- a/packages/compute/src/__tests__/warm-start-cache.test.ts
+++ b/packages/compute/src/__tests__/warm-start-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   computePaddedWindow,
+  computeSafeMargin,
   shouldWarmStart,
   WarmStartCache,
   type WarmStartEntry,
@@ -53,6 +54,32 @@ describe('computePaddedWindow', () => {
     expect(result.paddedEnd).toBe(10000);
     expect(result.resultOffset).toBe(0);
     expect(result.resultLength).toBe(10000);
+  });
+
+  it('caps padding at MAX_PADDING_SECONDS (5 min) for very long windows', () => {
+    // fs=30, maxPadding = ceil(5*60*30) = 9000 samples.
+    // visibleSamples = 20000 > maxPadding, so padding caps at 9000 per side.
+    // Contract (see warm-start-cache.ts): padding may be smaller than the
+    // visible window for very long visible regions.
+    const result = computePaddedWindow(50_000, 70_000, 100_000, 0.4, 30);
+    expect(result.paddedStart).toBe(41_000);
+    expect(result.paddedEnd).toBe(79_000);
+    expect(50_000 - result.paddedStart).toBe(9000);
+    expect(result.paddedEnd - 70_000).toBe(9000);
+  });
+});
+
+// ---------- computeSafeMargin ----------
+
+describe('computeSafeMargin', () => {
+  it('returns 5 * tauDecay * fs samples', () => {
+    expect(computeSafeMargin(0.4, 30)).toBe(60); // ceil(5 * 0.4 * 30) = 60
+    expect(computeSafeMargin(2.0, 100)).toBe(1000); // ceil(5 * 2 * 100) = 1000
+  });
+
+  it('always rounds up via ceil', () => {
+    // 5 * 0.333 * 30 = 49.95 → 50
+    expect(computeSafeMargin(0.333, 30)).toBe(50);
   });
 });
 
@@ -123,6 +150,19 @@ describe('shouldWarmStart', () => {
     const newParams = { ...baseParams, fs: 60 };
     expect(shouldWarmStart(cached, newParams, 940, 2060)).toBe('cold');
   });
+
+  it('returns cold when filterEnabled toggles', () => {
+    const cached = makeEntry(baseParams);
+    const newParams = { ...baseParams, filterEnabled: true };
+    expect(shouldWarmStart(cached, newParams, 940, 2060)).toBe('cold');
+  });
+
+  it('handles zero-tauRise safely without dividing by zero', () => {
+    const cached = makeEntry({ ...baseParams, tauRise: 0 });
+    // old tauRise=0 → branch returns 0 if new is 0 else 1
+    expect(shouldWarmStart(cached, { ...baseParams, tauRise: 0 }, 940, 2060)).toBe('warm');
+    expect(shouldWarmStart(cached, { ...baseParams, tauRise: 0.01 }, 940, 2060)).toBe('cold');
+  });
 });
 
 // ---------- WarmStartCache ----------
@@ -161,5 +201,36 @@ describe('WarmStartCache', () => {
     cache.store(new Uint8Array([1]), params, 940, 2060);
     cache.clear();
     expect(cache.get()).toBeNull();
+  });
+
+  it('getStrategy returns cached state for warm-no-momentum', () => {
+    const cache = new WarmStartCache();
+    const state = new Uint8Array([7, 7, 7]);
+    cache.store(state, params, 940, 2060);
+    // 10% tau change → warm-no-momentum, state still returned
+    const result = cache.getStrategy({ ...params, tauDecay: 0.44 }, 940, 2060);
+    expect(result.strategy).toBe('warm-no-momentum');
+    expect(result.state).toBe(state);
+  });
+
+  it('getStrategy returns null state for cold even when entry exists', () => {
+    const cache = new WarmStartCache();
+    cache.store(new Uint8Array([1, 2, 3]), params, 940, 2060);
+    // Window shift → cold
+    const result = cache.getStrategy(params, 1000, 2120);
+    expect(result.strategy).toBe('cold');
+    expect(result.state).toBeNull();
+  });
+
+  it('store() replaces the previous entry (single-entry cache)', () => {
+    const cache = new WarmStartCache();
+    const first = new Uint8Array([1, 1]);
+    const second = new Uint8Array([2, 2]);
+    cache.store(first, params, 940, 2060);
+    cache.store(second, params, 5000, 6000);
+    // Old window is no longer cached
+    expect(cache.getStrategy(params, 940, 2060).strategy).toBe('cold');
+    // New window is warm and returns the second state
+    expect(cache.get()?.state).toBe(second);
   });
 });

--- a/packages/io/src/__tests__/export.test.ts
+++ b/packages/io/src/__tests__/export.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { tauToShape } from '@calab/compute';
+import { buildExportData, parseExport } from '../export.ts';
+
+// Derive a (tPeak, fwhm) pair from realistic tau values so buildExportData
+// (which goes through shapeToTau) doesn't bail on degenerate shapes.
+const { tPeak, fwhm } = tauToShape(0.02, 0.4)!;
+
+describe('buildExportData → parseExport roundtrip', () => {
+  it('preserves all fields through JSON stringify / parse', () => {
+    const original = buildExportData(
+      tPeak,
+      fwhm,
+      0.01,
+      30,
+      true,
+      { sourceFilename: 'traces.npy', numCells: 42, numTimepoints: 9000 },
+      '1.0.0-test',
+    );
+
+    const rehydrated = parseExport(JSON.parse(JSON.stringify(original)));
+
+    expect(rehydrated).toEqual(original);
+  });
+
+  it('preserves all fields without optional metadata', () => {
+    const original = buildExportData(tPeak, fwhm, 0.01, 30, false);
+    const rehydrated = parseExport(JSON.parse(JSON.stringify(original)));
+    expect(rehydrated).toEqual(original);
+  });
+
+  it('throws on malformed input missing required fields', () => {
+    expect(() => parseExport({ schema_version: '1.2.0' })).toThrow(/Invalid CaTune export/);
+  });
+
+  it('throws on wrong types', () => {
+    const valid = buildExportData(tPeak, fwhm, 0.01, 30, true);
+    const corrupted = JSON.parse(JSON.stringify(valid));
+    corrupted.parameters.lambda = 'not-a-number';
+    expect(() => parseExport(corrupted)).toThrow(/Invalid CaTune export/);
+  });
+
+  it('accepts a legacy export missing optional t_peak_s/fwhm_s', () => {
+    const valid = buildExportData(tPeak, fwhm, 0.01, 30, true);
+    const legacy = JSON.parse(JSON.stringify(valid));
+    delete legacy.parameters.t_peak_s;
+    delete legacy.parameters.fwhm_s;
+    const parsed = parseExport(legacy);
+    expect(parsed.parameters.tau_rise_s).toBe(valid.parameters.tau_rise_s);
+    expect(parsed.parameters.tau_decay_s).toBe(valid.parameters.tau_decay_s);
+  });
+});

--- a/python/tests/test_simulate.py
+++ b/python/tests/test_simulate.py
@@ -252,3 +252,53 @@ def test_high_snr_clean():
     # With very high SNR and no drift, trace should closely match clean signal
     residual = np.abs(result.traces[0] - gt.clean_calcium)
     assert residual.max() < gt.clean_calcium.max() * 0.05 or gt.clean_calcium.max() < 1e-6
+
+
+# ── Sub-frame timing (regression for ac70732) ────────────────────
+
+
+def test_fast_kernel_integral_matches_continuous_time():
+    """Regression for ac70732 (convolve at high-res rate before downsampling).
+
+    For a fast kernel (tau_rise ~ 0.3 frames at fs_hz=30), the continuous-time
+    integral of the clean calcium signal per spike equals alpha * kernel_area,
+    where kernel_area = (tau_d - tau_r) / peak_height for the peak-normalized
+    double-exponential. The fix convolves at spike_sim_hz=300 before
+    bin-average downsampling so this integral is preserved. Under the pre-fix
+    pipeline (bin spikes to imaging rate, convolve with fs_hz-sampled kernel),
+    the relative integral error for this kernel exceeds 5%; the test asserts
+    < 3% so it fails pre-fix and passes post-fix.
+    """
+    tau_r, tau_d = 0.01, 0.1
+    fs_hz = 30.0
+    cfg = SimulationConfig(
+        num_cells=1,
+        num_timepoints=27000,  # 900s — enough spikes for <1% Monte Carlo noise
+        fs_hz=fs_hz,
+        spike_sim_hz=300.0,
+        kernel=KernelConfig(tau_rise_s=tau_r, tau_decay_s=tau_d),
+        spike_model=PoissonConfig(rate_hz=5.0),
+        noise=NoiseConfig(snr=1000.0),
+        drift=SinusoidalDrift(amplitude_fraction=0.0),
+        saturation=SaturationConfig(enabled=False),
+        photobleaching=PhotobleachingConfig(enabled=False),
+        alpha_cv=0.0,
+        seed=42,
+    )
+    result = simulate(cfg)
+    gt = result.ground_truth[0]
+
+    t_peak_s = np.log(tau_d / tau_r) * tau_r * tau_d / (tau_d - tau_r)
+    peak_height = np.exp(-t_peak_s / tau_d) - np.exp(-t_peak_s / tau_r)
+    kernel_area_s = (tau_d - tau_r) / peak_height
+
+    num_spikes = gt.spikes.sum()
+    expected_integral = gt.alpha * num_spikes * kernel_area_s
+    measured_integral = gt.clean_calcium.sum() / fs_hz
+
+    rel_err = abs(measured_integral - expected_integral) / expected_integral
+    assert rel_err < 0.03, (
+        f"clean_calcium integral deviates from continuous-time theory: "
+        f"measured={measured_integral:.4f}, expected={expected_integral:.4f}, "
+        f"rel_err={rel_err:.3%}"
+    )


### PR DESCRIPTION
## Summary
Fills four small test-coverage gaps from `.planning/CODEBASE_AUDIT.md`:

- **TEST-M5** — Replaces the `expect(1+1).toBe(2)` placeholder in `apps/catune/src/__tests__/smoke.test.ts` with a real kernel shape ↔ tau round-trip through `@calab/compute`, exercising the transform that the CaTune UI performs on every slider change.
- **TEST-M2** — New `packages/io/src/__tests__/export.test.ts` with `buildExportData → JSON → parseExport` round-trip coverage (happy path, no-metadata, malformed input, wrong types, legacy exports missing optional `t_peak_s`/`fwhm_s`).
- **TEST-M1** — Regression test in `python/tests/test_simulate.py` for commit `ac70732` (convolve at high-res rate before downsampling). Asserts that for a fast kernel (`tau_r=0.01s` ≈ 0.3 frames at `fs=30Hz`), the integral of `clean_calcium` per spike matches the continuous-time theoretical value within 3%. Under the pre-fix pipeline, `fs_hz`-sampled kernel discretization error exceeds 5% for this kernel, so the test would have failed before the fix.
- **TEST-2** — Fills gaps in `packages/compute/src/__tests__/warm-start-cache.test.ts`:
  - `computeSafeMargin` (was entirely untested)
  - `MAX_PADDING` cap path in `computePaddedWindow`
  - `filterEnabled` branch in `shouldWarmStart`
  - Zero-`tauRise` divide-by-zero guard
  - Warm-no-momentum state passthrough in `WarmStartCache.getStrategy`
  - Cold-with-existing-entry returning `state: null`
  - Single-entry cache replacement (second `store()` wins)

## Test plan
- [x] `npm test --workspaces` — all passing (including 67 compute tests, 62 io tests, 10 catune tests)
- [x] `pytest -m "not integration"` — 196 passed
- [x] `npm run lint` — 0 errors (21 pre-existing `solid/reactivity` warnings unchanged)
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean

Four PRs remaining in the audit test-coverage track (TEST-1 iteration-manager, TEST-3 store reactivity, TEST-4 geo-session + RLS, TEST-M3/TEST-M4 bridge failure modes + migration smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)