### PR TITLE
chore: gitignore the whole .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ crates/solver/target/
 test/
 .env
 .env.local
-.claude/settings.local.json
+.claude/
 python/src/calab/*.so
 python/docs/_build/
 python/docs/autoapi/


### PR DESCRIPTION
## Summary

- `.gitignore` previously ignored only `.claude/settings.local.json`, so runtime state files like `.claude/scheduled_tasks.lock` leaked into `git status`.
- CaLab doesn't share Claude config via the repo, so broaden to the whole `.claude/` directory.

## Test plan

- [x] `git status` on a fresh clone with the Claude Code CLI active no longer lists any `.claude/` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)