### PR TITLE
chore: bump GHA versions for Node 24 and clear solid/reactivity lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -26,7 +26,7 @@ jobs:
       - run: npm ci
 
       - name: Cache build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             **/.tsbuildinfo
@@ -56,7 +56,7 @@ jobs:
       run:
         working-directory: crates/solver
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-15)
@@ -87,9 +87,9 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -142,7 +142,7 @@ jobs:
       PGPASSWORD: test
       PGDATABASE: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install psql
         run: sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -52,9 +52,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -81,11 +81,11 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           VITE_APP_VERSION: ${{ github.ref_name }}
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: './dist/CaLab'
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/py/v')
@@ -29,7 +29,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: python3 -c "import re,os; v=os.environ['REF_NAME'].removeprefix('py/v'); p='python/pyproject.toml'; t=open(p).read(); open(p,'w').write(re.sub(r'^version = .*',f'version = \"{v}\"',t,flags=re.M))"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -76,7 +76,7 @@ jobs:
             target: x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/py/v')
@@ -85,7 +85,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: python3 -c "import re,os; v=os.environ['REF_NAME'].removeprefix('py/v'); p='python/pyproject.toml'; t=open(p).read(); open(p,'w').write(re.sub(r'^version = .*',f'version = \"{v}\"',t,flags=re.M))"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -98,7 +98,7 @@ jobs:
           manylinux: auto
           working-directory: python
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}-py${{ matrix.python-version }}
           path: python/dist
@@ -107,7 +107,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/py/v')
@@ -122,7 +122,7 @@ jobs:
           args: --out dist
           working-directory: python
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: python/dist
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true

--- a/apps/carank/src/App.tsx
+++ b/apps/carank/src/App.tsx
@@ -10,9 +10,11 @@ import { tutorials } from './tutorials/index.ts';
 import type { CnmfData } from './types.ts';
 
 const App: Component = () => {
-  if (isAuthCallback()) {
-    return <AuthCallback />;
-  }
+  // `isAuthCallback()` inspects window.location at mount time; the URL
+  // doesn't change within a single component lifetime, so the early
+  // return is safe.
+  // eslint-disable-next-line solid/components-return-once
+  if (isAuthCallback()) return <AuthCallback />;
 
   const [data, setData] = createSignal<CnmfData | null>(null);
   const [tutorialOpen, setTutorialOpen] = createSignal(false);

--- a/apps/catune/src/App.tsx
+++ b/apps/catune/src/App.tsx
@@ -64,10 +64,12 @@ function loadBannerDismissedState(): boolean {
 }
 
 const App: Component = () => {
-  // Magic-link callback: show lightweight confirmation instead of full app
-  if (isAuthCallback()) {
-    return <AuthCallback />;
-  }
+  // Magic-link callback: show lightweight confirmation instead of full app.
+  // `isAuthCallback()` inspects window.location at mount time; the URL
+  // doesn't change within a single component lifetime, so the early
+  // return is safe.
+  // eslint-disable-next-line solid/components-return-once
+  if (isAuthCallback()) return <AuthCallback />;
 
   // Auto-load from Python bridge if ?bridge= URL param is present
   const bridgeUrlParam = getBridgeUrl();

--- a/apps/catune/src/components/cards/CaTuneZoomWindow.tsx
+++ b/apps/catune/src/components/cards/CaTuneZoomWindow.tsx
@@ -279,6 +279,9 @@ export function CaTuneZoomWindow(props: CaTuneZoomWindowProps) {
       }
     }
 
+    // The mapper closures below read signals; they're invoked synchronously
+    // by sliceAndDownsample from within this memo's tracked scope.
+    /* eslint-disable solid/reactivity */
     const dsDeconv = sliceAndDownsample(
       props.deconvolvedTrace,
       x,
@@ -313,6 +316,7 @@ export function CaTuneZoomWindow(props: CaTuneZoomWindowProps) {
       dsX.length,
       (vals) => scaleToDeconvBand(vals, pinnedDeconvMinMax(), zMin, zMax),
     );
+    /* eslint-enable solid/reactivity */
 
     let dsGTCalcium: number[];
     if (props.groundTruthCalcium && props.groundTruthCalcium.length > 0) {

--- a/apps/catune/src/components/community/ScatterPlot.tsx
+++ b/apps/catune/src/components/community/ScatterPlot.tsx
@@ -219,6 +219,9 @@ export function ScatterPlot(props: ScatterPlotProps) {
     // Read CSS custom properties for theme-aware colors
     const theme = getThemeColors();
 
+    // The getters below bridge Solid reactivity into uPlot's draw-time hook;
+    // they're tracked scopes by virtue of being invoked inside the plot.
+    /* eslint-disable solid/reactivity */
     const drawFn = makeDrawPoints(
       lambdaColors,
       () => props.userParams,
@@ -227,6 +230,7 @@ export function ScatterPlot(props: ScatterPlotProps) {
       theme.textPrimary,
       theme.textSecondary,
     );
+    /* eslint-enable solid/reactivity */
 
     // Compute padded ranges so points aren't on the edge
     const xVals = subs.map((s) => s.t_peak * 1000);

--- a/apps/catune/src/components/community/SubmitForm.tsx
+++ b/apps/catune/src/components/community/SubmitForm.tsx
@@ -206,7 +206,7 @@ export function SubmitForm(props: SubmitFormProps) {
 
         <button
           class="btn-primary"
-          onClick={props.onSubmit}
+          onClick={() => props.onSubmit()}
           disabled={!props.requiredFieldsFilled() || props.submitting()}
         >
           {props.submitting() ? 'Submitting...' : 'Submit Parameters'}

--- a/apps/catune/src/components/layout/ImportOverlay.tsx
+++ b/apps/catune/src/components/layout/ImportOverlay.tsx
@@ -88,7 +88,7 @@ export function ImportOverlay(props: ImportOverlayProps): JSX.Element {
       {/* Start Over button */}
       <Show when={props.hasFile}>
         <div class="start-over-row">
-          <button class="btn-secondary btn-small" onClick={props.onReset}>
+          <button class="btn-secondary btn-small" onClick={() => props.onReset()}>
             Start Over
           </button>
         </div>

--- a/apps/catune/src/components/layout/SidebarTabs.tsx
+++ b/apps/catune/src/components/layout/SidebarTabs.tsx
@@ -49,12 +49,14 @@ export function SidebarTabs(props: SidebarTabsProps) {
     return list;
   };
 
-  let defaultTab: SidebarTab = 'metrics';
-  if (props.communityContent) {
-    defaultTab = 'community';
-  } else if (props.spectrumContent) {
-    defaultTab = 'spectrum';
-  }
+  // Default tab is intentionally computed once at mount from the initial
+  // props; callers never swap communityContent / spectrumContent after first
+  // render. Disable the reactivity rule for these one-shot reads.
+  // eslint-disable-next-line solid/reactivity
+  const hasCommunity = !!props.communityContent;
+  // eslint-disable-next-line solid/reactivity
+  const hasSpectrum = !!props.spectrumContent;
+  const defaultTab: SidebarTab = hasCommunity ? 'community' : hasSpectrum ? 'spectrum' : 'metrics';
 
   setActiveSidebarTab(defaultTab);
 

--- a/apps/catune/src/components/traces/KernelDisplay.tsx
+++ b/apps/catune/src/components/traces/KernelDisplay.tsx
@@ -67,6 +67,9 @@ export function KernelDisplay() {
     return computeKernelAnnotations(tau.tauRise, tau.tauDecay, fs);
   });
 
+  // The getter `() => annotations()` is the tracked scope bridge from
+  // Solid into the uPlot plugin API — the plugin invokes it at draw time.
+  // eslint-disable-next-line solid/reactivity
   const kernelPlugins: uPlot.Plugin[] = [kernelAnnotationsPlugin(() => annotations(), 1000)];
 
   return (

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -44,9 +44,9 @@ export function Card(props: CardProps) {
     <div
       class={`calab-card${props.class ? ` ${props.class}` : ''}`}
       style={props.height != null ? { height: `${props.height}px` } : undefined}
-      onClick={props.onClick}
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
+      onClick={(e) => props.onClick?.(e)}
+      onMouseEnter={(e) => props.onMouseEnter?.(e)}
+      onMouseLeave={(e) => props.onMouseLeave?.(e)}
       data-tutorial={props['data-tutorial']}
       ref={props.ref}
       {...spreadDataAttrs(props)}

--- a/packages/ui/src/CommunityBrowserShell.tsx
+++ b/packages/ui/src/CommunityBrowserShell.tsx
@@ -83,6 +83,9 @@ export function CommunityBrowserShell<
 >(props: CommunityBrowserShellProps<T, F, P>) {
   // --- State signals ---
   const [submissions, setSubmissions] = createSignal<T[]>([]);
+  // Seed dataSource from initial props.isDemo(); subsequent changes flow
+  // through the createEffect below.
+  // eslint-disable-next-line solid/reactivity
   const [dataSource, setDataSource] = createSignal<DataSource>(props.isDemo() ? 'demo' : 'user');
   const [loading, setLoading] = createSignal(false);
   const [collapsed, setCollapsed] = createSignal(false);
@@ -173,7 +176,10 @@ export function CommunityBrowserShell<
   const compareLabels = () =>
     props.compareLabel ?? { active: 'Hide my params', inactive: 'Compare my params' };
 
-  // Guard: do not render if Supabase is not configured
+  // Guard: do not render if Supabase is not configured. `supabaseEnabled`
+  // is a module-constant (env-derived at load time), not a reactive signal,
+  // so an early return here is safe and never becomes stale.
+  // eslint-disable-next-line solid/components-return-once
   if (!supabaseEnabled) return null;
 
   return (

--- a/packages/ui/src/FilterBar.tsx
+++ b/packages/ui/src/FilterBar.tsx
@@ -137,7 +137,7 @@ export function FilterBar<F extends BaseFilterState>(props: FilterBarProps<F>) {
       <Show when={props.canHighlight}>
         <button
           class={`filter-bar__highlight-btn ${props.highlightMine ? 'filter-bar__highlight-btn--active' : ''}`}
-          onClick={props.onHighlightMineChange}
+          onClick={() => props.onHighlightMineChange?.()}
         >
           {props.highlightMine ? '\u25CF' : '\u25CB'} My submissions
         </button>

--- a/packages/ui/src/SubmissionSummary.tsx
+++ b/packages/ui/src/SubmissionSummary.tsx
@@ -57,7 +57,7 @@ export function SubmissionSummary<T extends BaseSubmission>(props: SubmissionSum
       </Show>
 
       <div class="submission-summary__actions">
-        <button class="btn-primary btn-small" onClick={props.onDismiss}>
+        <button class="btn-primary btn-small" onClick={() => props.onDismiss()}>
           Close
         </button>
         <button class="btn-secondary btn-small" onClick={handleDelete} disabled={deleting()}>

--- a/packages/ui/src/TutorialLauncher.tsx
+++ b/packages/ui/src/TutorialLauncher.tsx
@@ -10,7 +10,7 @@ export function TutorialLauncher(props: TutorialLauncherProps): JSX.Element {
     <button
       class="btn-secondary btn-small"
       data-tutorial="tutorial-launcher"
-      onClick={props.onToggle}
+      onClick={() => props.onToggle()}
     >
       {props.isOpen() ? 'Close Tutorial' : 'Tutorial'}
     </button>

--- a/packages/ui/src/chart/TracePanel.tsx
+++ b/packages/ui/src/chart/TracePanel.tsx
@@ -61,7 +61,9 @@ export function TracePanel(props: TracePanelProps) {
   };
 
   // Build axes config once — stable references prevent SolidUplot from
-  // recreating the chart on every data update
+  // recreating the chart on every data update. `props.xLabel` is read at
+  // mount; callers never swap it mid-chart-life.
+  /* eslint-disable solid/reactivity */
   const xAxis: uPlot.Axis = {
     stroke: AXIS_TEXT,
     grid: { stroke: AXIS_GRID },
@@ -71,6 +73,7 @@ export function TracePanel(props: TracePanelProps) {
       ? { label: props.xLabel, labelSize: 10, labelGap: 0, labelFont: '10px sans-serif', size: 30 }
       : {}),
   };
+  /* eslint-enable solid/reactivity */
 
   const yAxisBase: uPlot.Axis = {
     stroke: AXIS_TEXT,


### PR DESCRIPTION
## Summary
Two small cleanups bundled together.

### 1. Node-24-ready GitHub Actions
Clears the \`Node.js 20 actions are deprecated\` warning surfaced on every CI/deploy run (Node 20 leaves the runner 2026-09-16). First-party actions only; third-party actions remain SHA-pinned.

| Action | Old | New |
| --- | --- | --- |
| \`actions/checkout\` | v4 | v6 |
| \`actions/setup-node\` | v4 | v6 |
| \`actions/setup-python\` | v5 | v6 |
| \`actions/cache\` | v4 | v5 |
| \`actions/configure-pages\` | v4 | v6 |
| \`actions/upload-pages-artifact\` | v3 | v5 |
| \`actions/deploy-pages\` | v4 | v5 |
| \`actions/upload-artifact\` | v4 | v7 |
| \`actions/download-artifact\` | v4 | v8 |

### 2. Clear 21 lint warnings
\`npm run lint\` is now silent (0 errors, 0 warnings). Two kinds of fixes:

- **Wrap event-handler prop bindings** in \`(...args) => props.onX?.(...args)\` so handlers stay tracked when parents swap them: \`Card\`, \`FilterBar\`, \`SubmissionSummary\`, \`TutorialLauncher\`, \`SubmitForm\`, \`ImportOverlay\`.
- **Suppress with a justified comment** where the read is genuinely one-shot at mount: \`SidebarTabs\` initial default-tab, \`CommunityBrowserShell\` \`supabaseEnabled\` guard + initial \`dataSource\` seed, \`KernelDisplay\` plugin getter, \`TracePanel\` axes config, \`ScatterPlot\` drawFn closures, \`CaTuneZoomWindow\` downsample mappers, catune/carank \`App.tsx\` auth-callback early returns.

None of these change runtime behavior — the event-handler wrappers call through to the same underlying handler, and the suppression comments document why the one-shot reads are safe.

## Test plan
- [x] \`npm run lint\` — 0 errors, 0 warnings (was 0 errors, 21 warnings)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm test --workspaces\` — all 6 workspaces green (269 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)