### PR TITLE
test: cover iteration-store and multi-cell-store reactivity

### DIFF
--- a/apps/cadecon/src/lib/__tests__/iteration-store.test.ts
+++ b/apps/cadecon/src/lib/__tests__/iteration-store.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Reactivity tests for iteration-store.
+ *
+ * Every derived memo (progress, isRunLocked, cellResultLookup, alphaValues,
+ * pveValues, subsetVarianceData) is verified to track its source signals.
+ * Writes go through the exported actions (setRunState, setCurrentIteration,
+ * updateTraceResult, addConvergenceSnapshot, snapshotIteration, ...) and
+ * reads happen inside createRoot scopes so the memos are subscribed and do
+ * not produce "computation created outside a createRoot" warnings.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import {
+  runState,
+  setRunState,
+  runPhase,
+  setRunPhase,
+  currentIteration,
+  setCurrentIteration,
+  totalSubsetTraceJobs,
+  setTotalSubsetTraceJobs,
+  setCompletedSubsetTraceJobs,
+  progress,
+  isRunLocked,
+  convergenceHistory,
+  addConvergenceSnapshot,
+  debugTraceSnapshots,
+  addDebugTraceSnapshot,
+  currentTauRise,
+  setCurrentTauRise,
+  currentTauDecay,
+  setCurrentTauDecay,
+  convergedAtIteration,
+  setConvergedAtIteration,
+  cellResultLookup,
+  alphaValues,
+  pveValues,
+  subsetVarianceData,
+  iterationHistory,
+  snapshotIteration,
+  updateTraceResult,
+  bulkUpdateTraceResults,
+  resetIterationState,
+  cellSubsetKey,
+} from '../iteration-store.ts';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/** Run `fn` inside a createRoot scope that disposes immediately after. */
+function withRoot<T>(fn: () => T): T {
+  return createRoot((dispose) => {
+    try {
+      return fn();
+    } finally {
+      dispose();
+    }
+  });
+}
+
+function makeTraceEntry(
+  cellIndex: number,
+  subsetIdx: number,
+  alpha: number,
+  pve: number,
+): import('../iteration-store.ts').TraceResultEntry {
+  return {
+    cellIndex,
+    subsetIdx,
+    sCounts: new Float32Array(0),
+    alpha,
+    baseline: 0,
+    threshold: 0,
+    pve,
+  };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('iteration-store: core signals', () => {
+  beforeEach(() => resetIterationState());
+
+  it('setRunState updates the runState signal', () => {
+    withRoot(() => {
+      expect(runState()).toBe('idle');
+      setRunState('running');
+      expect(runState()).toBe('running');
+      setRunState('paused');
+      expect(runState()).toBe('paused');
+      setRunState('stopping');
+      expect(runState()).toBe('stopping');
+    });
+  });
+
+  it('setCurrentIteration updates its signal', () => {
+    setCurrentIteration(7);
+    expect(currentIteration()).toBe(7);
+  });
+
+  it('tau signals update independently', () => {
+    setCurrentTauRise(0.03);
+    setCurrentTauDecay(0.6);
+    expect(currentTauRise()).toBe(0.03);
+    expect(currentTauDecay()).toBe(0.6);
+  });
+});
+
+describe('iteration-store: derived memos', () => {
+  beforeEach(() => resetIterationState());
+
+  it('progress = completed / total and is 0 when total=0', () => {
+    withRoot(() => {
+      expect(progress()).toBe(0);
+      setTotalSubsetTraceJobs(10);
+      setCompletedSubsetTraceJobs(3);
+      expect(progress()).toBeCloseTo(0.3);
+      setCompletedSubsetTraceJobs(10);
+      expect(progress()).toBe(1);
+    });
+  });
+
+  it('progress reacts to both numerator and denominator', () => {
+    withRoot(() => {
+      setTotalSubsetTraceJobs(4);
+      setCompletedSubsetTraceJobs(2);
+      expect(progress()).toBe(0.5);
+      setCompletedSubsetTraceJobs(4);
+      expect(progress()).toBe(1);
+      expect(totalSubsetTraceJobs()).toBe(4);
+    });
+  });
+
+  it('isRunLocked is true only while running/paused/stopping', () => {
+    withRoot(() => {
+      setRunState('idle');
+      expect(isRunLocked()).toBe(false);
+      setRunState('running');
+      expect(isRunLocked()).toBe(true);
+      setRunState('paused');
+      expect(isRunLocked()).toBe(true);
+      setRunState('stopping');
+      expect(isRunLocked()).toBe(true);
+      setRunState('complete');
+      expect(isRunLocked()).toBe(false);
+    });
+  });
+
+  it('cellResultLookup dedupes by cellIndex, preferring finalization (subsetIdx=-1)', () => {
+    withRoot(() => {
+      bulkUpdateTraceResults({
+        [cellSubsetKey(0, 0)]: makeTraceEntry(0, 0, 1, 0.5),
+        [cellSubsetKey(0, 1)]: makeTraceEntry(0, 1, 2, 0.6),
+        [cellSubsetKey(0, -1)]: makeTraceEntry(0, -1, 99, 0.99),
+        [cellSubsetKey(1, 0)]: makeTraceEntry(1, 0, 3, 0.7),
+      });
+      const lookup = cellResultLookup();
+      expect(lookup.get(0)?.alpha).toBe(99);
+      expect(lookup.get(0)?.pve).toBe(0.99);
+      expect(lookup.get(1)?.alpha).toBe(3);
+    });
+  });
+
+  it('alphaValues/pveValues derive from cellResultLookup', () => {
+    withRoot(() => {
+      bulkUpdateTraceResults({
+        [cellSubsetKey(0, 0)]: makeTraceEntry(0, 0, 1, 0.1),
+        [cellSubsetKey(1, 0)]: makeTraceEntry(1, 0, 2, 0.2),
+      });
+      expect(alphaValues().sort()).toEqual([1, 2]);
+      expect(pveValues().sort()).toEqual([0.1, 0.2]);
+    });
+  });
+
+  it('subsetVarianceData tracks the latest convergence snapshot and exposes ms units', () => {
+    withRoot(() => {
+      expect(subsetVarianceData()).toEqual([]);
+      addConvergenceSnapshot({
+        iteration: 1,
+        tauRise: 0.05,
+        tauDecay: 0.4,
+        beta: 1,
+        residual: 0.01,
+        tauRiseFast: 0.05,
+        tauDecayFast: 0.4,
+        betaFast: 1,
+        fs: 30,
+        subsets: [
+          {
+            tauRise: 0.05,
+            tauDecay: 0.4,
+            beta: 1,
+            residual: 0.01,
+            tauRiseFast: 0.05,
+            tauDecayFast: 0.4,
+            betaFast: 1,
+            hFree: new Float32Array(),
+          },
+          {
+            tauRise: 0.06,
+            tauDecay: 0.5,
+            beta: 1,
+            residual: 0.01,
+            tauRiseFast: 0.06,
+            tauDecayFast: 0.5,
+            betaFast: 1,
+            hFree: new Float32Array(),
+          },
+        ],
+      });
+      const variance = subsetVarianceData();
+      expect(variance).toHaveLength(2);
+      expect(variance[0].tauRise).toBeCloseTo(50); // ms
+      expect(variance[0].tauDecay).toBeCloseTo(400);
+      expect(variance[1].tauRise).toBeCloseTo(60);
+    });
+  });
+});
+
+describe('iteration-store: history actions', () => {
+  beforeEach(() => resetIterationState());
+
+  it('addConvergenceSnapshot / addDebugTraceSnapshot append', () => {
+    withRoot(() => {
+      expect(convergenceHistory()).toHaveLength(0);
+      addConvergenceSnapshot({
+        iteration: 0,
+        tauRise: 0,
+        tauDecay: 0,
+        beta: 0,
+        residual: 0,
+        tauRiseFast: 0,
+        tauDecayFast: 0,
+        betaFast: 0,
+        fs: 30,
+        subsets: [],
+      });
+      expect(convergenceHistory()).toHaveLength(1);
+
+      expect(debugTraceSnapshots()).toHaveLength(0);
+      addDebugTraceSnapshot({
+        iteration: 1,
+        cellIndex: 0,
+        rawTrace: new Float32Array(),
+        sCounts: new Float32Array(),
+        reconvolved: new Float32Array(),
+        alpha: 1,
+        baseline: 0,
+        threshold: 0,
+        pve: 0,
+      });
+      expect(debugTraceSnapshots()).toHaveLength(1);
+    });
+  });
+
+  it('snapshotIteration caps history at MAX_HISTORY_ITERATIONS (50)', () => {
+    withRoot(() => {
+      for (let i = 0; i < 55; i++) {
+        snapshotIteration(i, 0.05 + i * 0.001, 0.4);
+      }
+      const history = iterationHistory();
+      expect(history).toHaveLength(50);
+      // Oldest entries were dropped: iteration numbers start at 5
+      expect(history[0].iteration).toBe(5);
+      expect(history[history.length - 1].iteration).toBe(54);
+    });
+  });
+
+  it('snapshotIteration captures current perTraceResults as a shallow copy', () => {
+    withRoot(() => {
+      const e1 = makeTraceEntry(0, -1, 1, 0.5);
+      updateTraceResult(cellSubsetKey(0, -1), e1);
+      snapshotIteration(1, 0.05, 0.4);
+
+      // Mutate the source: should NOT leak into the snapshot
+      const e2 = makeTraceEntry(0, -1, 99, 0.99);
+      updateTraceResult(cellSubsetKey(0, -1), e2);
+
+      const snap = iterationHistory()[0].results;
+      expect(snap[cellSubsetKey(0, -1)].alpha).toBe(1);
+    });
+  });
+});
+
+describe('iteration-store: updateTraceResult / bulkUpdateTraceResults', () => {
+  beforeEach(() => resetIterationState());
+
+  it('updateTraceResult merges one entry into cellResultLookup', () => {
+    withRoot(() => {
+      expect(cellResultLookup().size).toBe(0);
+      updateTraceResult(cellSubsetKey(3, 0), makeTraceEntry(3, 0, 5, 0.5));
+      expect(cellResultLookup().get(3)?.alpha).toBe(5);
+      updateTraceResult(cellSubsetKey(4, 0), makeTraceEntry(4, 0, 6, 0.6));
+      expect(cellResultLookup().size).toBe(2);
+    });
+  });
+
+  it('bulkUpdateTraceResults writes all entries in one pass', () => {
+    withRoot(() => {
+      bulkUpdateTraceResults({
+        [cellSubsetKey(0, 0)]: makeTraceEntry(0, 0, 1, 0.1),
+        [cellSubsetKey(1, 0)]: makeTraceEntry(1, 0, 2, 0.2),
+        [cellSubsetKey(2, 0)]: makeTraceEntry(2, 0, 3, 0.3),
+      });
+      expect(cellResultLookup().size).toBe(3);
+      expect(alphaValues().sort()).toEqual([1, 2, 3]);
+    });
+  });
+});
+
+describe('iteration-store: resetIterationState', () => {
+  it('restores every tracked signal to its initial value', () => {
+    withRoot(() => {
+      setRunState('complete');
+      setRunPhase('finalization');
+      setCurrentIteration(9);
+      setTotalSubsetTraceJobs(10);
+      setCompletedSubsetTraceJobs(5);
+      setCurrentTauRise(0.05);
+      setCurrentTauDecay(0.4);
+      setConvergedAtIteration(3);
+      addConvergenceSnapshot({
+        iteration: 1,
+        tauRise: 0,
+        tauDecay: 0,
+        beta: 0,
+        residual: 0,
+        tauRiseFast: 0,
+        tauDecayFast: 0,
+        betaFast: 0,
+        fs: 30,
+        subsets: [],
+      });
+      updateTraceResult(cellSubsetKey(0, 0), makeTraceEntry(0, 0, 1, 0.5));
+      snapshotIteration(1, 0.05, 0.4);
+
+      resetIterationState();
+
+      expect(runState()).toBe('idle');
+      expect(runPhase()).toBe('idle');
+      expect(currentIteration()).toBe(0);
+      expect(totalSubsetTraceJobs()).toBe(0);
+      expect(progress()).toBe(0);
+      expect(convergenceHistory()).toEqual([]);
+      expect(debugTraceSnapshots()).toEqual([]);
+      expect(currentTauRise()).toBeNull();
+      expect(currentTauDecay()).toBeNull();
+      expect(convergedAtIteration()).toBeNull();
+      expect(cellResultLookup().size).toBe(0);
+      expect(iterationHistory()).toEqual([]);
+    });
+  });
+});

--- a/apps/catune/src/lib/__tests__/multi-cell-store.test.ts
+++ b/apps/catune/src/lib/__tests__/multi-cell-store.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Reactivity tests for multi-cell-store.
+ *
+ * Covers selection-mode branching (top-active / random / manual), the per-cell
+ * update helpers that gate on existing rows, and the snapshot/clear lifecycle
+ * for pinned multi-cell comparisons.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import {
+  selectionMode,
+  setSelectionMode,
+  selectedCells,
+  setSelectedCells,
+  displayCount,
+  setDisplayCount,
+  multiCellResults,
+  setMultiCellResults,
+  multiCellSolving,
+  setMultiCellSolving,
+  multiCellProgress,
+  setMultiCellProgress,
+  solvingCells,
+  setSolvingCells,
+  activelySolvingCell,
+  setActivelySolvingCell,
+  activityRanking,
+  setActivityRanking,
+  gridColumns,
+  setGridColumns,
+  cellSolverStatuses,
+  cellIterationCounts,
+  pinnedMultiCellResults,
+  visibleCellIndices,
+  setVisibleCellIndices,
+  hoveredCell,
+  setHoveredCell,
+  updateOneCellStatus,
+  updateOneCellIteration,
+  updateOneCellTraces,
+  updateCellSelection,
+  clearMultiCellState,
+  pinMultiCellResults,
+  unpinMultiCellResults,
+} from '../multi-cell-store.ts';
+import { setParsedData, resetImport } from '../data-store.ts';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((dispose) => {
+    try {
+      return fn();
+    } finally {
+      dispose();
+    }
+  });
+}
+
+function seedDataset(numCells: number, numTimepoints: number): void {
+  const data = new Float64Array(numCells * numTimepoints);
+  setParsedData({
+    data,
+    shape: [numCells, numTimepoints],
+    dtype: '<f8',
+    fortranOrder: false,
+  });
+}
+
+function seedCellTraces(cellIndex: number): void {
+  setMultiCellResults(cellIndex, {
+    cellIndex,
+    raw: new Float64Array(10),
+    deconvolved: new Float32Array(10),
+    reconvolution: new Float32Array(10),
+  });
+}
+
+function resetStoreState(): void {
+  clearMultiCellState();
+  unpinMultiCellResults();
+  setDisplayCount(5);
+  setMultiCellSolving(false);
+  setMultiCellProgress(null);
+  setGridColumns(2);
+  setVisibleCellIndices(new Set<number>());
+  setHoveredCell(null);
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('multi-cell-store: signals', () => {
+  beforeEach(() => {
+    resetStoreState();
+    resetImport();
+  });
+
+  it('selectionMode setter cycles through modes', () => {
+    withRoot(() => {
+      expect(selectionMode()).toBe('top-active');
+      setSelectionMode('random');
+      expect(selectionMode()).toBe('random');
+      setSelectionMode('manual');
+      expect(selectionMode()).toBe('manual');
+    });
+  });
+
+  it('selectedCells, displayCount, gridColumns are independent writable signals', () => {
+    withRoot(() => {
+      setSelectedCells([1, 2, 3]);
+      setDisplayCount(8);
+      setGridColumns(4);
+      expect(selectedCells()).toEqual([1, 2, 3]);
+      expect(displayCount()).toBe(8);
+      expect(gridColumns()).toBe(4);
+    });
+  });
+
+  it('solving signals track progress state', () => {
+    withRoot(() => {
+      setMultiCellSolving(true);
+      setMultiCellProgress({ current: 3, total: 10 });
+      setActivelySolvingCell(7);
+      setSolvingCells(new Set([7, 8, 9]));
+      expect(multiCellSolving()).toBe(true);
+      expect(multiCellProgress()).toEqual({ current: 3, total: 10 });
+      expect(activelySolvingCell()).toBe(7);
+      expect([...solvingCells()].sort()).toEqual([7, 8, 9]);
+    });
+  });
+
+  it('visibleCellIndices and hoveredCell track viewport signals', () => {
+    withRoot(() => {
+      setVisibleCellIndices(new Set([0, 1, 2]));
+      setHoveredCell(2);
+      expect([...visibleCellIndices()].sort()).toEqual([0, 1, 2]);
+      expect(hoveredCell()).toBe(2);
+      setHoveredCell(null);
+      expect(hoveredCell()).toBeNull();
+    });
+  });
+});
+
+// ── updateCellSelection: mode-dependent branching ──────────────────────────
+
+describe('multi-cell-store: updateCellSelection', () => {
+  beforeEach(() => {
+    resetStoreState();
+    resetImport();
+  });
+
+  it('top-active takes first N entries from activityRanking', () => {
+    withRoot(() => {
+      seedDataset(20, 300);
+      setActivityRanking([5, 10, 3, 8, 0, 7, 2]);
+      setDisplayCount(3);
+      setSelectionMode('top-active');
+      updateCellSelection();
+      expect(selectedCells()).toEqual([5, 10, 3]);
+    });
+  });
+
+  it('top-active is a no-op when activityRanking is null', () => {
+    withRoot(() => {
+      setActivityRanking(null);
+      setSelectedCells([42]); // sentinel
+      setSelectionMode('top-active');
+      updateCellSelection();
+      expect(selectedCells()).toEqual([42]);
+    });
+  });
+
+  it('random mode samples displayCount cells from the loaded shape', () => {
+    withRoot(() => {
+      seedDataset(8, 300);
+      setDisplayCount(4);
+      setSelectionMode('random');
+      updateCellSelection();
+      const picks = selectedCells();
+      expect(picks).toHaveLength(4);
+      for (const idx of picks) {
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(8);
+      }
+      // No duplicates
+      expect(new Set(picks).size).toBe(4);
+    });
+  });
+
+  it('random mode is a no-op when no dataset is loaded', () => {
+    withRoot(() => {
+      setSelectedCells([99]);
+      setSelectionMode('random');
+      updateCellSelection();
+      expect(selectedCells()).toEqual([99]);
+    });
+  });
+
+  it('manual mode never touches selectedCells', () => {
+    withRoot(() => {
+      seedDataset(10, 300);
+      setActivityRanking([0, 1, 2, 3, 4]);
+      setSelectedCells([9, 8]);
+      setSelectionMode('manual');
+      updateCellSelection();
+      expect(selectedCells()).toEqual([9, 8]);
+    });
+  });
+});
+
+// ── per-cell update helpers ────────────────────────────────────────────────
+
+describe('multi-cell-store: per-cell update helpers', () => {
+  beforeEach(() => {
+    resetStoreState();
+    resetImport();
+  });
+
+  it('updateOneCellStatus writes status and zeroes iterations on stale', () => {
+    withRoot(() => {
+      updateOneCellIteration(0, 50);
+      updateOneCellStatus(0, 'solving');
+      expect(cellSolverStatuses[0]).toBe('solving');
+      expect(cellIterationCounts[0]).toBe(50);
+
+      updateOneCellStatus(0, 'stale');
+      expect(cellSolverStatuses[0]).toBe('stale');
+      expect(cellIterationCounts[0]).toBe(0);
+    });
+  });
+
+  it('updateOneCellIteration writes per-cell iteration count', () => {
+    withRoot(() => {
+      updateOneCellIteration(5, 123);
+      expect(cellIterationCounts[5]).toBe(123);
+      updateOneCellIteration(5, 200);
+      expect(cellIterationCounts[5]).toBe(200);
+    });
+  });
+
+  it('updateOneCellTraces ignores cells with no existing entry', () => {
+    withRoot(() => {
+      updateOneCellTraces(99, new Float32Array([1, 2]), new Float32Array([3, 4]));
+      expect(multiCellResults[99]).toBeUndefined();
+    });
+  });
+
+  it('updateOneCellTraces merges deconvolved/reconvolution when the cell exists', () => {
+    withRoot(() => {
+      seedCellTraces(7);
+      const d = new Float32Array([0.1, 0.2, 0.3]);
+      const r = new Float32Array([0.01, 0.02, 0.03]);
+      const filtered = new Float32Array([0.5, 0.6, 0.7]);
+      updateOneCellTraces(7, d, r, 42, filtered);
+      expect(multiCellResults[7].deconvolved).toBe(d);
+      expect(multiCellResults[7].reconvolution).toBe(r);
+      expect(multiCellResults[7].filteredTrace).toBe(filtered);
+      expect(multiCellResults[7].windowStartSample).toBe(42);
+      // Raw trace preserved
+      expect(multiCellResults[7].raw).toBeDefined();
+    });
+  });
+});
+
+// ── pinned snapshots ───────────────────────────────────────────────────────
+
+describe('multi-cell-store: pinned snapshots', () => {
+  beforeEach(() => {
+    resetStoreState();
+    resetImport();
+  });
+
+  it('pinMultiCellResults snapshots the current live results by value', () => {
+    withRoot(() => {
+      seedCellTraces(0);
+      seedCellTraces(1);
+      // Set known values on the live store
+      setMultiCellResults(0, (r) => ({ ...r, deconvolved: new Float32Array([9]) }));
+      pinMultiCellResults();
+      expect(pinnedMultiCellResults[0]).toBeDefined();
+      expect(pinnedMultiCellResults[0].deconvolved[0]).toBe(9);
+
+      // Subsequent live edits should not affect the pinned snapshot
+      setMultiCellResults(0, (r) => ({ ...r, deconvolved: new Float32Array([1]) }));
+      expect(pinnedMultiCellResults[0].deconvolved[0]).toBe(9);
+    });
+  });
+
+  it('unpinMultiCellResults clears the snapshot', () => {
+    withRoot(() => {
+      seedCellTraces(0);
+      pinMultiCellResults();
+      expect(Object.keys(pinnedMultiCellResults).length).toBeGreaterThan(0);
+      unpinMultiCellResults();
+      expect(Object.keys(pinnedMultiCellResults)).toEqual([]);
+    });
+  });
+});
+
+// ── clearMultiCellState ────────────────────────────────────────────────────
+
+describe('multi-cell-store: clearMultiCellState', () => {
+  it('restores selection-mode, clears results, statuses, iteration counts, and selection', () => {
+    withRoot(() => {
+      seedCellTraces(0);
+      updateOneCellStatus(0, 'solving');
+      updateOneCellIteration(0, 50);
+      setSelectionMode('random');
+      setSelectedCells([5, 6]);
+      setSolvingCells(new Set([1, 2]));
+      setActivelySolvingCell(1);
+      setActivityRanking([0, 1]);
+
+      clearMultiCellState();
+
+      expect(Object.keys(multiCellResults)).toEqual([]);
+      expect(Object.keys(cellSolverStatuses)).toEqual([]);
+      expect(Object.keys(cellIterationCounts)).toEqual([]);
+      expect(selectedCells()).toEqual([]);
+      expect([...solvingCells()]).toEqual([]);
+      expect(activelySolvingCell()).toBeNull();
+      expect(activityRanking()).toBeNull();
+      expect(selectionMode()).toBe('top-active');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Addresses **TEST-3** from `.planning/CODEBASE_AUDIT.md`. The audit called out 11 SolidJS stores with zero reactivity tests and specifically asked that, as a minimum, `iteration-store.ts` (CaDecon orchestration) and `multi-cell-store.ts` (CaTune multi-cell selection) be covered with \`createRoot\` + signal assertions. This PR adds 31 tests across both.

### iteration-store (15 tests)
- **Core signals**: `runState` / `runPhase` / `currentIteration` / tau writes round-trip.
- **Derived memos**:
  - `progress = completed / total` (0 when `total=0`).
  - `isRunLocked` is true only during `running` / `paused` / `stopping`.
  - `cellResultLookup` dedupes by cell index, preferring finalization entries (`subsetIdx=-1`).
  - `alphaValues` / `pveValues` derive from `cellResultLookup`.
  - `subsetVarianceData` exposes ms units from the latest convergence snapshot.
- **History**: `addConvergenceSnapshot` and `addDebugTraceSnapshot` append; `snapshotIteration` caps at `MAX_HISTORY_ITERATIONS=50` and captures a shallow copy that is not mutated by subsequent writes.
- **Writes**: `updateTraceResult` merges per cell; `bulkUpdateTraceResults` writes all entries at once.
- `resetIterationState` restores every tracked signal.

### multi-cell-store (16 tests)
- **Signals**: selection mode, selected cells, display count, grid columns, solving / progress / active cell, visible cell indices, hovered cell.
- **`updateCellSelection` branches**:
  - `top-active` slices `activityRanking` by `displayCount`; no-op when ranking is `null`.
  - `random` samples without duplicates within shape bounds; no-op when no dataset is loaded.
  - `manual` never touches `selectedCells`.
- **Per-cell helpers**: `updateOneCellStatus` zeroes iteration on `'stale'`; `updateOneCellIteration` writes count; `updateOneCellTraces` merges only when the cell row exists (silently ignored otherwise).
- **Pinned snapshots**: `pinMultiCellResults` copies traces by value (subsequent live edits do not affect the pinned snapshot); `unpinMultiCellResults` clears the pinned store.
- `clearMultiCellState` resets results, statuses, iteration counts, selection, and selection mode.

### Testing approach
Tests use `createRoot` + direct signal/memo reads rather than effect counters. Solid schedules effect re-runs on microtask after writes inside a `runUpdates` frame, so effect-count assertions would be flaky; reading the memo after each write exercises the same reactive graph without that race.

## Test plan
- [x] `npm -w cadecon test` — 33 passing (18 iteration-manager + 15 iteration-store)
- [x] `npm -w catune test` — 26 passing (10 pre-existing + 16 multi-cell-store)
- [x] `npm test --workspaces` — all 6 workspaces green (269 total)
- [x] `npm run lint` — 0 errors (21 pre-existing \`solid/reactivity\` warnings unchanged)
- [x] `npm run format:check` / `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)