### PR TITLE
test: cover bridge timeout and mid-run browser-crash detection

### DIFF
--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -483,6 +483,74 @@ def test_options_without_pna_request_omits_pna_header(bridge_server: BridgeServe
         assert resp.headers.get("Access-Control-Allow-Private-Network") is None
 
 
+# --- _run_bridge failure-mode tests (TEST-M3) ---
+
+
+def test_run_bridge_timeout_returns_false() -> None:
+    """``_run_bridge`` exits with False when the bridge event never fires."""
+    from calab._bridge._apps import _run_bridge
+
+    server = _make_server()
+    event = threading.Event()
+
+    start = time.monotonic()
+    received = _run_bridge(
+        server,
+        event,
+        app_name="CaTune",
+        app_url="about:blank",  # webbrowser.open on a noop URL
+        open_browser=False,
+        timeout=0.2,
+    )
+    elapsed = time.monotonic() - start
+
+    assert received is False, "timeout path must return False"
+    # 0.2s timeout + server.serve_forever.shutdown handshake; allow headroom
+    # but fail loudly if it exceeds the heartbeat fallback (10s).
+    assert elapsed < 3.0, f"timeout respected (elapsed={elapsed:.2f}s)"
+
+
+def test_run_bridge_detects_browser_crash_via_heartbeat_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead browser is detected when ``last_heartbeat`` goes stale.
+
+    Simulates a browser that started (sent at least one heartbeat) and then
+    crashed or was killed: ``_run_bridge`` should notice
+    ``now - last_heartbeat > HEARTBEAT_TIMEOUT`` on its next tick and exit
+    False instead of hanging until the outer timeout.
+    """
+    from calab._bridge import _apps
+    from calab._bridge._apps import _run_bridge
+
+    # Shorten HEARTBEAT_TIMEOUT so the loop's 1s tick can reliably fire.
+    monkeypatch.setattr(_apps, "HEARTBEAT_TIMEOUT", 0.1)
+
+    server = _make_server()
+    event = threading.Event()
+    # Prime with a heartbeat that arrived "long ago" from the loop's POV.
+    server.last_heartbeat = time.monotonic() - 5.0
+
+    start = time.monotonic()
+    received = _run_bridge(
+        server,
+        event,
+        app_name="CaDecon",
+        app_url="about:blank",
+        open_browser=False,
+        timeout=10.0,  # larger than real wait so we know heartbeat is what ended it
+    )
+    elapsed = time.monotonic() - start
+
+    assert received is False, "heartbeat timeout path must return False"
+    # Heartbeat check runs inside the wait loop that ticks every 1.0s, so
+    # first detection lands on the next tick. Cap at 3s to guard against
+    # regressions that fall through to the outer `timeout=10`.
+    assert elapsed < 3.0, (
+        f"heartbeat detection too slow: elapsed={elapsed:.2f}s (would hit outer 10s fallback)"
+    )
+
+
 # --- Cross-language schema consistency tests ---
 
 


### PR DESCRIPTION
## Summary
Final PR of the audit remediation track, addressing the remaining two test-coverage items:

### TEST-M3 — headless bridge failure modes
Existing bridge tests covered per-endpoint happy paths, the PNA/HTTPS fix from `b9f1536`, and the server's heartbeat tracking variable — but nothing exercised the `_run_bridge` wait loop's exit conditions. Two new tests in `python/tests/test_bridge.py`:

- **`test_run_bridge_timeout_returns_false`**: runs the loop with `timeout=0.2` and no event firing, asserts it returns `False` and elapsed < 3.0 so a regression that falls through to the heartbeat fallback (10s) fails loudly.
- **`test_run_bridge_detects_browser_crash_via_heartbeat_timeout`**: monkeypatches `HEARTBEAT_TIMEOUT` down to 0.1s, primes `last_heartbeat` with a stale timestamp (simulating a browser that started and then died), and asserts `_run_bridge` notices the timeout on its next 1s tick and exits `False` before reaching the outer 10s safety timeout.

### TEST-M4 — migrations apply-clean smoke test
Effectively satisfied by the `supabase` CI job added in #130. The "Apply migrations and run RLS policy matrix" step applies preamble + every migration 001–009 against a fresh `postgres:16` service container on every PR. Any migration that fails to apply cleanly would abort the job before the RLS matrix even ran. No additional tests needed; closing TEST-M4 retroactively.

## Test plan
- [x] `pytest -m "not integration"` — 198 passed (196 pre-existing + 2 new)
- [x] `ruff check src/ tests/` — clean
- [x] The two new tests complete in ~2.1s total

This closes out the 8-PR audit remediation sequence from `.planning/CODEBASE_AUDIT.md`. Original breakdown: 5 security/CI/logic/dead-code PRs (#120–126) + 5 test-coverage PRs (#127–130 + this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)