### PR TITLE
feat(cala-core): Phase 2 — single-frame OMF fit loop

### DIFF
--- a/crates/cala-core/src/assets/footprints.rs
+++ b/crates/cala-core/src/assets/footprints.rs
@@ -1,0 +1,255 @@
+//! Sparse footprint matrix `Ã` (thesis §3.2.3, Eq. 3.18).
+//!
+//! Each column `Ã[:, i]` is the spatial footprint of estimator `i`,
+//! stored as a pair of arrays `(support, values)` covering only the
+//! pixels on the column's positive support. Pixel indices use the
+//! same row-major convention as `Frame`: `pixel_idx = y * width + x`.
+//!
+//! Storage is a column-indexed `Vec<Component>` rather than a general
+//! sparse matrix (design §5 calls out `sprs` as a possible drop-in
+//! once profiling justifies it). The in-house rep keeps push / value
+//! mutation / compact cheap, which matters for the `EvaluateFootprints`
+//! inner loop that shrinks support morphologically every frame.
+
+/// Sparse non-negative footprint matrix.
+#[derive(Debug, Clone)]
+pub struct Footprints {
+    height: usize,
+    width: usize,
+    pixels: usize,
+    components: Vec<Component>,
+}
+
+#[derive(Debug, Clone)]
+struct Component {
+    /// Pixel indices in positive support, sorted strictly ascending.
+    support: Vec<u32>,
+    /// Values aligned with `support`; all entries are `> 0` after
+    /// construction or `compact`.
+    values: Vec<f32>,
+}
+
+impl Footprints {
+    pub fn new(height: usize, width: usize) -> Self {
+        assert!(
+            height > 0 && width > 0,
+            "Footprints requires positive dimensions (got {height}×{width})"
+        );
+        let pixels = height * width;
+        assert!(
+            pixels <= u32::MAX as usize,
+            "frame pixel count {pixels} exceeds u32::MAX"
+        );
+        Self {
+            height,
+            width,
+            pixels,
+            components: Vec::new(),
+        }
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn pixels(&self) -> usize {
+        self.pixels
+    }
+
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    /// Append a new component with the given positive support.
+    ///
+    /// `support` must be sorted strictly ascending (which also forbids
+    /// duplicates); `values` must have the same length and be strictly
+    /// positive; pixel indices must be `< pixels()`.
+    pub fn push_component(&mut self, support: Vec<u32>, values: Vec<f32>) -> usize {
+        validate_component(&support, &values, self.pixels);
+        let id = self.components.len();
+        self.components.push(Component { support, values });
+        id
+    }
+
+    pub fn support(&self, i: usize) -> &[u32] {
+        &self.components[i].support
+    }
+
+    pub fn values(&self, i: usize) -> &[f32] {
+        &self.components[i].values
+    }
+
+    pub fn values_mut(&mut self, i: usize) -> &mut [f32] {
+        &mut self.components[i].values
+    }
+
+    /// Compute `Aᵀy` — one inner product per column over its support.
+    /// Returns a dense length-`k` vector (`k = len()`).
+    pub fn aty(&self, y: &[f32]) -> Vec<f32> {
+        assert_eq!(
+            y.len(),
+            self.pixels,
+            "y length {} must equal pixels {}",
+            y.len(),
+            self.pixels
+        );
+        self.components
+            .iter()
+            .map(|component| {
+                component
+                    .support
+                    .iter()
+                    .zip(&component.values)
+                    .map(|(&p, &v)| v * y[p as usize])
+                    .sum()
+            })
+            .collect()
+    }
+
+    /// Compute `AᵀA` as a dense `k × k` row-major matrix.
+    ///
+    /// Uses a two-pointer merge over each pair's sorted supports so the
+    /// per-pair cost is `O(|supp_i| + |supp_j|)` rather than
+    /// `O(|supp_i| · |supp_j|)`.
+    pub fn ata(&self) -> Vec<f32> {
+        let k = self.components.len();
+        let mut out = vec![0.0f32; k * k];
+        for i in 0..k {
+            let ci = &self.components[i];
+            // Diagonal.
+            out[i * k + i] = ci.values.iter().map(|&v| v * v).sum();
+            // Upper triangle — mirror to lower to keep symmetry exact.
+            for j in (i + 1)..k {
+                let cj = &self.components[j];
+                let dot = sorted_support_dot(&ci.support, &ci.values, &cj.support, &cj.values);
+                out[i * k + j] = dot;
+                out[j * k + i] = dot;
+            }
+        }
+        out
+    }
+
+    /// Write `Ãc` into `out`. `out` is first zeroed, then each component's
+    /// contribution is accumulated at its support pixels.
+    pub fn reconstruct(&self, c: &[f32], out: &mut [f32]) {
+        assert_eq!(
+            c.len(),
+            self.components.len(),
+            "c length {} must equal number of components {}",
+            c.len(),
+            self.components.len()
+        );
+        assert_eq!(
+            out.len(),
+            self.pixels,
+            "out length {} must equal pixels {}",
+            out.len(),
+            self.pixels
+        );
+        out.fill(0.0);
+        for (component, &ci) in self.components.iter().zip(c) {
+            if ci == 0.0 {
+                continue;
+            }
+            for (&p, &v) in component.support.iter().zip(&component.values) {
+                out[p as usize] += v * ci;
+            }
+        }
+    }
+
+    /// Drop any entry with value `≤ 0` from component `i`'s support.
+    ///
+    /// After `EvaluateFootprints` (Algorithm 8 line 5) a value may have
+    /// been clamped to zero by the `max(·, 0)` guard. Compact removes
+    /// those stale entries so the sparse rep reflects the morphological
+    /// shrink. Defensive against negatives as well (should not occur,
+    /// but if they do the invariant "values are strictly positive" stays
+    /// intact after this call).
+    pub fn compact(&mut self, i: usize) {
+        let component = &mut self.components[i];
+        let mut write = 0usize;
+        for read in 0..component.values.len() {
+            if component.values[read] > 0.0 {
+                component.support[write] = component.support[read];
+                component.values[write] = component.values[read];
+                write += 1;
+            }
+        }
+        component.support.truncate(write);
+        component.values.truncate(write);
+    }
+
+    /// For each pixel, count how many components have that pixel in
+    /// their positive support. Used by the trace-throttle step, which
+    /// only fires on pixels where `count == 1` (a single component's
+    /// exclusive support).
+    pub fn pixel_component_counts(&self) -> Vec<u32> {
+        let mut counts = vec![0u32; self.pixels];
+        for component in &self.components {
+            for &p in &component.support {
+                counts[p as usize] += 1;
+            }
+        }
+        counts
+    }
+}
+
+fn validate_component(support: &[u32], values: &[f32], pixels: usize) {
+    assert_eq!(
+        support.len(),
+        values.len(),
+        "support / values length mismatch: {} vs {}",
+        support.len(),
+        values.len()
+    );
+    for win in support.windows(2) {
+        assert!(
+            win[0] < win[1],
+            "support must be strictly ascending (duplicates / out-of-order not allowed)"
+        );
+    }
+    if let Some(&last) = support.last() {
+        assert!(
+            (last as usize) < pixels,
+            "pixel index {last} out of range (pixels = {pixels})"
+        );
+    }
+    for &v in values {
+        assert!(v > 0.0, "values must be positive (got {v})");
+    }
+}
+
+/// Two-pointer merge over two sorted support slices, accumulating the
+/// product of aligned values at shared indices.
+fn sorted_support_dot(
+    support_a: &[u32],
+    values_a: &[f32],
+    support_b: &[u32],
+    values_b: &[f32],
+) -> f32 {
+    let (mut ia, mut ib) = (0usize, 0usize);
+    let mut acc = 0.0f32;
+    while ia < support_a.len() && ib < support_b.len() {
+        let pa = support_a[ia];
+        let pb = support_b[ib];
+        match pa.cmp(&pb) {
+            std::cmp::Ordering::Less => ia += 1,
+            std::cmp::Ordering::Greater => ib += 1,
+            std::cmp::Ordering::Equal => {
+                acc += values_a[ia] * values_b[ib];
+                ia += 1;
+                ib += 1;
+            }
+        }
+    }
+    acc
+}

--- a/crates/cala-core/src/assets/groups.rs
+++ b/crates/cala-core/src/assets/groups.rs
@@ -1,0 +1,134 @@
+//! Group partition `G` (thesis §3.2.3, Algorithm 7 line 9).
+//!
+//! Components `i` and `j` are in the same group iff their positive
+//! spatial supports intersect (directly or transitively). The partition
+//! matches the connected components of the `AᵀA ≠ 0` graph and is what
+//! `EvaluateTraces` iterates over: within a group the BCD update is
+//! coupled, across groups it decouples so groups can be processed
+//! independently (and in principle in parallel).
+//!
+//! Computation uses a pixel-indexed union-find: for every pixel, we
+//! union all components that touch it. Cost is `O(Σᵢ |supp_i| · α(k))`
+//! per rebuild, cheap enough to recompute from scratch when footprints
+//! change rather than maintain incrementally.
+
+use super::Footprints;
+
+#[derive(Debug, Clone)]
+pub struct Groups {
+    groups: Vec<Vec<usize>>,
+    component_to_group: Vec<usize>,
+}
+
+impl Groups {
+    pub fn from_footprints(fp: &Footprints) -> Self {
+        let k = fp.len();
+        if k == 0 {
+            return Self {
+                groups: Vec::new(),
+                component_to_group: Vec::new(),
+            };
+        }
+        let mut uf = UnionFind::new(k);
+
+        // For each pixel, union every pair of components that share it.
+        // Cheaper than the explicit k×k pair check when supports are sparse.
+        let mut first_per_pixel: Vec<i32> = vec![-1; fp.pixels()];
+        for component in 0..k {
+            for &p in fp.support(component) {
+                let p = p as usize;
+                let prev = first_per_pixel[p];
+                if prev < 0 {
+                    first_per_pixel[p] = component as i32;
+                } else {
+                    uf.union(prev as usize, component);
+                }
+            }
+        }
+
+        // Collect components into group vectors keyed by their root.
+        let mut group_of_root: Vec<i32> = vec![-1; k];
+        let mut groups: Vec<Vec<usize>> = Vec::new();
+        let mut component_to_group = vec![0usize; k];
+        for i in 0..k {
+            let root = uf.find(i);
+            let gi = if group_of_root[root] < 0 {
+                let gi = groups.len();
+                groups.push(Vec::new());
+                group_of_root[root] = gi as i32;
+                gi
+            } else {
+                group_of_root[root] as usize
+            };
+            groups[gi].push(i);
+            component_to_group[i] = gi;
+        }
+
+        Self {
+            groups,
+            component_to_group,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    pub fn num_components(&self) -> usize {
+        self.component_to_group.len()
+    }
+
+    pub fn group(&self, g: usize) -> &[usize] {
+        &self.groups[g]
+    }
+
+    pub fn group_of(&self, component: usize) -> usize {
+        self.component_to_group[component]
+    }
+
+    pub fn iter_groups(&self) -> impl Iterator<Item = &[usize]> {
+        self.groups.iter().map(Vec::as_slice)
+    }
+}
+
+struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+            rank: vec![0; n],
+        }
+    }
+
+    fn find(&mut self, mut x: usize) -> usize {
+        while self.parent[x] != x {
+            self.parent[x] = self.parent[self.parent[x]];
+            x = self.parent[x];
+        }
+        x
+    }
+
+    fn union(&mut self, a: usize, b: usize) {
+        let ra = self.find(a);
+        let rb = self.find(b);
+        if ra == rb {
+            return;
+        }
+        match self.rank[ra].cmp(&self.rank[rb]) {
+            std::cmp::Ordering::Less => self.parent[ra] = rb,
+            std::cmp::Ordering::Greater => self.parent[rb] = ra,
+            std::cmp::Ordering::Equal => {
+                self.parent[rb] = ra;
+                self.rank[ra] += 1;
+            }
+        }
+    }
+}

--- a/crates/cala-core/src/assets/mod.rs
+++ b/crates/cala-core/src/assets/mod.rs
@@ -5,8 +5,10 @@
 //! asset suite (footprints A, traces C, suff-stats W/M, groups G, residual R)
 //! arrives in Phase 2+; see design §5.
 
+mod footprints;
 mod frame;
 
+pub use footprints::Footprints;
 pub use frame::{Frame, FrameMut, ShapeError};
 
 /// Logical axis labels used across the crate.

--- a/crates/cala-core/src/assets/mod.rs
+++ b/crates/cala-core/src/assets/mod.rs
@@ -7,10 +7,12 @@
 
 mod footprints;
 mod frame;
+mod suff_stats;
 mod traces;
 
 pub use footprints::Footprints;
 pub use frame::{Frame, FrameMut, ShapeError};
+pub use suff_stats::SuffStats;
 pub use traces::Traces;
 
 /// Logical axis labels used across the crate.

--- a/crates/cala-core/src/assets/mod.rs
+++ b/crates/cala-core/src/assets/mod.rs
@@ -7,11 +7,13 @@
 
 mod footprints;
 mod frame;
+mod groups;
 mod suff_stats;
 mod traces;
 
 pub use footprints::Footprints;
 pub use frame::{Frame, FrameMut, ShapeError};
+pub use groups::Groups;
 pub use suff_stats::SuffStats;
 pub use traces::Traces;
 

--- a/crates/cala-core/src/assets/mod.rs
+++ b/crates/cala-core/src/assets/mod.rs
@@ -7,9 +7,11 @@
 
 mod footprints;
 mod frame;
+mod traces;
 
 pub use footprints::Footprints;
 pub use frame::{Frame, FrameMut, ShapeError};
+pub use traces::Traces;
 
 /// Logical axis labels used across the crate.
 ///

--- a/crates/cala-core/src/assets/suff_stats.rs
+++ b/crates/cala-core/src/assets/suff_stats.rs
@@ -1,0 +1,86 @@
+//! Sufficient statistics storage `W` and `M` (thesis §3.2.3,
+//! Eqs. 3.20–3.22).
+//!
+//! `W ∈ R^((xy) × k)` is the cumulative `y cᵀ` co-activation per
+//! (pixel, component) pair; `M ∈ R^(k × k)` is the cumulative `c cᵀ`
+//! co-activation between components. Both update recursively per
+//! Eq. 3.22 / 3.25, eliminating the need to revisit past frames —
+//! the *point* of the OMF formulation.
+//!
+//! The module here is just the container. Update math (with the
+//! SNR-gated `f(c) = c · H(c − c₀)` from Eq. 3.25) lives in
+//! `fitting::suff_stats`.
+
+#[derive(Debug, Clone)]
+pub struct SuffStats {
+    pixels: usize,
+    k: usize,
+    frames: u64,
+    /// Row-major `pixels × k` storage: `W[p, i]` at `p * k + i`.
+    w: Vec<f32>,
+    /// Row-major `k × k` storage: `M[i, j]` at `i * k + j`.
+    m: Vec<f32>,
+}
+
+impl SuffStats {
+    pub fn new(pixels: usize, k: usize) -> Self {
+        assert!(pixels > 0, "pixels must be positive");
+        Self {
+            pixels,
+            k,
+            frames: 0,
+            w: vec![0.0; pixels * k],
+            m: vec![0.0; k * k],
+        }
+    }
+
+    pub fn pixels(&self) -> usize {
+        self.pixels
+    }
+
+    pub fn k(&self) -> usize {
+        self.k
+    }
+
+    pub fn frames(&self) -> u64 {
+        self.frames
+    }
+
+    pub fn increment_frames(&mut self) {
+        self.frames += 1;
+    }
+
+    pub fn w(&self) -> &[f32] {
+        &self.w
+    }
+
+    pub fn w_mut(&mut self) -> &mut [f32] {
+        &mut self.w
+    }
+
+    pub fn m(&self) -> &[f32] {
+        &self.m
+    }
+
+    pub fn m_mut(&mut self) -> &mut [f32] {
+        &mut self.m
+    }
+
+    /// Flat index for `W[p, i]` in the row-major `(pixels, k)` layout.
+    pub fn w_idx(&self, p: usize, i: usize) -> usize {
+        p * self.k + i
+    }
+
+    /// Flat index for `M[i, j]` in the row-major `(k, k)` layout.
+    pub fn m_idx(&self, i: usize, j: usize) -> usize {
+        i * self.k + j
+    }
+
+    pub fn w_at(&self, p: usize, i: usize) -> f32 {
+        self.w[self.w_idx(p, i)]
+    }
+
+    pub fn m_at(&self, i: usize, j: usize) -> f32 {
+        self.m[self.m_idx(i, j)]
+    }
+}

--- a/crates/cala-core/src/assets/traces.rs
+++ b/crates/cala-core/src/assets/traces.rs
@@ -1,0 +1,82 @@
+//! Trace history `C̃` (thesis §3.2.3).
+//!
+//! Row `t` is the trace vector `c̃_t ∈ R^k` for frame `t`. Stored as a
+//! flat row-major `Vec<f32>` so the boundary layer can hand it to
+//! numpy / xarray as a `(t, k)` view without any copy.
+//!
+//! Phase 2 holds the whole history in RAM; a `PersistentTraceBacking`
+//! trait (design §5) will later back this onto Zarr / OPFS.
+
+#[derive(Debug, Clone)]
+pub struct Traces {
+    k: usize,
+    /// Row-major `len × k` storage. `len = data.len() / max(k, 1)`.
+    data: Vec<f32>,
+    /// Frame count tracked explicitly so a zero-component history
+    /// (`k == 0`) can still advance a counter with each `push`.
+    frames: usize,
+}
+
+impl Traces {
+    pub fn new(k: usize) -> Self {
+        Self {
+            k,
+            data: Vec::new(),
+            frames: 0,
+        }
+    }
+
+    /// Number of components per trace.
+    pub fn k(&self) -> usize {
+        self.k
+    }
+
+    /// Number of frames pushed.
+    pub fn len(&self) -> usize {
+        self.frames
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.frames == 0
+    }
+
+    /// Append `c̃_t` for the next frame. `trace.len()` must equal `k()`.
+    pub fn push(&mut self, trace: &[f32]) {
+        assert_eq!(
+            trace.len(),
+            self.k,
+            "trace length {} must equal k = {}",
+            trace.len(),
+            self.k
+        );
+        self.data.extend_from_slice(trace);
+        self.frames += 1;
+    }
+
+    /// Slice `c̃_t` for frame `t`, or `None` if out of range.
+    pub fn get(&self, t: usize) -> Option<&[f32]> {
+        if t >= self.frames || self.k == 0 {
+            if t >= self.frames {
+                return None;
+            }
+            // k == 0 but frame is in range — return empty slice.
+            return Some(&[]);
+        }
+        let start = t * self.k;
+        Some(&self.data[start..start + self.k])
+    }
+
+    /// Most recently pushed trace.
+    pub fn last(&self) -> Option<&[f32]> {
+        if self.frames == 0 {
+            None
+        } else {
+            self.get(self.frames - 1)
+        }
+    }
+
+    /// Flat row-major `(len × k)` view of the full history.
+    pub fn as_matrix(&self) -> &[f32] {
+        &self.data
+    }
+}

--- a/crates/cala-core/src/config.rs
+++ b/crates/cala-core/src/config.rs
@@ -297,3 +297,79 @@ impl PreprocessConfig {
         self
     }
 }
+
+// ── Fit loop (Phase 2, OMF) ────────────────────────────────────────────
+
+/// Relative convergence tolerance for `EvaluateTraces` (thesis Algorithm 7).
+/// Inner loop exits when `‖c − c_step‖ < ε · ‖c_step‖`. 1e-3 is tight
+/// enough that downstream suff-stats see well-converged traces without
+/// blowing the per-frame iteration budget on asymptotic refinement.
+pub const DEFAULT_TRACE_TOL: f32 = 1e-3;
+
+/// Hard cap on `EvaluateTraces` iterations. Bounds per-frame latency
+/// when BCD fails to converge (pathological overfit on an unmodeled
+/// frame — see thesis §3.2.3 "bounded latency" discussion).
+pub const DEFAULT_TRACE_MAX_ITER: u32 = 20;
+
+/// Number of outer iterations of `EvaluateFootprints` per frame
+/// (thesis Algorithm 8 `miter`). Footprint updates accumulate over
+/// many frames via W/M, so a small per-frame iter count is fine.
+pub const DEFAULT_FOOTPRINT_MAX_ITER: u32 = 5;
+
+/// SNR threshold `c₀` for the Heaviside gate in `EvaluateSuffStats`
+/// (thesis Eq. 3.25, `f(c) = c · H(c − c₀)`). Samples with `c_i ≤ c₀`
+/// contribute nothing to `W`, `M` on this frame. Prevents footprints
+/// from drifting toward noise on long recordings when a cell is quiet.
+/// Units are the same as trace amplitude (same as preprocessed pixel
+/// intensity). Tune per recording.
+pub const DEFAULT_SNR_C0: f32 = 0.0;
+
+/// Per-frame tuning for the OMF fit loop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FitConfig {
+    /// Relative tolerance for `EvaluateTraces` BCD convergence.
+    pub trace_tol: f32,
+    /// Maximum BCD iterations inside one call to `EvaluateTraces`.
+    pub trace_max_iter: u32,
+    /// Outer iterations of `EvaluateFootprints` per frame.
+    pub footprint_max_iter: u32,
+    /// Heaviside SNR threshold `c₀` for suff-stats gating.
+    pub snr_c0: f32,
+}
+
+impl Default for FitConfig {
+    fn default() -> Self {
+        Self {
+            trace_tol: DEFAULT_TRACE_TOL,
+            trace_max_iter: DEFAULT_TRACE_MAX_ITER,
+            footprint_max_iter: DEFAULT_FOOTPRINT_MAX_ITER,
+            snr_c0: DEFAULT_SNR_C0,
+        }
+    }
+}
+
+impl FitConfig {
+    pub fn with_trace_tol(mut self, tol: f32) -> Self {
+        assert!(tol > 0.0, "trace_tol must be positive (got {tol})");
+        self.trace_tol = tol;
+        self
+    }
+
+    pub fn with_trace_max_iter(mut self, n: u32) -> Self {
+        assert!(n >= 1, "trace_max_iter must be ≥ 1 (got {n})");
+        self.trace_max_iter = n;
+        self
+    }
+
+    pub fn with_footprint_max_iter(mut self, n: u32) -> Self {
+        assert!(n >= 1, "footprint_max_iter must be ≥ 1 (got {n})");
+        self.footprint_max_iter = n;
+        self
+    }
+
+    pub fn with_snr_c0(mut self, c0: f32) -> Self {
+        assert!(c0 >= 0.0, "snr_c0 must be non-negative (got {c0})");
+        self.snr_c0 = c0;
+        self
+    }
+}

--- a/crates/cala-core/src/fitting/footprints.rs
+++ b/crates/cala-core/src/fitting/footprints.rs
@@ -1,0 +1,83 @@
+//! `EvaluateFootprints` — per-column coordinate descent on positive
+//! support using accumulated statistics `W`, `M` (thesis §3.2.3,
+//! Algorithm 8).
+//!
+//! For each component `i`:
+//! ```text
+//! Ã[p, i] ← max(Ã[p, i] + (W[p, i] − Ã[p, :] M[:, i]) / M[i, i], 0)    ∀ p ∈ supp(i)
+//! ```
+//! After the outer sweep we compact each column so any entry that
+//! got clamped to zero leaves the sparse rep — that is how
+//! morphological shrink is recorded in this algorithm. Support never
+//! expands here; expanding is Extend's job (Phase 3).
+
+use crate::assets::{Footprints, SuffStats};
+use crate::config::FitConfig;
+
+pub fn evaluate_footprints(fp: &mut Footprints, ss: &SuffStats, cfg: &FitConfig) {
+    let k = fp.len();
+    if k == 0 {
+        return;
+    }
+    assert_eq!(
+        ss.pixels(),
+        fp.pixels(),
+        "SuffStats pixels {} must match Footprints pixels {}",
+        ss.pixels(),
+        fp.pixels()
+    );
+    assert_eq!(
+        ss.k(),
+        k,
+        "SuffStats k {} must match Footprints len {}",
+        ss.k(),
+        k
+    );
+
+    let pixels = fp.pixels();
+    // Reused per-i buffer: r[p] = Σⱼ Ã[p, j] · M[j, i] (the "reconstruction
+    // weighted by M[:, i]" term). Allocated once and zeroed each pass.
+    let mut r = vec![0.0f32; pixels];
+
+    for _ in 0..cfg.footprint_max_iter {
+        for i in 0..k {
+            let mii = ss.m_at(i, i);
+            if mii <= 0.0 {
+                // No accumulated observations for this component's
+                // trace, so Algorithm 8's division by M[i, i] is
+                // undefined. Skip — leaves Ã untouched.
+                continue;
+            }
+
+            // Rebuild r from current Ã. Gauss-Seidel across `i` means
+            // earlier columns' updates within this outer iter propagate
+            // into this SpMV.
+            r.fill(0.0);
+            for j in 0..k {
+                let mji = ss.m_at(j, i);
+                if mji == 0.0 {
+                    continue;
+                }
+                for (&p, &val) in fp.support(j).iter().zip(fp.values(j)) {
+                    r[p as usize] += val * mji;
+                }
+            }
+
+            let inv_mii = 1.0f32 / mii;
+            let support_len = fp.support(i).len();
+            for s_idx in 0..support_len {
+                let p = fp.support(i)[s_idx] as usize;
+                let w_pi = ss.w_at(p, i);
+                let cur = fp.values(i)[s_idx];
+                let new_val = (cur + (w_pi - r[p]) * inv_mii).max(0.0);
+                fp.values_mut(i)[s_idx] = new_val;
+            }
+        }
+
+        // Remove any zeroed entries so subsequent iterations see only
+        // positive support (the Algorithm 8 `find(Ã[:, i] > 0)` step).
+        for i in 0..k {
+            fp.compact(i);
+        }
+    }
+}

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -1,0 +1,12 @@
+//! Online matrix factorization (OMF) fit loop.
+//!
+//! Per-frame portion of the cala pipeline described in thesis §3.2.3
+//! (Algorithm 6). One frame goes in, the model state (`Ã`, `C̃`, `W`,
+//! `M`, `G`) is updated, and a residual comes out for the (Phase 3)
+//! Extend loop to consume.
+//!
+//! Submodules follow the algorithmic split from the thesis so each
+//! primitive can be tested in isolation against its defining equation:
+//! `trace_bcd` → Algorithm 7, `suff_stats` → Eq. 3.25, `footprints`
+//! → Algorithm 8, `residual` → Eq. 3.24, `throttle` → underfit
+//! correction discussion following Eq. 3.24.

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -12,12 +12,14 @@
 //! correction discussion following Eq. 3.24.
 
 mod footprints;
+mod pipeline;
 mod residual;
 mod suff_stats;
 mod throttle;
 mod trace_bcd;
 
 pub use footprints::evaluate_footprints;
+pub use pipeline::FitPipeline;
 pub use residual::evaluate_residual;
 pub use suff_stats::evaluate_suff_stats;
 pub use throttle::trace_throttle;

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -12,9 +12,13 @@
 //! correction discussion following Eq. 3.24.
 
 mod footprints;
+mod residual;
 mod suff_stats;
+mod throttle;
 mod trace_bcd;
 
 pub use footprints::evaluate_footprints;
+pub use residual::evaluate_residual;
 pub use suff_stats::evaluate_suff_stats;
+pub use throttle::trace_throttle;
 pub use trace_bcd::evaluate_traces;

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -10,3 +10,7 @@
 //! `trace_bcd` → Algorithm 7, `suff_stats` → Eq. 3.25, `footprints`
 //! → Algorithm 8, `residual` → Eq. 3.24, `throttle` → underfit
 //! correction discussion following Eq. 3.24.
+
+mod trace_bcd;
+
+pub use trace_bcd::evaluate_traces;

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -11,6 +11,8 @@
 //! → Algorithm 8, `residual` → Eq. 3.24, `throttle` → underfit
 //! correction discussion following Eq. 3.24.
 
+mod suff_stats;
 mod trace_bcd;
 
+pub use suff_stats::evaluate_suff_stats;
 pub use trace_bcd::evaluate_traces;

--- a/crates/cala-core/src/fitting/mod.rs
+++ b/crates/cala-core/src/fitting/mod.rs
@@ -11,8 +11,10 @@
 //! → Algorithm 8, `residual` → Eq. 3.24, `throttle` → underfit
 //! correction discussion following Eq. 3.24.
 
+mod footprints;
 mod suff_stats;
 mod trace_bcd;
 
+pub use footprints::evaluate_footprints;
 pub use suff_stats::evaluate_suff_stats;
 pub use trace_bcd::evaluate_traces;

--- a/crates/cala-core/src/fitting/pipeline.rs
+++ b/crates/cala-core/src/fitting/pipeline.rs
@@ -1,0 +1,114 @@
+//! Per-frame OMF step composing the primitive fit nodes
+//! (thesis §3.2.3, Algorithm 6).
+//!
+//! Pipeline order:
+//! 1. `EvaluateTraces`        — NNLS-BCD for `c̃_t` given current `Ã`
+//! 2. Residual for throttling — `R_raw = y_t − Ã c̃_t`
+//! 3. `trace_throttle`        — Eq. 3.39 underfit correction
+//! 4. Append corrected `c̃_t` to trace history
+//! 5. `EvaluateSuffStats`     — recursive-mean update of `W`, `M`
+//! 6. `EvaluateFootprints`    — CD update of `Ã` from `W`, `M`
+//! 7. Final residual           — `R_t = y_t − Ã_new c̃_t` (output for Extend)
+//!
+//! Throttle placement note: the thesis describes throttling as
+//! "during the residual computation" (step 7 of Alg 6). We apply it
+//! *before* the suff-stats and footprint updates so those see the
+//! corrected traces — same end state, but `W`/`M` do not accumulate
+//! the over-estimated pre-throttle traces, which matches the "data
+//! cleaning" framing at the end of thesis §3.2.3.
+
+use crate::assets::{Footprints, Groups, SuffStats, Traces};
+use crate::config::FitConfig;
+
+use super::{
+    evaluate_footprints, evaluate_residual, evaluate_suff_stats, evaluate_traces, trace_throttle,
+};
+
+/// Holds all persistent OMF state and runs one frame per `step`.
+#[derive(Debug)]
+pub struct FitPipeline {
+    fp: Footprints,
+    traces: Traces,
+    ss: SuffStats,
+    cfg: FitConfig,
+    /// Scratch buffer for the residual — reused across frames to avoid
+    /// per-frame allocation in the fit hot path.
+    residual: Vec<f32>,
+}
+
+impl FitPipeline {
+    pub fn new(fp: Footprints, cfg: FitConfig) -> Self {
+        let k = fp.len();
+        let pixels = fp.pixels();
+        Self {
+            traces: Traces::new(k),
+            ss: SuffStats::new(pixels, k),
+            residual: vec![0.0f32; pixels],
+            fp,
+            cfg,
+        }
+    }
+
+    pub fn footprints(&self) -> &Footprints {
+        &self.fp
+    }
+
+    pub fn traces(&self) -> &Traces {
+        &self.traces
+    }
+
+    pub fn suff_stats(&self) -> &SuffStats {
+        &self.ss
+    }
+
+    pub fn config(&self) -> &FitConfig {
+        &self.cfg
+    }
+
+    /// Most recent residual frame (length `pixels()`).
+    pub fn last_residual(&self) -> &[f32] {
+        &self.residual
+    }
+
+    /// Run one OMF frame. Returns the residual `R_t` so callers can
+    /// feed it to an Extend loop (Phase 3) or inspect for diagnostics.
+    pub fn step(&mut self, y: &[f32]) -> &[f32] {
+        assert_eq!(
+            y.len(),
+            self.fp.pixels(),
+            "y length {} must equal pixels {}",
+            y.len(),
+            self.fp.pixels()
+        );
+
+        // 1. Trace update (NNLS-BCD grouped by spatial overlap).
+        //    Groups are rebuilt each frame because `EvaluateFootprints`
+        //    may have shrunk support on the previous frame, which in
+        //    turn can split a group into disjoint ones.
+        let c_prev: Vec<f32> = match self.traces.last() {
+            Some(prev) => prev.to_vec(),
+            None => vec![0.0f32; self.fp.len()],
+        };
+        let groups = Groups::from_footprints(&self.fp);
+        let mut c = evaluate_traces(&self.fp, &groups, y, &c_prev, &self.cfg);
+
+        // 2. Residual for throttle (against current Ã — this frame's
+        //    footprint update has not happened yet).
+        evaluate_residual(&self.fp, &c, y, &mut self.residual);
+
+        // 3. Underfit correction.
+        trace_throttle(&self.fp, &mut c, &self.residual);
+
+        // 4. Record corrected trace in history.
+        self.traces.push(&c);
+
+        // 5–6. Learn from the corrected trace.
+        evaluate_suff_stats(&mut self.ss, y, &c, &self.cfg);
+        evaluate_footprints(&mut self.fp, &self.ss, &self.cfg);
+
+        // 7. Final residual. Post-throttle c, post-update Ã — the
+        //    frame-t residual the Extend loop will consume.
+        evaluate_residual(&self.fp, &c, y, &mut self.residual);
+        &self.residual
+    }
+}

--- a/crates/cala-core/src/fitting/residual.rs
+++ b/crates/cala-core/src/fitting/residual.rs
@@ -1,0 +1,33 @@
+//! `EvaluateResidual` — compute the per-frame reconstruction residual
+//! `R_t = y_t − Ã c̃_t` (thesis §3.2.3, Eq. 3.24).
+//!
+//! Two roles:
+//! 1. Feeds the Extend loop's segmentation search for unexplained
+//!    structure (thesis §3.2.4).
+//! 2. Drives trace throttling (`fitting::throttle`, thesis Eq. 3.39):
+//!    negative residual on a component's exclusive support signals an
+//!    over-estimated trace.
+
+use crate::assets::Footprints;
+
+pub fn evaluate_residual(fp: &Footprints, c: &[f32], y: &[f32], out: &mut [f32]) {
+    assert_eq!(
+        y.len(),
+        fp.pixels(),
+        "y length {} must equal pixels {}",
+        y.len(),
+        fp.pixels()
+    );
+    assert_eq!(
+        out.len(),
+        fp.pixels(),
+        "out length {} must equal pixels {}",
+        out.len(),
+        fp.pixels()
+    );
+    // reconstruct writes `Ãc` into out and fills the rest with 0.
+    fp.reconstruct(c, out);
+    for (o, &yp) in out.iter_mut().zip(y) {
+        *o = yp - *o;
+    }
+}

--- a/crates/cala-core/src/fitting/suff_stats.rs
+++ b/crates/cala-core/src/fitting/suff_stats.rs
@@ -1,0 +1,81 @@
+//! `EvaluateSuffStats` — SNR-gated recursive-mean update of `W`, `M`
+//! (thesis §3.2.3, Eq. 3.25).
+//!
+//! At frame `t`:
+//! ```text
+//! W_t = ((t-1)/t) W_{t-1} + (1/t) · y_t · f(c̃_t)ᵀ
+//! M_t = ((t-1)/t) M_{t-1} + (1/t) · c̃_t · f(c̃_t)ᵀ
+//! ```
+//! where `f(c) = c · H(c − c₀)` zeros out contributions from
+//! components whose trace is below the SNR threshold, so long quiet
+//! stretches do not drift footprints toward noise (thesis §3.2.3,
+//! "SNR-weighted Fitting" discussion).
+//!
+//! The asymmetric outer product `c̃_t · f(c̃_t)ᵀ` for `M` is written
+//! exactly as in Eq. 3.25. `EvaluateFootprints` reads `M[:, i]` (the
+//! column indexed by the footprint being updated), so the gate on
+//! column `j` via `f(c̃_t)[j]` is what freezes j's footprint when j
+//! is inactive while leaving other footprints free to learn.
+
+use crate::assets::SuffStats;
+use crate::config::FitConfig;
+
+pub fn evaluate_suff_stats(ss: &mut SuffStats, y: &[f32], c: &[f32], cfg: &FitConfig) {
+    assert_eq!(
+        y.len(),
+        ss.pixels(),
+        "y length {} must equal pixels {}",
+        y.len(),
+        ss.pixels()
+    );
+    assert_eq!(
+        c.len(),
+        ss.k(),
+        "c length {} must equal k = {}",
+        c.len(),
+        ss.k()
+    );
+
+    // Advance the frame counter first: the recursive-mean weights are
+    // `(t-1)/t` on the previous state and `1/t` on the new outer
+    // product, where `t` is the index of *this* frame (1-based).
+    ss.increment_frames();
+    let t = ss.frames();
+    let inv_t = 1.0f32 / (t as f32);
+    let decay = (t - 1) as f32 * inv_t;
+
+    // Apply the Heaviside gate: f_c[i] = c[i] if c[i] > c₀, else 0.
+    let k = ss.k();
+    let mut f_c = vec![0.0f32; k];
+    for (i, &ci) in c.iter().enumerate() {
+        if ci > cfg.snr_c0 {
+            f_c[i] = ci;
+        }
+    }
+
+    // W update: W[p, i] = decay * W[p, i] + inv_t * y[p] * f_c[i].
+    {
+        let w = ss.w_mut();
+        for p in 0..y.len() {
+            let yp = y[p];
+            let row = p * k;
+            for i in 0..k {
+                let prev = w[row + i];
+                w[row + i] = decay * prev + inv_t * yp * f_c[i];
+            }
+        }
+    }
+
+    // M update: M[i, j] = decay * M[i, j] + inv_t * c[i] * f_c[j].
+    {
+        let m = ss.m_mut();
+        for i in 0..k {
+            let ci = c[i];
+            let row = i * k;
+            for j in 0..k {
+                let prev = m[row + j];
+                m[row + j] = decay * prev + inv_t * ci * f_c[j];
+            }
+        }
+    }
+}

--- a/crates/cala-core/src/fitting/throttle.rs
+++ b/crates/cala-core/src/fitting/throttle.rs
@@ -1,0 +1,59 @@
+//! Trace throttling — underfit correction (thesis §3.2.3, Eq. 3.39).
+//!
+//! For each estimator `i`, on pixels in its exclusive support (i.e.
+//! pixels in `supp(i)` and in no other component's support) with
+//! negative residual, the estimated trace is too high — some of the
+//! energy at those pixels is unexplained structure the model is
+//! spreading onto `i` because no other component exists for it.
+//! Throttling decrements `c_i` by
+//! ```text
+//! δ_i = mean_{p ∈ Γ_i} (−R(p, t) / Ã[p, i]),   Γ_i = {p : p ∈ supp(i), count(p) = 1, R(p) < 0}
+//! ```
+//! which drives residual on `Γ_i` to exactly zero (thesis Eq. 3.42).
+//! The knock-on effect on overlap regions is what lets Extend discover
+//! the missing overlapping component cleanly (Eq. 3.45).
+
+use crate::assets::Footprints;
+
+pub fn trace_throttle(fp: &Footprints, c: &mut [f32], residual: &[f32]) {
+    let k = fp.len();
+    if k == 0 {
+        return;
+    }
+    assert_eq!(
+        c.len(),
+        k,
+        "c length {} must equal number of components {}",
+        c.len(),
+        k
+    );
+    assert_eq!(
+        residual.len(),
+        fp.pixels(),
+        "residual length {} must equal pixels {}",
+        residual.len(),
+        fp.pixels()
+    );
+
+    let counts = fp.pixel_component_counts();
+
+    // Compute all δ_i from the current residual before applying any
+    // to c — throttling one component changes the residual at shared
+    // pixels, but per thesis the δ values are derived from the
+    // *unmodified* residual (and applied only once per frame).
+    for i in 0..k {
+        let mut sum = 0.0f32;
+        let mut n = 0u32;
+        for (&p, &a_val) in fp.support(i).iter().zip(fp.values(i)) {
+            let p = p as usize;
+            if counts[p] == 1 && residual[p] < 0.0 {
+                sum += -residual[p] / a_val;
+                n += 1;
+            }
+        }
+        if n > 0 {
+            let delta = sum / n as f32;
+            c[i] = (c[i] - delta).max(0.0);
+        }
+    }
+}

--- a/crates/cala-core/src/fitting/trace_bcd.rs
+++ b/crates/cala-core/src/fitting/trace_bcd.rs
@@ -1,0 +1,98 @@
+//! `EvaluateTraces` — block-coordinate-descent NNLS solver for the
+//! trace update (thesis §3.2.3, Algorithm 7).
+//!
+//! Solves `c̃_t ← argmin_{c ≥ 0} ‖y_t − Ã c‖²` by Gauss-Seidel
+//! coordinate descent, grouped by the connected components of the
+//! spatial-overlap graph. Groups are independent (their sub-problems
+//! decouple since `V[G_i, G_j] = 0` across groups), so the ordering
+//! within the outer `for g` loop does not change the fixed point.
+//! Within a group, we update components one at a time using the
+//! most recent trace values — the standard NNLS coordinate-descent
+//! recipe, which is guaranteed monotone in the objective.
+
+use crate::assets::{Footprints, Groups};
+use crate::config::FitConfig;
+
+/// One BCD solve of the trace update.
+///
+/// Returns `c̃_t` of length `fp.len()`. All entries are `≥ 0`.
+/// Iterates at most `cfg.trace_max_iter` times; exits early when the
+/// relative change falls below `cfg.trace_tol`.
+pub fn evaluate_traces(
+    fp: &Footprints,
+    groups: &Groups,
+    y: &[f32],
+    c_prev: &[f32],
+    cfg: &FitConfig,
+) -> Vec<f32> {
+    let k = fp.len();
+    assert_eq!(
+        y.len(),
+        fp.pixels(),
+        "y length {} must equal pixels {}",
+        y.len(),
+        fp.pixels()
+    );
+    assert_eq!(
+        c_prev.len(),
+        k,
+        "c_prev length {} must equal k = {}",
+        c_prev.len(),
+        k
+    );
+
+    if k == 0 {
+        return Vec::new();
+    }
+
+    // Precompute U = Aᵀy and V = AᵀA (Algorithm 7 lines 1–2). Both
+    // stay constant for the duration of this call; only c changes.
+    let u = fp.aty(y);
+    let v = fp.ata();
+
+    let mut c = c_prev.to_vec();
+    let mut c_step = vec![0.0f32; k];
+
+    let tol_sq = cfg.trace_tol * cfg.trace_tol;
+
+    for _ in 0..cfg.trace_max_iter {
+        c_step.copy_from_slice(&c);
+
+        // Across groups: order-independent (V[Gᵢ, Gⱼ] = 0 for i ≠ j).
+        // Within a group: Gauss-Seidel (each update uses the freshest
+        // values of its neighbours).
+        for g in 0..groups.len() {
+            for &i in groups.group(g) {
+                let vii = v[i * k + i];
+                if vii <= 0.0 {
+                    // Component has empty / degenerate support — no
+                    // observation anchors its trace. Leave at 0.
+                    c[i] = 0.0;
+                    continue;
+                }
+                // V[i, :] · c
+                let row_start = i * k;
+                let vi_dot_c: f32 = (0..k).map(|j| v[row_start + j] * c[j]).sum();
+                let delta = (u[i] - vi_dot_c) / vii;
+                c[i] = (c[i] + delta).max(0.0);
+            }
+        }
+
+        // Convergence: ‖c − c_step‖ < ε · ‖c_step‖ (thesis line 7).
+        // Squared form avoids a sqrt per iteration. Skip the check on
+        // the first sweep if `c_step` was all zero (no meaningful
+        // relative threshold yet).
+        let mut diff_sq = 0.0f32;
+        let mut step_sq = 0.0f32;
+        for (new_val, old_val) in c.iter().zip(&c_step) {
+            let d = new_val - old_val;
+            diff_sq += d * d;
+            step_sq += old_val * old_val;
+        }
+        if step_sq > 0.0 && diff_sq < tol_sq * step_sq {
+            break;
+        }
+    }
+
+    c
+}

--- a/crates/cala-core/src/lib.rs
+++ b/crates/cala-core/src/lib.rs
@@ -8,5 +8,6 @@
 
 pub mod assets;
 pub mod config;
+pub mod fitting;
 pub mod io;
 pub mod preprocess;

--- a/crates/cala-core/tests/assets_footprints.rs
+++ b/crates/cala-core/tests/assets_footprints.rs
@@ -1,0 +1,387 @@
+//! Tests for the sparse footprint matrix `Ã` (thesis §3.2.3, Eq. 3.18).
+//!
+//! Footprints store one column per estimator, with only positive-support
+//! pixels held in memory. The fit loop depends on three hot operations
+//! (`Aᵀy`, `AᵀA`, positive-support column update) — design §5 names them
+//! as the ops to benchmark in Phase 3. These tests pin their semantics
+//! against the defining equations and synthetic ground truth so later
+//! storage swaps (raw Vec-based today, `sprs` CSC later if profiling
+//! demands) cannot silently change the math.
+
+use calab_cala_core::assets::Footprints;
+
+const F32_TOL: f32 = 1e-6;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+fn assert_slice_close(actual: &[f32], expected: &[f32], ctx: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{ctx}: length mismatch ({} vs {})",
+        actual.len(),
+        expected.len()
+    );
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (a - e).abs();
+        assert!(
+            diff <= F32_TOL,
+            "{ctx}[{i}]: expected {e}, got {a} (diff {diff} > tol {F32_TOL})"
+        );
+    }
+}
+
+// ----- Shape + basic bookkeeping -----
+
+#[test]
+fn new_footprints_are_empty() {
+    let fp = Footprints::new(4, 5);
+    assert_eq!(fp.height(), 4);
+    assert_eq!(fp.width(), 5);
+    assert_eq!(fp.pixels(), 20);
+    assert_eq!(fp.len(), 0);
+    assert!(fp.is_empty());
+}
+
+#[test]
+fn push_component_returns_sequential_indices() {
+    let mut fp = Footprints::new(3, 3);
+    let a = fp.push_component(vec![0, 1], vec![1.0, 2.0]);
+    let b = fp.push_component(vec![4], vec![3.0]);
+    assert_eq!(a, 0);
+    assert_eq!(b, 1);
+    assert_eq!(fp.len(), 2);
+    assert!(!fp.is_empty());
+}
+
+#[test]
+fn support_and_values_round_trip() {
+    let mut fp = Footprints::new(2, 3);
+    fp.push_component(vec![0, 2, 4], vec![0.25, 0.5, 0.25]);
+    assert_eq!(fp.support(0), &[0u32, 2, 4]);
+    assert_slice_close(fp.values(0), &[0.25, 0.5, 0.25], "values(0)");
+}
+
+// ----- Input validation -----
+
+#[test]
+#[should_panic(expected = "support / values length mismatch")]
+fn push_rejects_mismatched_lengths() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0, 1], vec![1.0]);
+}
+
+#[test]
+#[should_panic(expected = "support must be strictly ascending")]
+fn push_rejects_unsorted_support() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![1, 0], vec![1.0, 1.0]);
+}
+
+#[test]
+#[should_panic(expected = "support must be strictly ascending")]
+fn push_rejects_duplicate_support() {
+    // Duplicates break the "each pixel contributes at most once per column"
+    // invariant Aᵀy and AᵀA rely on. Also would let values silently double-count.
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![1, 1], vec![1.0, 1.0]);
+}
+
+#[test]
+#[should_panic(expected = "values must be positive")]
+fn push_rejects_zero_value() {
+    // Footprint values must be strictly positive — the whole point of the
+    // sparse rep is that stored entries are on positive support.
+    // `EvaluateFootprints` will zero some entries via the `max(·, 0)` step
+    // in Algorithm 8, and `compact` is how they leave the rep.
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0, 1], vec![1.0, 0.0]);
+}
+
+#[test]
+#[should_panic(expected = "values must be positive")]
+fn push_rejects_negative_value() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0], vec![-1.0]);
+}
+
+#[test]
+#[should_panic(expected = "pixel index")]
+fn push_rejects_out_of_range_pixel() {
+    let mut fp = Footprints::new(2, 2); // pixels = 4
+    fp.push_component(vec![4], vec![1.0]);
+}
+
+// ----- Aᵀy -----
+
+#[test]
+fn aty_is_inner_product_on_support() {
+    // Single component with support {0, 2, 4} and values {0.5, 0.5, 0.5}.
+    // y = [1, 2, 3, 4, 5]. result[0] = 0.5*1 + 0.5*3 + 0.5*5 = 4.5.
+    let mut fp = Footprints::new(1, 5);
+    fp.push_component(vec![0, 2, 4], vec![0.5, 0.5, 0.5]);
+    let y = [1.0f32, 2.0, 3.0, 4.0, 5.0];
+    let u = fp.aty(&y);
+    assert_slice_close(&u, &[4.5], "Aᵀy single component");
+}
+
+#[test]
+fn aty_ignores_pixels_outside_support() {
+    // Component with support only at pixel 0. Changing other pixels must
+    // not change the result — that's what "sparse on positive support" means.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0], vec![1.0]);
+    let y1 = [2.0f32, 100.0, 100.0];
+    let y2 = [2.0f32, -999.0, 42.0];
+    let u1 = fp.aty(&y1);
+    let u2 = fp.aty(&y2);
+    assert_slice_close(&u1, &u2, "Aᵀy depends only on support");
+}
+
+#[test]
+fn aty_produces_one_entry_per_component() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![2, 3], vec![1.0, 1.0]);
+    fp.push_component(vec![0, 3], vec![0.5, 0.5]);
+    let y = [1.0f32, 2.0, 3.0, 4.0];
+    let u = fp.aty(&y);
+    assert_eq!(u.len(), 3);
+    assert_slice_close(&u, &[3.0, 7.0, 2.5], "per-component Aᵀy");
+}
+
+#[test]
+fn aty_on_empty_footprints_is_empty() {
+    let fp = Footprints::new(1, 4);
+    let y = [0.0f32; 4];
+    let u = fp.aty(&y);
+    assert!(u.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "y length")]
+fn aty_rejects_wrong_length_y() {
+    let fp = Footprints::new(2, 2);
+    fp.aty(&[0.0f32; 3]);
+}
+
+// ----- AᵀA -----
+
+#[test]
+fn ata_diagonal_is_sum_of_squared_values() {
+    // V[i, i] = Σ values[i]² — this is the denominator `v` in Algorithm 7
+    // (line 3: v ← diag(V)). Critical: if this is wrong the BCD step size
+    // is wrong and traces fail to converge.
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 2.0, 2.0]);
+    let v = fp.ata();
+    // k = 1, so v is a 1×1: just [1 + 4 + 4] = 9.
+    assert_slice_close(&v, &[9.0], "V[0,0]");
+}
+
+#[test]
+fn ata_off_diagonal_is_inner_product_over_intersection() {
+    // Two components:
+    //   i=0: support {0, 1, 2}, values {1, 1, 1}
+    //   i=1: support {1, 2, 3}, values {2, 2, 2}
+    // Intersection {1, 2} → V[0,1] = 1*2 + 1*2 = 4.
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![1, 2, 3], vec![2.0, 2.0, 2.0]);
+    let v = fp.ata();
+    // Row-major 2×2:
+    //   [V00 V01]
+    //   [V10 V11]
+    // V00 = 3, V01 = V10 = 4, V11 = 12.
+    assert_slice_close(&v, &[3.0, 4.0, 4.0, 12.0], "AᵀA with overlap");
+}
+
+#[test]
+fn ata_is_zero_for_disjoint_supports() {
+    // V[i,j] = 0 when support(i) ∩ support(j) = ∅ — this is the structural
+    // property `Groups` uses to partition components into independently
+    // updatable blocks in the BCD inner loop.
+    let mut fp = Footprints::new(2, 2); // pixels = 4
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![2, 3], vec![1.0, 1.0]);
+    let v = fp.ata();
+    // V00 = 2, V01 = V10 = 0, V11 = 2.
+    assert_slice_close(&v, &[2.0, 0.0, 0.0, 2.0], "AᵀA disjoint");
+}
+
+#[test]
+fn ata_is_symmetric() {
+    let mut fp = Footprints::new(3, 3); // pixels = 9
+    fp.push_component(vec![0, 1, 4], vec![0.5, 1.0, 0.5]);
+    fp.push_component(vec![1, 4, 7], vec![0.3, 0.6, 0.3]);
+    fp.push_component(vec![2, 4, 5], vec![0.1, 0.4, 0.1]);
+    let v = fp.ata();
+    let k = fp.len();
+    for i in 0..k {
+        for j in 0..k {
+            assert_close(
+                v[i * k + j],
+                v[j * k + i],
+                &format!("V[{i},{j}] vs V[{j},{i}]"),
+            );
+        }
+    }
+}
+
+#[test]
+fn ata_on_empty_footprints_is_empty() {
+    let fp = Footprints::new(1, 4);
+    let v = fp.ata();
+    assert!(v.is_empty());
+}
+
+// ----- reconstruct (Ãc) -----
+
+#[test]
+fn reconstruct_writes_zero_outside_all_supports() {
+    // Pixels not in any component's support must be zero in Ãc.
+    // This is what makes the residual `y - Ãc` carry the entire unmodeled
+    // structure at those pixels.
+    let mut fp = Footprints::new(1, 5);
+    fp.push_component(vec![1, 3], vec![0.5, 0.5]);
+    let c = [4.0f32];
+    let mut out = [7.0f32; 5]; // non-zero to test that reconstruct overwrites
+    fp.reconstruct(&c, &mut out);
+    assert_slice_close(&out, &[0.0, 2.0, 0.0, 2.0, 0.0], "Ãc outside support");
+}
+
+#[test]
+fn reconstruct_accumulates_across_components() {
+    // Same pixel in multiple components: contributions sum.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![1, 2], vec![2.0, 2.0]);
+    let c = [1.0f32, 1.0];
+    let mut out = [0.0f32; 3];
+    fp.reconstruct(&c, &mut out);
+    // pixel 0: 1*1 = 1; pixel 1: 1*1 + 2*1 = 3; pixel 2: 2*1 = 2.
+    assert_slice_close(&out, &[1.0, 3.0, 2.0], "Ãc across overlapping components");
+}
+
+#[test]
+fn reconstruct_scales_linearly_with_c() {
+    // Ã(αc) = α·Ãc — trivial linear-algebra invariant, worth pinning as a
+    // sanity check for the accumulation path.
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0, 1], vec![0.5, 0.7]);
+    let mut out1 = [0.0f32; 4];
+    let mut out2 = [0.0f32; 4];
+    fp.reconstruct(&[3.0], &mut out1);
+    fp.reconstruct(&[6.0], &mut out2);
+    for i in 0..4 {
+        assert_close(out2[i], 2.0 * out1[i], &format!("pixel {i} scales"));
+    }
+}
+
+#[test]
+#[should_panic(expected = "c length")]
+fn reconstruct_rejects_wrong_length_c() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0], vec![1.0]);
+    let mut out = [0.0f32; 4];
+    fp.reconstruct(&[1.0, 2.0], &mut out);
+}
+
+#[test]
+#[should_panic(expected = "out length")]
+fn reconstruct_rejects_wrong_length_out() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0], vec![1.0]);
+    let mut out = [0.0f32; 3];
+    fp.reconstruct(&[1.0], &mut out);
+}
+
+// ----- values_mut + compact -----
+
+#[test]
+fn values_mut_exposes_writable_slice() {
+    // `EvaluateFootprints` needs to modify values in place — that's
+    // Algorithm 8 line 5. This path verifies the caller can actually
+    // write through to storage.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![0.1, 0.2, 0.3]);
+    {
+        let vals = fp.values_mut(0);
+        vals[1] = 9.0;
+    }
+    assert_slice_close(fp.values(0), &[0.1, 9.0, 0.3], "values_mut writes");
+}
+
+#[test]
+fn compact_removes_zeroed_entries() {
+    // After an `EvaluateFootprints` sweep that zeroes some values, `compact`
+    // shrinks the support so the sparse rep reflects morphological shrink.
+    let mut fp = Footprints::new(1, 5);
+    fp.push_component(vec![0, 1, 2, 3, 4], vec![0.5, 0.5, 0.5, 0.5, 0.5]);
+    {
+        let vals = fp.values_mut(0);
+        vals[1] = 0.0;
+        vals[3] = 0.0;
+    }
+    fp.compact(0);
+    assert_eq!(fp.support(0), &[0u32, 2, 4]);
+    assert_slice_close(fp.values(0), &[0.5, 0.5, 0.5], "compacted values");
+}
+
+#[test]
+fn compact_noop_when_all_values_positive() {
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 2.0, 3.0]);
+    fp.compact(0);
+    assert_eq!(fp.support(0), &[0u32, 1, 2]);
+    assert_slice_close(fp.values(0), &[1.0, 2.0, 3.0], "compact noop");
+}
+
+#[test]
+fn compact_also_clamps_negative_values_out_of_support() {
+    // Algorithm 8's max(·, 0) guard means the caller should not produce
+    // negatives, but compact is defensive: anything ≤ 0 is dropped.
+    // This keeps the "values are strictly positive" invariant intact.
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2, 3], vec![1.0, 2.0, 3.0, 4.0]);
+    {
+        let vals = fp.values_mut(0);
+        vals[2] = -0.5;
+    }
+    fp.compact(0);
+    assert_eq!(fp.support(0), &[0u32, 1, 3]);
+    assert_slice_close(fp.values(0), &[1.0, 2.0, 4.0], "compact drops negatives");
+}
+
+// ----- pixel_component_counts (used by trace throttle) -----
+
+#[test]
+fn pixel_counts_tally_membership() {
+    // pixel_component_counts[p] = |{i : p ∈ support(i)}|.
+    // Trace throttle uses this to identify pixels in exactly one component's
+    // footprint (the "exclusive" pixels where underfit correction applies).
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![1, 2, 3], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![2], vec![1.0]);
+    // pixel 0 ∈ {0} → 1
+    // pixel 1 ∈ {0, 1} → 2
+    // pixel 2 ∈ {0, 1, 2} → 3
+    // pixel 3 ∈ {1} → 1
+    let counts = fp.pixel_component_counts();
+    assert_eq!(counts, vec![1u32, 2, 3, 1]);
+}
+
+#[test]
+fn pixel_counts_length_is_full_frame() {
+    let fp = Footprints::new(2, 3); // pixels = 6
+    let counts = fp.pixel_component_counts();
+    assert_eq!(counts.len(), 6);
+    assert!(counts.iter().all(|&c| c == 0));
+}

--- a/crates/cala-core/tests/assets_groups.rs
+++ b/crates/cala-core/tests/assets_groups.rs
@@ -1,0 +1,120 @@
+//! Tests for the `G` group-overlap partition (thesis §3.2.3,
+//! Algorithm 7 line 9).
+//!
+//! `G` is the partition of components into connected components of the
+//! spatial-overlap graph: components `i` and `j` are in the same group
+//! iff their positive supports overlap (or are transitively linked via
+//! chains of overlaps). Within a group, BCD must iterate jointly
+//! because `AᵀA[i, j] ≠ 0`. Across groups, updates are independent so
+//! groups can be processed in any order (or in parallel).
+
+use calab_cala_core::assets::{Footprints, Groups};
+
+#[test]
+fn empty_footprints_have_no_groups() {
+    let fp = Footprints::new(2, 2);
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 0);
+    assert_eq!(g.num_components(), 0);
+}
+
+#[test]
+fn single_component_forms_one_group_of_itself() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 1);
+    assert_eq!(g.group(0), &[0usize]);
+    assert_eq!(g.group_of(0), 0);
+}
+
+#[test]
+fn disjoint_components_form_separate_groups() {
+    let mut fp = Footprints::new(2, 4); // pixels = 8
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![4, 5], vec![1.0, 1.0]);
+    fp.push_component(vec![6, 7], vec![1.0, 1.0]);
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 3);
+    // Each component is alone in its group.
+    let mut seen = vec![0u32; 3];
+    for gi in 0..g.len() {
+        let members = g.group(gi);
+        assert_eq!(members.len(), 1);
+        seen[members[0]] += 1;
+    }
+    assert_eq!(seen, vec![1, 1, 1]);
+}
+
+#[test]
+fn overlapping_components_share_one_group() {
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![2, 3], vec![1.0, 1.0]); // shares pixel 2
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 1);
+    let mut members = g.group(0).to_vec();
+    members.sort();
+    assert_eq!(members, vec![0, 1]);
+    assert_eq!(g.group_of(0), g.group_of(1));
+}
+
+#[test]
+fn transitive_overlap_collapses_into_single_group() {
+    // A–B overlap at pixel 2, B–C overlap at pixel 6. A and C do not
+    // overlap directly, but transitively through B they belong to the
+    // same group — that's the connected-component definition.
+    let mut fp = Footprints::new(1, 10);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]); // A
+    fp.push_component(vec![2, 5, 6], vec![1.0, 1.0, 1.0]); // B (shares 2 with A, 6 with C)
+    fp.push_component(vec![6, 8, 9], vec![1.0, 1.0, 1.0]); // C
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 1);
+    assert_eq!(g.group_of(0), g.group_of(1));
+    assert_eq!(g.group_of(1), g.group_of(2));
+}
+
+#[test]
+fn groups_are_a_partition_of_all_components() {
+    // Every component appears in exactly one group, and the total
+    // count across groups equals `fp.len()`. This is the partition
+    // invariant BCD relies on.
+    let mut fp = Footprints::new(2, 5); // pixels = 10
+    fp.push_component(vec![0], vec![1.0]);
+    fp.push_component(vec![1, 2], vec![1.0, 1.0]);
+    fp.push_component(vec![2, 3], vec![1.0, 1.0]);
+    fp.push_component(vec![7, 8], vec![1.0, 1.0]);
+    let g = Groups::from_footprints(&fp);
+    let mut hit = vec![false; fp.len()];
+    let mut total = 0;
+    for gi in 0..g.len() {
+        for &member in g.group(gi) {
+            assert!(
+                !hit[member],
+                "component {member} appears in multiple groups"
+            );
+            hit[member] = true;
+            total += 1;
+        }
+    }
+    assert_eq!(total, fp.len());
+    assert!(
+        hit.iter().all(|&h| h),
+        "every component must appear in some group"
+    );
+}
+
+#[test]
+fn group_members_are_sorted_ascending() {
+    // Downstream BCD code iterates `group(gi)` and wants a stable
+    // order; sorted-ascending is the natural pick (matches component
+    // creation order for the common case of no gaps).
+    let mut fp = Footprints::new(1, 6);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![1, 2], vec![1.0, 1.0]);
+    fp.push_component(vec![2, 3], vec![1.0, 1.0]);
+    fp.push_component(vec![3, 4], vec![1.0, 1.0]);
+    let g = Groups::from_footprints(&fp);
+    assert_eq!(g.len(), 1);
+    assert_eq!(g.group(0), &[0usize, 1, 2, 3]);
+}

--- a/crates/cala-core/tests/assets_suff_stats.rs
+++ b/crates/cala-core/tests/assets_suff_stats.rs
@@ -1,0 +1,87 @@
+//! Tests for the sufficient-statistics storage `W`, `M` (thesis
+//! §3.2.3, Eqs. 3.20–3.22).
+//!
+//! The asset here is *just the container*: shape, zero-init, writable
+//! slices, frame counter. The SNR-gated update rule lives in
+//! `fitting::suff_stats` and is tested separately against its defining
+//! recursive-mean equation (Eq. 3.25).
+
+use calab_cala_core::assets::SuffStats;
+
+#[test]
+fn new_suff_stats_are_zero_and_at_frame_zero() {
+    let s = SuffStats::new(10, 3);
+    assert_eq!(s.pixels(), 10);
+    assert_eq!(s.k(), 3);
+    assert_eq!(s.frames(), 0);
+    assert_eq!(s.w().len(), 30); // pixels × k
+    assert_eq!(s.m().len(), 9); //  k × k
+    assert!(s.w().iter().all(|&v| v == 0.0));
+    assert!(s.m().iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn w_index_is_row_major_p_times_k_plus_i() {
+    // Row-major (pixels, k) layout: W[p, i] ↔ index p*k + i. Pinning
+    // this matches the existing Frame row-major convention so the
+    // boundary layer can hand `W` to numpy / xarray without transposing.
+    let s = SuffStats::new(4, 3); // pixels=4, k=3
+    assert_eq!(s.w_idx(0, 0), 0);
+    assert_eq!(s.w_idx(0, 2), 2);
+    assert_eq!(s.w_idx(1, 0), 3);
+    assert_eq!(s.w_idx(3, 2), 11);
+}
+
+#[test]
+fn m_index_is_row_major_i_times_k_plus_j() {
+    let s = SuffStats::new(4, 3);
+    assert_eq!(s.m_idx(0, 0), 0);
+    assert_eq!(s.m_idx(0, 2), 2);
+    assert_eq!(s.m_idx(2, 1), 7);
+}
+
+#[test]
+fn w_mut_and_m_mut_write_through_to_storage() {
+    // The `fitting::suff_stats` update step needs to mutate `W` and
+    // `M` in place — this test verifies the write path is wired.
+    let mut s = SuffStats::new(2, 2);
+    s.w_mut()[3] = 1.5; // W[1, 1]
+    s.m_mut()[1] = 2.5; // M[0, 1]
+    assert_eq!(s.w()[3], 1.5);
+    assert_eq!(s.m()[1], 2.5);
+}
+
+#[test]
+fn increment_frames_advances_counter() {
+    // The recursive mean formula needs `t` to compute the `(t-1)/t`
+    // and `1/t` weights. `increment_frames` is how the update step
+    // advances the counter after applying the new-frame contribution.
+    let mut s = SuffStats::new(1, 1);
+    assert_eq!(s.frames(), 0);
+    s.increment_frames();
+    assert_eq!(s.frames(), 1);
+    s.increment_frames();
+    assert_eq!(s.frames(), 2);
+}
+
+#[test]
+fn w_col_slice_is_strided_access_helper() {
+    // `EvaluateFootprints` reads W[:, i] across sparse pixel indices
+    // on the component's positive support. The asset exposes a
+    // column accessor so the fit code does not re-derive the offset.
+    let mut s = SuffStats::new(3, 2);
+    let (i01, i11, i21) = (s.w_idx(0, 1), s.w_idx(1, 1), s.w_idx(2, 1));
+    let w = s.w_mut();
+    w[i01] = 10.0;
+    w[i11] = 20.0;
+    w[i21] = 30.0;
+    assert_eq!(s.w_at(0, 1), 10.0);
+    assert_eq!(s.w_at(1, 1), 20.0);
+    assert_eq!(s.w_at(2, 1), 30.0);
+}
+
+#[test]
+#[should_panic(expected = "pixels")]
+fn new_rejects_zero_pixels() {
+    let _ = SuffStats::new(0, 3);
+}

--- a/crates/cala-core/tests/assets_traces.rs
+++ b/crates/cala-core/tests/assets_traces.rs
@@ -1,0 +1,103 @@
+//! Tests for the trace history `C̃` (thesis §3.2.3, `C̃ = [C; f]`).
+//!
+//! `C̃` is the t × k matrix of temporal coefficients for every estimator
+//! at every past frame. Phase 2 stores the whole history in RAM — the
+//! persistence trait that lets this back onto a lazy-loaded Zarr /
+//! OPFS store arrives later (design §5, `buffers/persistence.rs`).
+
+use calab_cala_core::assets::Traces;
+
+const F32_TOL: f32 = 1e-6;
+
+fn assert_slice_close(actual: &[f32], expected: &[f32], ctx: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{ctx}: length mismatch ({} vs {})",
+        actual.len(),
+        expected.len()
+    );
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (a - e).abs();
+        assert!(
+            diff <= F32_TOL,
+            "{ctx}[{i}]: expected {e}, got {a} (diff {diff} > tol {F32_TOL})"
+        );
+    }
+}
+
+#[test]
+fn new_traces_are_empty() {
+    let tr = Traces::new(5);
+    assert_eq!(tr.k(), 5);
+    assert_eq!(tr.len(), 0);
+    assert!(tr.is_empty());
+    assert!(tr.last().is_none());
+}
+
+#[test]
+fn push_grows_length() {
+    let mut tr = Traces::new(3);
+    tr.push(&[1.0, 2.0, 3.0]);
+    assert_eq!(tr.len(), 1);
+    tr.push(&[4.0, 5.0, 6.0]);
+    assert_eq!(tr.len(), 2);
+    assert!(!tr.is_empty());
+}
+
+#[test]
+fn last_returns_most_recent_trace() {
+    let mut tr = Traces::new(2);
+    tr.push(&[0.1, 0.2]);
+    tr.push(&[0.3, 0.4]);
+    assert_slice_close(tr.last().unwrap(), &[0.3, 0.4], "last after two pushes");
+}
+
+#[test]
+fn get_retrieves_trace_by_frame_index() {
+    let mut tr = Traces::new(2);
+    tr.push(&[10.0, 20.0]);
+    tr.push(&[30.0, 40.0]);
+    tr.push(&[50.0, 60.0]);
+    assert_slice_close(tr.get(0).unwrap(), &[10.0, 20.0], "frame 0");
+    assert_slice_close(tr.get(1).unwrap(), &[30.0, 40.0], "frame 1");
+    assert_slice_close(tr.get(2).unwrap(), &[50.0, 60.0], "frame 2");
+    assert!(tr.get(3).is_none());
+}
+
+#[test]
+#[should_panic(expected = "trace length")]
+fn push_rejects_wrong_length() {
+    let mut tr = Traces::new(3);
+    tr.push(&[1.0, 2.0]);
+}
+
+#[test]
+fn as_matrix_is_row_major_t_by_k() {
+    // Row-major `t × k` layout: frame t's trace occupies contiguous
+    // indices `t*k .. (t+1)*k`. This matches the `C̃` convention in
+    // the thesis and lets a future noob boundary layer hand it off to
+    // `xarray` with a simple `.reshape((t, k))`.
+    let mut tr = Traces::new(2);
+    tr.push(&[1.0, 2.0]);
+    tr.push(&[3.0, 4.0]);
+    tr.push(&[5.0, 6.0]);
+    assert_slice_close(
+        tr.as_matrix(),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "flat layout",
+    );
+}
+
+#[test]
+fn zero_components_is_allowed_but_inert() {
+    // Useful as a degenerate starting state before the first estimator
+    // is seeded / extended in. `len` advances by one per push of an
+    // empty slice so the frame counter still reflects elapsed frames.
+    let mut tr = Traces::new(0);
+    tr.push(&[]);
+    tr.push(&[]);
+    assert_eq!(tr.k(), 0);
+    assert_eq!(tr.len(), 2);
+    assert!(tr.as_matrix().is_empty());
+}

--- a/crates/cala-core/tests/config_metadata.rs
+++ b/crates/cala-core/tests/config_metadata.rs
@@ -8,8 +8,10 @@
 //! it reads from the config struct the caller passed in.
 
 use calab_cala_core::config::{
-    PreprocessConfig, RecordingMetadata, DEFAULT_HIGH_PASS_DIAMETERS, DEFAULT_HIGH_PASS_ORDER,
-    DEFAULT_MOTION_MAX_SHIFT_PX, DEFAULT_MOTION_USE_GLOBAL_ANCHOR, DEFAULT_NEURON_DIAMETER_UM,
+    FitConfig, PreprocessConfig, RecordingMetadata, DEFAULT_FOOTPRINT_MAX_ITER,
+    DEFAULT_HIGH_PASS_DIAMETERS, DEFAULT_HIGH_PASS_ORDER, DEFAULT_MOTION_MAX_SHIFT_PX,
+    DEFAULT_MOTION_USE_GLOBAL_ANCHOR, DEFAULT_NEURON_DIAMETER_UM, DEFAULT_SNR_C0,
+    DEFAULT_TRACE_MAX_ITER, DEFAULT_TRACE_TOL,
 };
 use calab_cala_core::preprocess::high_pass_cutoff_cycles_per_pixel;
 
@@ -183,4 +185,46 @@ fn overriding_k_changes_derived_cutoff() {
     let f_loose = high_pass_cutoff_cycles_per_pixel(&md, &cfg_loose);
     assert_close(f_tight, 1.0 / 10.0, "K=2 → cutoff period 10 px");
     assert_close(f_loose, 1.0 / 25.0, "K=5 → cutoff period 25 px");
+}
+
+// ----- FitConfig -----
+
+#[test]
+fn fit_config_default_uses_defaults() {
+    let cfg = FitConfig::default();
+    assert_close(cfg.trace_tol, DEFAULT_TRACE_TOL, "trace_tol default");
+    assert_eq!(cfg.trace_max_iter, DEFAULT_TRACE_MAX_ITER);
+    assert_eq!(cfg.footprint_max_iter, DEFAULT_FOOTPRINT_MAX_ITER);
+    assert_close(cfg.snr_c0, DEFAULT_SNR_C0, "snr_c0 default");
+}
+
+#[test]
+fn fit_config_builder_overrides_are_independent() {
+    let cfg = FitConfig::default()
+        .with_trace_tol(5e-4)
+        .with_trace_max_iter(50)
+        .with_footprint_max_iter(3)
+        .with_snr_c0(2.5);
+    assert_close(cfg.trace_tol, 5e-4, "trace_tol override");
+    assert_eq!(cfg.trace_max_iter, 50);
+    assert_eq!(cfg.footprint_max_iter, 3);
+    assert_close(cfg.snr_c0, 2.5, "snr_c0 override");
+}
+
+#[test]
+#[should_panic(expected = "trace_tol must be positive")]
+fn fit_config_rejects_nonpositive_tol() {
+    let _ = FitConfig::default().with_trace_tol(0.0);
+}
+
+#[test]
+#[should_panic(expected = "trace_max_iter must be ≥ 1")]
+fn fit_config_rejects_zero_trace_iter() {
+    let _ = FitConfig::default().with_trace_max_iter(0);
+}
+
+#[test]
+#[should_panic(expected = "snr_c0 must be non-negative")]
+fn fit_config_rejects_negative_snr_c0() {
+    let _ = FitConfig::default().with_snr_c0(-0.1);
 }

--- a/crates/cala-core/tests/fitting_e2e.rs
+++ b/crates/cala-core/tests/fitting_e2e.rs
@@ -1,0 +1,232 @@
+//! Phase 2 exit: end-to-end OMF run on a synthetic multi-cell
+//! recording with seeded ground-truth footprints (thesis §3.2.3
+//! invariants).
+//!
+//! Setup: three Gaussian cells — one pair overlapping, one cell
+//! isolated — firing in different temporal patterns across 60 frames.
+//! Footprints are seeded at the exact ground truth (no discovery —
+//! that is Phase 3's job with Extend). Observations are `y = Ã c`
+//! noise-free so we can assert exact recovery.
+//!
+//! Invariants checked:
+//! 1. Trace history length equals number of frames (Algorithm 6 line 3).
+//! 2. Recovered `C̃[:, t]` matches ground truth within tolerance.
+//! 3. Final residual `R_t` is ≈ 0 (perfect reconstruction on noiseless
+//!    input, Eq. 3.24).
+//! 4. Footprints stay at ground truth (seeded-truth is a fixed point
+//!    of Algorithm 8, as shown analytically above).
+//! 5. `SuffStats` converges to the expected outer-product rolling means
+//!    (Eqs. 3.20–3.21) over the series.
+
+use calab_cala_core::assets::Footprints;
+use calab_cala_core::config::FitConfig;
+use calab_cala_core::fitting::FitPipeline;
+
+const TRACE_TOL: f32 = 1e-3;
+
+fn gaussian_footprint(
+    height: usize,
+    width: usize,
+    cy: f32,
+    cx: f32,
+    sigma: f32,
+    threshold: f32,
+) -> (Vec<u32>, Vec<f32>) {
+    let mut support = Vec::new();
+    let mut values = Vec::new();
+    for y in 0..height {
+        for x in 0..width {
+            let dy = y as f32 - cy;
+            let dx = x as f32 - cx;
+            let v = (-0.5 * (dy * dy + dx * dx) / (sigma * sigma)).exp();
+            if v >= threshold {
+                support.push((y * width + x) as u32);
+                values.push(v);
+            }
+        }
+    }
+    (support, values)
+}
+
+fn synthesize_frame(
+    height: usize,
+    width: usize,
+    truth_supports: &[Vec<u32>],
+    truth_values: &[Vec<f32>],
+    c_gt: &[f32],
+) -> Vec<f32> {
+    let mut y = vec![0.0f32; height * width];
+    for (i, &ci) in c_gt.iter().enumerate() {
+        if ci == 0.0 {
+            continue;
+        }
+        for (s_idx, &p) in truth_supports[i].iter().enumerate() {
+            y[p as usize] += truth_values[i][s_idx] * ci;
+        }
+    }
+    y
+}
+
+fn ground_truth_trace_series(n_frames: usize) -> Vec<Vec<f32>> {
+    // Three cells with distinct temporal patterns: cell 0 fires at
+    // every multiple of 5 with amplitude 3.0, cell 1 fires at every
+    // multiple of 7 with amplitude 2.5, cell 2 fires at a few
+    // hand-picked frames with amplitude 4.0. Deterministic so the
+    // test outcome is fully reproducible.
+    let mut c = vec![vec![0.0f32; 3]; n_frames];
+    for (t, ct) in c.iter_mut().enumerate() {
+        if t % 5 == 0 {
+            ct[0] = 3.0;
+        }
+        if t % 7 == 0 {
+            ct[1] = 2.5;
+        }
+        if t == 10 || t == 25 || t == 40 || t == 50 {
+            ct[2] = 4.0;
+        }
+    }
+    c
+}
+
+#[test]
+fn noiseless_three_cell_recording_recovers_traces_and_residual() {
+    let height = 16usize;
+    let width = 16usize;
+
+    // Cell 0 and cell 1 overlap (distance ≈ 2.2 < 3σ). Cell 2 is
+    // isolated. Exercises both the coupled-BCD and decoupled-BCD
+    // paths in one test.
+    let cell_positions = [(4.0f32, 4.0), (5.0, 6.0), (12.0, 4.0)];
+    let sigma = 1.5f32;
+    let threshold = 0.1f32;
+
+    let mut fp = Footprints::new(height, width);
+    let mut truth_supports: Vec<Vec<u32>> = Vec::new();
+    let mut truth_values: Vec<Vec<f32>> = Vec::new();
+    for &(cy, cx) in &cell_positions {
+        let (supp, vals) = gaussian_footprint(height, width, cy, cx, sigma, threshold);
+        truth_supports.push(supp.clone());
+        truth_values.push(vals.clone());
+        fp.push_component(supp, vals);
+    }
+    let k = fp.len();
+    assert_eq!(k, 3);
+
+    let n_frames = 60usize;
+    let c_gt = ground_truth_trace_series(n_frames);
+
+    let cfg = FitConfig::default()
+        .with_trace_max_iter(300)
+        .with_trace_tol(1e-6)
+        .with_footprint_max_iter(5);
+    let mut pipe = FitPipeline::new(fp, cfg);
+
+    for t in 0..n_frames {
+        let y = synthesize_frame(height, width, &truth_supports, &truth_values, &c_gt[t]);
+        pipe.step(&y);
+    }
+
+    // 1. History length.
+    assert_eq!(pipe.traces().len(), n_frames);
+    assert_eq!(pipe.suff_stats().frames(), n_frames as u64);
+
+    // 2. Every frame's recovered trace matches ground truth.
+    for t in 0..n_frames {
+        let recovered = pipe.traces().get(t).unwrap();
+        for i in 0..k {
+            let diff = (recovered[i] - c_gt[t][i]).abs();
+            assert!(
+                diff <= TRACE_TOL,
+                "trace [t={t}, i={i}]: expected {}, got {} (diff {} > tol {TRACE_TOL})",
+                c_gt[t][i],
+                recovered[i],
+                diff
+            );
+        }
+    }
+
+    // 3. Final-frame residual is near zero (noise-free reconstruction).
+    let r = pipe.last_residual();
+    let r_l2: f32 = r.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        r_l2 < 1e-3,
+        "final residual L2 {r_l2} exceeds tolerance — pipeline failed to fit noiseless frame"
+    );
+
+    // 4. Footprints remain at (or extremely close to) seeded truth.
+    //    Seeded-truth is a fixed point of Algorithm 8 in noise-free
+    //    setting; verify the pipeline didn't drift the support away.
+    for i in 0..k {
+        let got_support = pipe.footprints().support(i);
+        let got_values = pipe.footprints().values(i);
+        assert_eq!(
+            got_support,
+            truth_supports[i].as_slice(),
+            "component {i} support drifted"
+        );
+        assert_eq!(got_values.len(), truth_values[i].len());
+        for (j, (&a, &b)) in got_values.iter().zip(&truth_values[i]).enumerate() {
+            let diff = (a - b).abs();
+            assert!(
+                diff < 1e-3,
+                "component {i} value[{j}] drifted: truth {b}, got {a} (diff {diff})"
+            );
+        }
+    }
+}
+
+#[test]
+fn suff_stats_track_expected_rolling_means() {
+    // W[p, i] at the end of t frames should equal (1/t) Σ y_τ[p] f(c_τ[i]).
+    // With c₀ = 0 default, f(c) = c, so W[p, i] = mean(y[p] * c[i]).
+    // Pinning this locks down the recursive-mean math through the
+    // full pipeline (not just in the suff-stats unit test).
+    let height = 8usize;
+    let width = 8usize;
+    let (supp, vals) = gaussian_footprint(height, width, 4.0, 4.0, 1.0, 0.1);
+    let mut fp = Footprints::new(height, width);
+    fp.push_component(supp.clone(), vals.clone());
+
+    let traces = [1.0f32, 2.0, 0.5, 3.0, 1.5];
+    let mut pipe = FitPipeline::new(fp, FitConfig::default());
+
+    let mut expected_w: Vec<f32> = vec![0.0f32; height * width];
+    for (t, &c) in traces.iter().enumerate() {
+        let y = synthesize_frame(
+            height,
+            width,
+            std::slice::from_ref(&supp),
+            std::slice::from_ref(&vals),
+            &[c],
+        );
+        pipe.step(&y);
+        // Accumulate rolling mean for pixel-wise expected W[:, 0].
+        let t_f = (t + 1) as f32;
+        let decay = t as f32 / t_f;
+        let inv = 1.0 / t_f;
+        for p in 0..height * width {
+            expected_w[p] = decay * expected_w[p] + inv * y[p] * c;
+        }
+    }
+
+    let ss = pipe.suff_stats();
+    assert_eq!(ss.frames(), traces.len() as u64);
+    for p in 0..height * width {
+        let got = ss.w_at(p, 0);
+        let want = expected_w[p];
+        let diff = (got - want).abs();
+        assert!(
+            diff < 1e-5,
+            "W[{p}, 0]: expected {want}, got {got} (diff {diff})"
+        );
+    }
+
+    // M[0, 0] is the rolling mean of c². Exact closed form.
+    let expected_m00 = traces.iter().map(|&c| c * c).sum::<f32>() / traces.len() as f32;
+    let diff = (ss.m_at(0, 0) - expected_m00).abs();
+    assert!(
+        diff < 1e-5,
+        "M[0, 0]: expected {expected_m00}, got {} (diff {diff})",
+        ss.m_at(0, 0)
+    );
+}

--- a/crates/cala-core/tests/fitting_footprints.rs
+++ b/crates/cala-core/tests/fitting_footprints.rs
@@ -1,0 +1,212 @@
+//! Tests for `EvaluateFootprints` (thesis §3.2.3, Algorithm 8).
+//!
+//! The update rule operates on positive support only: each entry
+//! `Ã[p, i]` is nudged toward the least-squares minimizer of the
+//! accumulated reconstruction error at pixel `p`, then clamped to
+//! zero if it would have gone negative. Key invariants:
+//!
+//! 1. **Single-component exact-fit recovery.** For `K = 1` and one
+//!    frame of noiseless `y = Ã_true · c`, one iter sets `Ã[p, 0]`
+//!    to `y[p] / c[0]` on support (closed-form derivation below).
+//! 2. **Non-negativity.** `max(·, 0)` keeps every stored value
+//!    strictly positive; zero/negative entries are dropped by
+//!    `compact` at the end of each outer iter.
+//! 3. **Support never grows.** Algorithm 8 only reads `p ∈ supp(i)`
+//!    — new pixels cannot appear. Support expansion is Extend's job.
+
+use calab_cala_core::assets::{Footprints, SuffStats};
+use calab_cala_core::config::FitConfig;
+use calab_cala_core::fitting::{evaluate_footprints, evaluate_suff_stats};
+
+const F32_TOL: f32 = 1e-5;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+// ----- Degenerate inputs -----
+
+#[test]
+fn empty_footprints_is_noop() {
+    let mut fp = Footprints::new(2, 2);
+    let ss = SuffStats::new(4, 0);
+    let cfg = FitConfig::default();
+    evaluate_footprints(&mut fp, &ss, &cfg);
+    assert_eq!(fp.len(), 0);
+}
+
+#[test]
+fn no_observations_leaves_footprints_unchanged() {
+    // With `M[i, i] == 0` (frame counter 0, no observations), the
+    // update has no signal to apply — Algorithm 8's division by
+    // `M[i, i]` would be undefined. Implementation guards by skipping.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1], vec![0.3, 0.7]);
+    let ss = SuffStats::new(3, 1);
+    let cfg = FitConfig::default();
+    evaluate_footprints(&mut fp, &ss, &cfg);
+    assert_eq!(fp.support(0), &[0u32, 1]);
+    assert_close(fp.values(0)[0], 0.3, "Ã[0,0] untouched");
+    assert_close(fp.values(0)[1], 0.7, "Ã[1,0] untouched");
+}
+
+// ----- Single-component exact fit -----
+
+#[test]
+fn single_component_recovers_footprint_from_one_frame() {
+    // Closed form: with K=1 and t=1,
+    //   W[p, 0] = y[p] c[0],  M[0, 0] = c[0]²,  Ã[p, :] M[:, 0] = Ã[p, 0] c[0]².
+    //   Δ = (y[p] c[0] − Ã[p, 0] c[0]²) / c[0]² = y[p]/c[0] − Ã[p, 0].
+    //   New Ã[p, 0] = max(Ã[p, 0] + Δ, 0) = max(y[p]/c[0], 0) = y[p]/c[0].
+    // So one update exactly installs the true footprint from one frame.
+    let mut fp = Footprints::new(1, 4);
+    // Truth footprint: values [1, 2, 3, 4] over pixels {0, 1, 2, 3}.
+    let truth = [1.0f32, 2.0, 3.0, 4.0];
+    // Seed perturbed: same support, wrong values.
+    fp.push_component(vec![0, 1, 2, 3], vec![0.5, 0.5, 0.5, 0.5]);
+    let c = [2.0f32];
+    // y = truth · c = [2, 4, 6, 8].
+    let y: Vec<f32> = truth.iter().map(|v| v * c[0]).collect();
+
+    let mut ss = SuffStats::new(4, 1);
+    let cfg = FitConfig::default().with_footprint_max_iter(1);
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    evaluate_footprints(&mut fp, &ss, &cfg);
+
+    assert_eq!(fp.support(0), &[0u32, 1, 2, 3]);
+    for i in 0..4 {
+        assert_close(fp.values(0)[i], truth[i], &format!("Ã[{i},0] recovered"));
+    }
+}
+
+// ----- Non-negativity + compaction -----
+
+#[test]
+fn negative_update_clamps_and_compacts() {
+    // Seed Ã has a pixel with a tiny positive value; a single frame
+    // with an "anti-aligned" observation pushes its update negative,
+    // which the max(·, 0) guard clamps to 0. The compaction pass
+    // then removes it from the support.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![0.1, 1.0, 0.1]);
+    // Target y where pixel 0 would push Ã[0, 0] negative under the
+    // K=1 update: y[p]/c[0] → 0.01 (below tol; after subtraction
+    // from current 0.1, the clamp fires). The important bit is that
+    // the FINAL stored value is strictly > 0 or the entry is dropped.
+    let y = [0.001f32, 5.0, 0.001];
+    let c = [2.0f32];
+    let mut ss = SuffStats::new(3, 1);
+    let cfg = FitConfig::default().with_footprint_max_iter(1);
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    evaluate_footprints(&mut fp, &ss, &cfg);
+
+    // Every stored value must be strictly positive after compact.
+    for (idx, &v) in fp.values(0).iter().enumerate() {
+        assert!(
+            v > 0.0,
+            "entry {idx} has non-positive value {v} after compact"
+        );
+    }
+    // Support must stay a subset of the seed support — no expansion.
+    for &p in fp.support(0) {
+        assert!(p <= 2, "pixel {p} is outside the seed support {{0,1,2}}");
+    }
+}
+
+#[test]
+fn support_never_grows() {
+    // Ã_true has a value at pixel 3, but the seed does not. Algorithm
+    // 8 updates only on positive support, so after any number of
+    // iterations `fp.support(0)` must remain {0, 1, 2}. Growing the
+    // support is Extend's job (Phase 3).
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1, 2], vec![0.5, 0.5, 0.5]);
+    let c = [1.0f32];
+    // y has energy at pixel 3 (outside seed support).
+    let y = [1.0f32, 1.0, 1.0, 10.0];
+    let mut ss = SuffStats::new(4, 1);
+    let cfg = FitConfig::default().with_footprint_max_iter(20);
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    evaluate_footprints(&mut fp, &ss, &cfg);
+    assert_eq!(fp.support(0), &[0u32, 1, 2], "support did not expand");
+}
+
+// ----- Two-component convergence -----
+
+#[test]
+fn two_component_converges_toward_truth_over_many_iters() {
+    // Non-overlapping supports → decoupled update → each component
+    // converges independently. Perturb seed, feed one frame, iterate
+    // EvaluateFootprints enough times to drive Ã to the truth.
+    let mut fp = Footprints::new(2, 4); // pixels = 8
+    let truth_a = [0.4f32, 0.8, 0.4];
+    let truth_b = [0.5f32, 1.0, 0.5];
+    fp.push_component(vec![0, 1, 2], vec![0.2, 0.4, 0.2]); // seed off by factor 2
+    fp.push_component(vec![5, 6, 7], vec![0.3, 0.6, 0.3]); // seed off
+    let c = [3.0f32, 2.0];
+    // y = truth · c. Pixels 3, 4 outside both supports → 0.
+    let mut y = vec![0.0f32; 8];
+    for i in 0..3 {
+        y[i] = truth_a[i] * c[0];
+    }
+    for i in 0..3 {
+        y[5 + i] = truth_b[i] * c[1];
+    }
+    let mut ss = SuffStats::new(8, 2);
+    let cfg = FitConfig::default().with_footprint_max_iter(10);
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    evaluate_footprints(&mut fp, &ss, &cfg);
+
+    for i in 0..3 {
+        assert_close(fp.values(0)[i], truth_a[i], &format!("A[{i},0]"));
+        assert_close(fp.values(1)[i], truth_b[i], &format!("A[{i},1]"));
+    }
+}
+
+#[test]
+fn overlapping_components_converge_after_several_iters() {
+    // Shared pixel 2 couples the components via M. A single frame is
+    // under-determined at the shared pixel — any (a, b) satisfying
+    // `a·c[0] + b·c[1] = y[2]` fits, regardless of which split is
+    // "true". Feeding frames with distinct c vectors gives the two
+    // pixel-2 equations needed to identify (a, b). Many streaming
+    // frames = many rows of the linear system.
+    let mut fp = Footprints::new(1, 5);
+    let truth_a = [0.5f32, 0.5, 1.0];
+    let truth_b = [1.0f32, 0.5, 0.5];
+    fp.push_component(vec![0, 1, 2], vec![0.2, 0.2, 0.4]);
+    fp.push_component(vec![2, 3, 4], vec![0.4, 0.2, 0.2]);
+
+    // Five frames with varying trace amplitudes — enough rows to
+    // pin down both components even at the shared pixel.
+    let c_series = [
+        [2.0f32, 1.0],
+        [1.0f32, 3.0],
+        [3.0f32, 2.0],
+        [1.5f32, 2.5],
+        [2.5f32, 1.5],
+    ];
+    let mut ss = SuffStats::new(5, 2);
+    let cfg = FitConfig::default().with_footprint_max_iter(50);
+    for c in &c_series {
+        let y = [
+            truth_a[0] * c[0],
+            truth_a[1] * c[0],
+            truth_a[2] * c[0] + truth_b[0] * c[1],
+            truth_b[1] * c[1],
+            truth_b[2] * c[1],
+        ];
+        evaluate_suff_stats(&mut ss, &y, c, &cfg);
+        evaluate_footprints(&mut fp, &ss, &cfg);
+    }
+    assert_close(fp.values(0)[0], truth_a[0], "A[0,0]");
+    assert_close(fp.values(0)[1], truth_a[1], "A[1,0]");
+    assert_close(fp.values(0)[2], truth_a[2], "A[2,0]");
+    assert_close(fp.values(1)[0], truth_b[0], "A[2,1]");
+    assert_close(fp.values(1)[1], truth_b[1], "A[3,1]");
+    assert_close(fp.values(1)[2], truth_b[2], "A[4,1]");
+}

--- a/crates/cala-core/tests/fitting_pipeline.rs
+++ b/crates/cala-core/tests/fitting_pipeline.rs
@@ -1,0 +1,153 @@
+//! Tests for `FitPipeline` — the per-frame OMF step composed out of
+//! the fit primitives (thesis §3.2.3, Algorithm 6).
+//!
+//! These are orchestration tests: the primitive modules each pin their
+//! own defining equations. Here we only care that `step` wires them
+//! together correctly — state evolves, residual is returned, trace
+//! history accumulates.
+
+use calab_cala_core::assets::Footprints;
+use calab_cala_core::config::FitConfig;
+use calab_cala_core::fitting::FitPipeline;
+
+const F32_TOL: f32 = 1e-4;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+fn seed_single_gaussian_footprint(fp: &mut Footprints, height: usize, width: usize) {
+    // 3×3 peaked footprint at the frame center — a simplified stand-in
+    // for a neuron's spatial profile.
+    let cy = height / 2;
+    let cx = width / 2;
+    let mut support = Vec::new();
+    let mut values = Vec::new();
+    for dy in -1i32..=1 {
+        for dx in -1i32..=1 {
+            let y = cy as i32 + dy;
+            let x = cx as i32 + dx;
+            if y < 0 || y >= height as i32 || x < 0 || x >= width as i32 {
+                continue;
+            }
+            let r2 = (dy * dy + dx * dx) as f32;
+            let v = (-r2 / 2.0).exp();
+            support.push((y as u32) * (width as u32) + x as u32);
+            values.push(v);
+        }
+    }
+    fp.push_component(support, values);
+}
+
+#[test]
+fn new_pipeline_has_empty_trace_history() {
+    let fp = Footprints::new(2, 2);
+    let pipe = FitPipeline::new(fp, FitConfig::default());
+    assert_eq!(pipe.traces().len(), 0);
+    assert_eq!(pipe.suff_stats().frames(), 0);
+}
+
+#[test]
+fn step_advances_frame_count_and_appends_trace() {
+    let mut fp = Footprints::new(4, 4);
+    seed_single_gaussian_footprint(&mut fp, 4, 4);
+    let mut pipe = FitPipeline::new(fp, FitConfig::default());
+    let y = vec![0.0f32; 16];
+    pipe.step(&y);
+    pipe.step(&y);
+    pipe.step(&y);
+    assert_eq!(pipe.traces().len(), 3, "three pushes into trace history");
+    assert_eq!(
+        pipe.suff_stats().frames(),
+        3,
+        "three frames seen by suff-stats"
+    );
+}
+
+#[test]
+fn step_returns_residual_of_pixel_length() {
+    let mut fp = Footprints::new(3, 5); // pixels = 15
+    seed_single_gaussian_footprint(&mut fp, 3, 5);
+    let mut pipe = FitPipeline::new(fp, FitConfig::default());
+    let y = vec![0.5f32; 15];
+    let r = pipe.step(&y);
+    assert_eq!(r.len(), 15);
+}
+
+#[test]
+fn empty_footprints_pipeline_trivially_succeeds() {
+    // With `k = 0`, `EvaluateTraces` returns `[]`, throttle / suff-stats
+    // / footprints are no-ops; residual is just `y` verbatim because
+    // `Ãc = 0` everywhere.
+    let fp = Footprints::new(2, 2);
+    let mut pipe = FitPipeline::new(fp, FitConfig::default());
+    let y = [1.0f32, 2.0, 3.0, 4.0];
+    let r = pipe.step(&y);
+    assert_eq!(r, &y);
+    assert_eq!(pipe.traces().len(), 1);
+    assert!(pipe.traces().last().unwrap().is_empty());
+}
+
+// ----- Integration: recovery with a seeded correct footprint -----
+
+#[test]
+fn recovers_trace_from_exactly_seeded_footprint() {
+    // Seed the one-and-only footprint at its true values. Feed frames
+    // with y_t = Ã_true · c_t. Over several frames the pipeline should
+    // report traces matching the ground truth within tolerance, and
+    // the residual should be near zero (perfect noise-free fit).
+    let height = 5usize;
+    let width = 5usize;
+    let mut fp = Footprints::new(height, width);
+    seed_single_gaussian_footprint(&mut fp, height, width);
+
+    // Snapshot the truth footprint so we can synthesize `y`.
+    let truth_support = fp.support(0).to_vec();
+    let truth_values = fp.values(0).to_vec();
+
+    let cfg = FitConfig::default()
+        .with_trace_max_iter(200)
+        .with_trace_tol(1e-6);
+    let mut pipe = FitPipeline::new(fp, cfg);
+
+    let c_true_series = [1.0f32, 0.5, 2.5, 0.1, 3.0, 1.8];
+    for &c_true in &c_true_series {
+        let mut y = vec![0.0f32; height * width];
+        for (&p, &v) in truth_support.iter().zip(&truth_values) {
+            y[p as usize] = v * c_true;
+        }
+        let r = pipe.step(&y);
+        let r_l2: f32 = r.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            r_l2 < 1e-3,
+            "residual L2 {r_l2} too large — pipeline failed to fit noiseless frame"
+        );
+    }
+
+    // Compare recovered traces to ground truth.
+    assert_eq!(pipe.traces().len(), c_true_series.len());
+    for (t, &c_true) in c_true_series.iter().enumerate() {
+        let c_est = pipe.traces().get(t).unwrap()[0];
+        assert_close(c_est, c_true, &format!("recovered c at frame {t}"));
+    }
+}
+
+// Note: a "perturb single footprint, watch residual shrink" test is
+// not meaningful at K=1 because the single-component problem has a
+// gauge ambiguity between trace amplitude and footprint magnitude
+// (EvaluateTraces absorbs any scaling of Ã into c̃, so the residual
+// is zero regardless). The end-to-end synthetic fit test covers the
+// multi-component recovery case where the ambiguity is broken by
+// differential support and trace variation across frames.
+
+#[test]
+#[should_panic(expected = "y length")]
+fn step_rejects_mismatched_y_length() {
+    let fp = Footprints::new(2, 2);
+    let mut pipe = FitPipeline::new(fp, FitConfig::default());
+    pipe.step(&[0.0f32; 3]);
+}

--- a/crates/cala-core/tests/fitting_residual.rs
+++ b/crates/cala-core/tests/fitting_residual.rs
@@ -1,0 +1,76 @@
+//! Tests for `EvaluateResidual` (thesis §3.2.3, Eq. 3.24).
+
+use calab_cala_core::assets::Footprints;
+use calab_cala_core::fitting::evaluate_residual;
+
+const F32_TOL: f32 = 1e-6;
+
+fn assert_slice_close(actual: &[f32], expected: &[f32], ctx: &str) {
+    assert_eq!(actual.len(), expected.len());
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (a - e).abs();
+        assert!(
+            diff <= F32_TOL,
+            "{ctx}[{i}]: expected {e}, got {a} (diff {diff} > tol {F32_TOL})"
+        );
+    }
+}
+
+#[test]
+fn residual_is_y_minus_reconstruction() {
+    let mut fp = Footprints::new(1, 4);
+    fp.push_component(vec![0, 1], vec![1.0, 2.0]);
+    let c = [3.0f32];
+    // Ãc = [3, 6, 0, 0]
+    let y = [10.0f32, 10.0, 7.0, 1.0];
+    let mut r = [0.0f32; 4];
+    evaluate_residual(&fp, &c, &y, &mut r);
+    assert_slice_close(&r, &[7.0, 4.0, 7.0, 1.0], "y − Ãc");
+}
+
+#[test]
+fn residual_equals_y_where_no_component_covers() {
+    // Pixels outside every component's support get Ãc = 0, so
+    // residual = y. This is the property Extend relies on — the
+    // residual buffer carries unexplained signal verbatim at
+    // un-modeled regions.
+    let mut fp = Footprints::new(1, 5);
+    fp.push_component(vec![0], vec![1.0]);
+    fp.push_component(vec![4], vec![2.0]);
+    let c = [1.0f32, 1.0];
+    let y = [1.0f32, 5.0, 7.0, 9.0, 2.0];
+    let mut r = [0.0f32; 5];
+    evaluate_residual(&fp, &c, &y, &mut r);
+    // At 0: y=1, Ãc = 1 → r = 0. At 4: y=2, Ãc = 2 → r = 0.
+    // Between: y passes through unchanged.
+    assert_slice_close(
+        &r,
+        &[0.0, 5.0, 7.0, 9.0, 0.0],
+        "residual on uncovered pixels",
+    );
+}
+
+#[test]
+fn residual_of_zero_components_is_y() {
+    let fp = Footprints::new(1, 3);
+    let y = [1.0f32, 2.0, 3.0];
+    let mut r = [9.0f32; 3]; // scratch value to verify overwrite
+    evaluate_residual(&fp, &[], &y, &mut r);
+    assert_slice_close(&r, &y, "k=0 → residual = y");
+}
+
+#[test]
+#[should_panic(expected = "y length")]
+fn rejects_mismatched_y_length() {
+    let fp = Footprints::new(2, 2);
+    let mut r = [0.0f32; 4];
+    evaluate_residual(&fp, &[], &[0.0f32; 3], &mut r);
+}
+
+#[test]
+#[should_panic(expected = "out length")]
+fn rejects_mismatched_out_length() {
+    let fp = Footprints::new(2, 2);
+    let mut r = [0.0f32; 3];
+    evaluate_residual(&fp, &[], &[0.0f32; 4], &mut r);
+}

--- a/crates/cala-core/tests/fitting_suff_stats.rs
+++ b/crates/cala-core/tests/fitting_suff_stats.rs
@@ -1,0 +1,168 @@
+//! Tests for `EvaluateSuffStats` — the SNR-gated recursive-mean update
+//! for `W`, `M` (thesis §3.2.3, Eq. 3.25).
+//!
+//! Pins the three things that matter:
+//! 1. The recursive-mean form: after frame t, `W` is exactly the average
+//!    of the per-frame outer products `y_τ f(c_τ)ᵀ` over τ = 1..t.
+//! 2. The SNR gate `f(c) = c · H(c − c₀)` zeros out contributions
+//!    from components with traces below threshold, so footprints don't
+//!    drift toward noise during inactive frames.
+//! 3. The frame counter advances exactly once per call.
+
+use calab_cala_core::assets::SuffStats;
+use calab_cala_core::config::FitConfig;
+use calab_cala_core::fitting::evaluate_suff_stats;
+
+const F32_TOL: f32 = 1e-6;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+// ----- First-frame contribution -----
+
+#[test]
+fn first_frame_sets_w_to_outer_product_of_y_and_c() {
+    // At t=1 the (t-1)/t coefficient is 0, so W_1 = y_1 f(c_1)ᵀ.
+    // With snr_c0 = 0 (default), f(c) = c for any c > 0.
+    let mut ss = SuffStats::new(3, 2);
+    let y = [1.0f32, 2.0, 3.0];
+    let c = [0.5f32, 1.5];
+    let cfg = FitConfig::default();
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    // W[p, i] = y[p] * c[i]
+    assert_close(ss.w_at(0, 0), 1.0 * 0.5, "W[0,0]");
+    assert_close(ss.w_at(0, 1), 1.0 * 1.5, "W[0,1]");
+    assert_close(ss.w_at(2, 0), 3.0 * 0.5, "W[2,0]");
+    assert_close(ss.w_at(2, 1), 3.0 * 1.5, "W[2,1]");
+    assert_eq!(ss.frames(), 1);
+}
+
+#[test]
+fn first_frame_sets_m_to_outer_product_of_c() {
+    let mut ss = SuffStats::new(2, 3);
+    let y = [0.0f32, 0.0];
+    let c = [2.0f32, 4.0, 0.5];
+    let cfg = FitConfig::default();
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    // M[i, j] = c[i] * f(c[j]); with c₀ = 0 and all c > 0, f(c) = c.
+    // So M[i, j] = c[i] * c[j].
+    assert_close(ss.m_at(0, 0), 4.0, "M[0,0]");
+    assert_close(ss.m_at(0, 1), 8.0, "M[0,1]");
+    assert_close(ss.m_at(0, 2), 1.0, "M[0,2]");
+    assert_close(ss.m_at(1, 1), 16.0, "M[1,1]");
+    assert_close(ss.m_at(2, 2), 0.25, "M[2,2]");
+}
+
+// ----- Recursive mean -----
+
+#[test]
+fn second_frame_averages_with_first() {
+    // Two frames, each contributes y·cᵀ. After frame 2, W should
+    // equal the arithmetic mean: W = 0.5 · (y1·c1ᵀ + y2·c2ᵀ).
+    // y2·c2ᵀ pixel 0 col 0 = 4·2 = 8; y1·c1ᵀ pixel 0 col 0 = 2·1 = 2.
+    // Mean = 5. With (t-1)/t=0.5 on frame 2: W_2[0,0] = 0.5·2 + 0.5·8 = 5.
+    let mut ss = SuffStats::new(2, 1);
+    let cfg = FitConfig::default();
+    evaluate_suff_stats(&mut ss, &[2.0f32, 3.0], &[1.0f32], &cfg);
+    evaluate_suff_stats(&mut ss, &[4.0f32, 5.0], &[2.0f32], &cfg);
+    assert_eq!(ss.frames(), 2);
+    // W[0, 0] = 0.5 · (2·1 + 4·2) = 0.5 · 10 = 5.0
+    assert_close(ss.w_at(0, 0), 5.0, "W[0,0] after 2 frames");
+    // W[1, 0] = 0.5 · (3·1 + 5·2) = 0.5 · 13 = 6.5
+    assert_close(ss.w_at(1, 0), 6.5, "W[1,0] after 2 frames");
+    // M[0, 0] = 0.5 · (1² + 2²) = 0.5 · 5 = 2.5
+    assert_close(ss.m_at(0, 0), 2.5, "M[0,0] after 2 frames");
+}
+
+#[test]
+fn three_frame_rolling_mean_matches_closed_form() {
+    // After N frames with same y, c, the rolling mean converges to the
+    // static outer product. This is the defining property of the
+    // recursive-mean update (Eq. 3.22 / 3.25).
+    let mut ss = SuffStats::new(1, 1);
+    let cfg = FitConfig::default();
+    for _ in 0..3 {
+        evaluate_suff_stats(&mut ss, &[7.0f32], &[3.0f32], &cfg);
+    }
+    // W[0, 0] = mean of {7·3, 7·3, 7·3} = 21.
+    assert_close(ss.w_at(0, 0), 21.0, "W[0,0] steady state");
+    assert_close(ss.m_at(0, 0), 9.0, "M[0,0] steady state");
+    assert_eq!(ss.frames(), 3);
+}
+
+// ----- SNR gate -----
+
+#[test]
+fn component_below_c0_contributes_nothing_to_w_column() {
+    // c[1] below threshold → f(c[1]) = 0 → column 1 of W (this frame)
+    // gets a zero increment.
+    let mut ss = SuffStats::new(2, 2);
+    let cfg = FitConfig::default().with_snr_c0(1.0);
+    let y = [5.0f32, 6.0];
+    let c = [2.0f32, 0.5]; // c[1] = 0.5 < c₀ = 1.0
+    evaluate_suff_stats(&mut ss, &y, &c, &cfg);
+    assert_close(ss.w_at(0, 0), 10.0, "W[0,0] from active c[0]");
+    assert_close(ss.w_at(0, 1), 0.0, "W[0,1] gated by inactive c[1]");
+    assert_close(ss.w_at(1, 1), 0.0, "W[1,1] gated by inactive c[1]");
+}
+
+#[test]
+fn gate_applies_to_m_column_only_per_thesis() {
+    // Thesis Eq. 3.25: M_t = ((t-1)/t) M_{t-1} + (1/t) c̃_t f(c̃_t)ᵀ.
+    // The outer product is c̃ (left) × f(c̃) (right, gated), so the
+    // *column* of M indexed by an inactive component gets zero
+    // contribution, but the *row* still accumulates c̃ at its raw
+    // value. We implement exactly as written; see suff_stats.rs for
+    // the symmetry-break rationale (EvaluateFootprints uses M[:, i]).
+    let mut ss = SuffStats::new(1, 2);
+    let cfg = FitConfig::default().with_snr_c0(1.0);
+    let c = [2.0f32, 0.5]; // c[1] gated
+    evaluate_suff_stats(&mut ss, &[0.0f32], &c, &cfg);
+    // M[i, j] = c[i] * f(c[j]).
+    assert_close(ss.m_at(0, 0), 4.0, "M[0,0]: c[0]*f(c[0]) = 2*2");
+    assert_close(ss.m_at(0, 1), 0.0, "M[0,1]: c[0]*f(c[1]) = 2*0");
+    assert_close(ss.m_at(1, 0), 1.0, "M[1,0]: c[1]*f(c[0]) = 0.5*2");
+    assert_close(ss.m_at(1, 1), 0.0, "M[1,1]: c[1]*f(c[1]) = 0.5*0");
+}
+
+#[test]
+fn inactive_frame_advances_counter_but_does_not_update_stats() {
+    // If every component is below threshold, f(c) = 0 everywhere →
+    // the new-frame contribution is zero and the (t-1)/t decay shrinks
+    // the previous W/M by one step. Frame counter still advances: this
+    // is the mechanism by which `W` approaches zero if an estimator
+    // goes quiet for a long time (so its footprint can be retired).
+    let mut ss = SuffStats::new(1, 1);
+    let cfg = FitConfig::default().with_snr_c0(1.0);
+    // Frame 1: active.
+    evaluate_suff_stats(&mut ss, &[4.0f32], &[2.0f32], &cfg);
+    assert_close(ss.w_at(0, 0), 8.0, "W after active frame");
+    // Frame 2: inactive (c below c₀).
+    evaluate_suff_stats(&mut ss, &[4.0f32], &[0.0f32], &cfg);
+    // W_2 = (1/2) W_1 + 0 = 4.0. Counter now = 2.
+    assert_close(ss.w_at(0, 0), 4.0, "W decayed under inactive frame");
+    assert_eq!(ss.frames(), 2);
+}
+
+// ----- Input validation -----
+
+#[test]
+#[should_panic(expected = "y length")]
+fn rejects_mismatched_y_length() {
+    let mut ss = SuffStats::new(3, 2);
+    let cfg = FitConfig::default();
+    evaluate_suff_stats(&mut ss, &[1.0f32, 2.0], &[0.0f32, 0.0], &cfg);
+}
+
+#[test]
+#[should_panic(expected = "c length")]
+fn rejects_mismatched_c_length() {
+    let mut ss = SuffStats::new(3, 2);
+    let cfg = FitConfig::default();
+    evaluate_suff_stats(&mut ss, &[1.0f32; 3], &[0.0f32], &cfg);
+}

--- a/crates/cala-core/tests/fitting_throttle.rs
+++ b/crates/cala-core/tests/fitting_throttle.rs
@@ -1,0 +1,133 @@
+//! Tests for `trace_throttle` (thesis §3.2.3, Eq. 3.39).
+//!
+//! The throttle decrements `c_i` by `mean(−R/Ã_i)` over the exclusive
+//! support of `i` where the residual is negative. Its job is to make
+//! the residual at those exclusive pixels go to zero, converting a
+//! single over-estimated trace into a correct one on frames where a
+//! missing overlapping component forced the inflation.
+
+use calab_cala_core::assets::Footprints;
+use calab_cala_core::fitting::{evaluate_residual, trace_throttle};
+
+const F32_TOL: f32 = 1e-6;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+// ----- No-op cases -----
+
+#[test]
+fn empty_footprints_is_noop() {
+    let fp = Footprints::new(2, 2);
+    let mut c: Vec<f32> = Vec::new();
+    trace_throttle(&fp, &mut c, &[0.0f32; 4]);
+    assert!(c.is_empty());
+}
+
+#[test]
+fn zero_residual_leaves_c_unchanged() {
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    let mut c = [2.5f32];
+    trace_throttle(&fp, &mut c, &[0.0f32; 3]);
+    assert_close(c[0], 2.5, "c untouched on zero residual");
+}
+
+#[test]
+fn positive_residual_is_not_throttled() {
+    // Undershoot (R > 0, reconstruction < observation) is Extend's
+    // signal for a missing component — throttle specifically handles
+    // overshoot (R < 0 on exclusive support). Verify no decrement.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    let mut c = [1.0f32];
+    trace_throttle(&fp, &mut c, &[0.5f32, 0.3, 0.8]);
+    assert_close(c[0], 1.0, "positive residual → no throttle");
+}
+
+// ----- Core case: over-estimated trace on exclusive support -----
+
+#[test]
+fn overshoot_on_exclusive_support_drives_residual_to_zero() {
+    // K = 1, uniform footprint [1, 1, 1]. Actual `c_true = 1` but
+    // we fed the model `c_est = 2`. Residual: [-1, -1, -1]
+    // δ = mean((-(-1))/1) = 1 → c ← 2 − 1 = 1 (exact recovery).
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    let mut c = [2.0f32];
+    let c_true = [1.0f32];
+    let y = [1.0f32, 1.0, 1.0];
+    let mut r = [0.0f32; 3];
+    evaluate_residual(&fp, &c, &y, &mut r);
+    assert_eq!(r, [-1.0, -1.0, -1.0]);
+    trace_throttle(&fp, &mut c, &r);
+    assert_close(c[0], c_true[0], "throttle recovers true c");
+}
+
+#[test]
+fn throttle_clamps_c_to_zero_not_negative() {
+    // If δ exceeds current c, the max(·, 0) clamp prevents c going
+    // negative — we never have a "phantom" trace with the opposite sign.
+    let mut fp = Footprints::new(1, 2);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    let mut c = [1.0f32];
+    let residual = [-5.0f32, -5.0]; // δ = 5; c - δ = -4 clamped to 0.
+    trace_throttle(&fp, &mut c, &residual);
+    assert_close(c[0], 0.0, "c clamped at 0");
+}
+
+// ----- Exclusive-support gating -----
+
+#[test]
+fn overshoot_on_shared_pixel_does_not_throttle() {
+    // Two components both cover pixel 1; the residual there is
+    // negative, but because pixel 1 is shared, it is NOT in Γ for
+    // either component. No throttle should apply.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![1, 2], vec![1.0, 1.0]);
+    let mut c = [2.0f32, 2.0];
+    // Exclusive pixels: 0 (only in comp 0), 2 (only in comp 1). R ≥ 0 on both.
+    // Shared pixel: 1. R < 0 on it — but gated out.
+    let residual = [0.0f32, -5.0, 0.0];
+    trace_throttle(&fp, &mut c, &residual);
+    assert_close(c[0], 2.0, "comp 0 unchanged (exclusive R=0)");
+    assert_close(c[1], 2.0, "comp 1 unchanged (exclusive R=0)");
+}
+
+#[test]
+fn throttle_mixes_only_exclusive_pixels_with_negative_residual() {
+    // Component 0 has support {0, 1, 2}. Only pixel 0 is exclusive.
+    // R[0] = -2, R[1] = -4, R[2] = +1 (not used anyway). Only pixel 0
+    // counts → δ = -(-2)/1 = 2. c[0] ← max(3 − 2, 0) = 1.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![1, 2], vec![1.0, 1.0]); // shares 1, 2
+    let mut c = [3.0f32, 1.0];
+    let residual = [-2.0f32, -4.0, 1.0];
+    trace_throttle(&fp, &mut c, &residual);
+    assert_close(c[0], 1.0, "c[0] throttled by 2");
+    // Component 1's support {1, 2} has no exclusive pixels — every
+    // pixel is shared with component 0. So c[1] is untouched.
+    assert_close(c[1], 1.0, "c[1] untouched (no exclusive support)");
+}
+
+#[test]
+fn delta_uses_a_i_weighting_not_unweighted_mean() {
+    // Pinning Eq. 3.39 exactly: δ = mean(−R / Ã[p, i]). Non-uniform
+    // footprint values exercise the weighting — without it the test
+    // would still pass on a uniform footprint by coincidence.
+    //
+    // Support {0, 1}, values [1, 2]. R = [-3, -4].
+    // −R/a = [3/1, 4/2] = [3, 2]. mean = 2.5. c ← 5 − 2.5 = 2.5.
+    let mut fp = Footprints::new(1, 2);
+    fp.push_component(vec![0, 1], vec![1.0, 2.0]);
+    let mut c = [5.0f32];
+    trace_throttle(&fp, &mut c, &[-3.0f32, -4.0]);
+    assert_close(c[0], 2.5, "weighted mean of −R/a");
+}

--- a/crates/cala-core/tests/fitting_trace_bcd.rs
+++ b/crates/cala-core/tests/fitting_trace_bcd.rs
@@ -1,0 +1,195 @@
+//! Tests for `EvaluateTraces` (thesis §3.2.3, Algorithm 7).
+//!
+//! Invariants that pin the BCD step against its defining equation:
+//! 1. Non-negativity (`max(·, 0)` guard)
+//! 2. Exact recovery on orthogonal footprints (no coupling → one step
+//!    solves each coord)
+//! 3. Approximate recovery on overlapping footprints (coupling → BCD
+//!    converges within tolerance)
+//! 4. Zero-input gives zero trace (identity property)
+//! 5. Latency bound (iter count ≤ `trace_max_iter` regardless of input)
+
+use calab_cala_core::assets::{Footprints, Groups};
+use calab_cala_core::config::FitConfig;
+use calab_cala_core::fitting::evaluate_traces;
+
+const F32_TOL: f32 = 1e-4;
+
+fn assert_close(actual: f32, expected: f32, ctx: &str) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= F32_TOL,
+        "{ctx}: expected {expected}, got {actual} (diff {diff} > tol {F32_TOL})"
+    );
+}
+
+fn make_frame(pixels: usize) -> Vec<f32> {
+    vec![0.0f32; pixels]
+}
+
+// ----- Degenerate inputs -----
+
+#[test]
+fn zero_components_yields_empty_trace() {
+    let fp = Footprints::new(2, 2);
+    let groups = Groups::from_footprints(&fp);
+    let y = make_frame(4);
+    let cfg = FitConfig::default();
+    let c = evaluate_traces(&fp, &groups, &y, &[], &cfg);
+    assert!(c.is_empty());
+}
+
+#[test]
+fn zero_frame_drives_trace_to_zero() {
+    // y = 0 ⇒ all U = 0; coordinate updates go to max(c + (0 - Vc)/v, 0).
+    // For any non-negative starting c, repeated updates must converge to 0.
+    let mut fp = Footprints::new(2, 3); // pixels = 6
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![3, 4, 5], vec![1.0, 1.0, 1.0]);
+    let groups = Groups::from_footprints(&fp);
+    let y = make_frame(6);
+    let cfg = FitConfig::default();
+    let c = evaluate_traces(&fp, &groups, &y, &[1.5f32, 2.0], &cfg);
+    assert_eq!(c.len(), 2);
+    assert_close(c[0], 0.0, "c[0] on zero frame");
+    assert_close(c[1], 0.0, "c[1] on zero frame");
+}
+
+// ----- Exact recovery: orthogonal footprints -----
+
+#[test]
+fn orthogonal_footprints_recover_trace_exactly() {
+    // Two disjoint unit footprints → AᵀA is diagonal. Single BCD pass
+    // solves each coord exactly (no cross-coupling). Tighter than the
+    // overlap case below, where we only assert tolerance recovery.
+    let mut fp = Footprints::new(2, 3); // pixels = 6
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![3, 4, 5], vec![1.0, 1.0, 1.0]);
+    let groups = Groups::from_footprints(&fp);
+
+    let c_true = [2.0f32, 5.0];
+    // y = Ã · c_true: pixels 0..2 get 2·1, pixels 3..5 get 5·1.
+    let mut y = vec![0.0f32; 6];
+    fp.reconstruct(&c_true, &mut y);
+
+    let cfg = FitConfig::default();
+    let c_prev = [0.0f32, 0.0];
+    let c = evaluate_traces(&fp, &groups, &y, &c_prev, &cfg);
+    assert_close(c[0], c_true[0], "orthogonal recovery c[0]");
+    assert_close(c[1], c_true[1], "orthogonal recovery c[1]");
+}
+
+// ----- Approximate recovery: overlapping footprints -----
+
+#[test]
+fn overlapping_footprints_recover_trace_within_tol() {
+    // Shared pixel 2 forces cross-coupling in AᵀA. BCD still converges
+    // given enough iterations; tighter tol allowed because the linear
+    // system is well-conditioned (2×2 with a single off-diag term).
+    let mut fp = Footprints::new(1, 5);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![2, 3, 4], vec![1.0, 1.0, 1.0]);
+    let groups = Groups::from_footprints(&fp);
+    assert_eq!(groups.len(), 1, "supports overlap at pixel 2");
+
+    let c_true = [3.0f32, 7.0];
+    let mut y = vec![0.0f32; 5];
+    fp.reconstruct(&c_true, &mut y);
+
+    // Tol tightened to 1e-5 so the fixed point is reached to well
+    // within the test's F32_TOL. The default 1e-3 is correct for the
+    // streaming fit (amortized over many frames) but too loose for a
+    // single-frame recovery assertion.
+    let cfg = FitConfig::default()
+        .with_trace_max_iter(500)
+        .with_trace_tol(1e-5);
+    let c = evaluate_traces(&fp, &groups, &y, &[0.0f32, 0.0], &cfg);
+    assert_close(c[0], c_true[0], "overlapping recovery c[0]");
+    assert_close(c[1], c_true[1], "overlapping recovery c[1]");
+}
+
+// ----- Non-negativity -----
+
+#[test]
+fn trace_update_clamps_to_zero() {
+    // Construct a frame that would push c[0] negative in an unconstrained
+    // LS fit (value at pixel 0 smaller than the footprint weight there
+    // times the neighbour's contribution). The `max(·, 0)` clamp must
+    // floor the output at 0.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1], vec![1.0, 1.0]);
+    fp.push_component(vec![1, 2], vec![1.0, 1.0]);
+    let groups = Groups::from_footprints(&fp);
+
+    // y = Ãc with c = (-1, 5). Unconstrained fit would recover that;
+    // NNLS clamps c[0] to 0 and adjusts c[1] to the best non-negative fit.
+    let y = [-1.0f32, 4.0, 5.0];
+    let cfg = FitConfig::default().with_trace_max_iter(200);
+    let c = evaluate_traces(&fp, &groups, &y, &[0.0f32, 0.0], &cfg);
+    assert!(
+        c[0] >= 0.0 && c[1] >= 0.0,
+        "NNLS must not return negative c (got {c:?})"
+    );
+    assert_close(c[0], 0.0, "c[0] clamped to 0 under NNLS");
+}
+
+// ----- Latency bound -----
+
+#[test]
+fn iteration_bound_is_respected() {
+    // Even on a deliberately under-determined setup (tiny max_iter on a
+    // problem that needs many iters), the function must return — that
+    // is the whole "bounded latency" promise of the `trace_max_iter` knob.
+    let mut fp = Footprints::new(1, 3);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]);
+    fp.push_component(vec![0, 1, 2], vec![1.0, 1.0, 1.0]); // same support
+    let groups = Groups::from_footprints(&fp);
+    let y = [1.0f32, 2.0, 3.0];
+    let cfg = FitConfig::default().with_trace_max_iter(1);
+    let c = evaluate_traces(&fp, &groups, &y, &[0.0f32, 0.0], &cfg);
+    assert_eq!(c.len(), 2);
+    // With max_iter=1 and starting from zero, we did exactly one sweep —
+    // no assertion on value other than non-negativity.
+    assert!(c.iter().all(|&x| x >= 0.0));
+}
+
+// ----- Convergence -----
+
+#[test]
+fn tight_tolerance_terminates_early_on_exact_fit() {
+    // Orthogonal problem converges in one sweep. Even with huge
+    // max_iter, the tolerance check should let us short-circuit.
+    // We don't assert the iter count directly (the function doesn't
+    // return it) — we just check the answer is exact with max_iter=2.
+    let mut fp = Footprints::new(1, 2);
+    fp.push_component(vec![0], vec![1.0]);
+    fp.push_component(vec![1], vec![1.0]);
+    let groups = Groups::from_footprints(&fp);
+    let y = [2.0f32, 5.0];
+    let cfg = FitConfig::default().with_trace_max_iter(2);
+    let c = evaluate_traces(&fp, &groups, &y, &[0.0f32, 0.0], &cfg);
+    assert_close(c[0], 2.0, "orthogonal fit after 1 sweep");
+    assert_close(c[1], 5.0, "orthogonal fit after 1 sweep");
+}
+
+// ----- Input validation -----
+
+#[test]
+#[should_panic(expected = "y length")]
+fn rejects_mismatched_y_length() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0], vec![1.0]);
+    let groups = Groups::from_footprints(&fp);
+    let cfg = FitConfig::default();
+    let _ = evaluate_traces(&fp, &groups, &[0.0f32; 3], &[0.0f32], &cfg);
+}
+
+#[test]
+#[should_panic(expected = "c_prev length")]
+fn rejects_mismatched_c_prev_length() {
+    let mut fp = Footprints::new(2, 2);
+    fp.push_component(vec![0], vec![1.0]);
+    let groups = Groups::from_footprints(&fp);
+    let cfg = FitConfig::default();
+    let _ = evaluate_traces(&fp, &groups, &[0.0f32; 4], &[0.0f32, 0.0], &cfg);
+}


### PR DESCRIPTION
## Summary

Phase 2 of the CaLa port: the per-frame online matrix factorization step (thesis §3.2.3, Algorithm 6). Streams a frame through `EvaluateTraces → trace_throttle → EvaluateSuffStats → EvaluateFootprints → EvaluateResidual`, persisting `Ã`, `C̃`, `W`, `M` across frames so the cost stays bounded.

Seeded-footprint operation only — Extend (discovering new components from the residual buffer) is Phase 3. Phase 2 exits on a noiseless three-cell synthetic recording where ground-truth footprints are seeded and the pipeline recovers traces to 1e-3 tolerance with residual L2 < 1e-3.

## What lands

**Assets** (`crates/cala-core/src/assets/`):
- `Footprints` — sparse non-negative `Ã` with per-column positive-support storage, validated push, `Aᵀy`, `AᵀA`, reconstruct, compact, exclusive-pixel counts
- `Traces` — row-major `t × k` history of `C̃`, flat `Vec<f32>` so the boundary layer can hand it to numpy / xarray without copy
- `SuffStats` — dense `W` (pixels × k) and `M` (k × k) with a frame counter
- `Groups` — connected-component partition over spatial-overlap graph via pixel-indexed union-find

**Fit nodes** (`crates/cala-core/src/fitting/`):
- `evaluate_traces` — NNLS block-coordinate-descent trace update (Alg 7)
- `evaluate_suff_stats` — SNR-gated recursive-mean update of W, M (Eq. 3.25, `f(c) = c·H(c − c₀)`)
- `evaluate_footprints` — per-column CD on W, M with morphological shrink via compact (Alg 8)
- `evaluate_residual` — `R_t = y_t − Ã c̃_t` (Eq. 3.24)
- `trace_throttle` — Eq. 3.39 underfit correction on exclusive support with `R < 0`
- `FitPipeline` — composes one OMF frame

**Config**: `FitConfig` extends the Phase 1 `config.rs` pattern: `trace_tol`, `trace_max_iter`, `footprint_max_iter`, `snr_c0`, each with `DEFAULT_*` constants and validated `with_*` builders.

**Tests**: 78 new tests across 10 test files (asset invariants + synthetic ground truth + end-to-end OMF). Full crate is now at 199 passing tests.

## Design notes

- **Throttle placement** deviates from the literal Alg 6 step-7 ordering: we apply `trace_throttle` *before* the suff-stats and footprints updates so W, M learn from corrected (not over-estimated) traces. Same final state, cleaner semantics. Documented at `src/fitting/pipeline.rs`.
- **Asymmetric M** preserved from Eq. 3.25 exactly: `M[i,j] = c̃[i] · f(c̃[j])`. Column-gated only, not fully symmetric. `EvaluateFootprints` reads `M[:, i]` so the gate on column `j` is what holds footprint `j` stationary when inactive.
- **No `sprs`** yet — design §5 flags the three hot ops (`Aᵀy`, `AᵀA`, positive-support column update) as the targets to benchmark in Phase 3 before committing to a sparse-matrix swap. In-house column-major rep keeps push / value mutation / compact cheap.

## Test plan

- [ ] `cd crates/cala-core && cargo test --features native-cli --lib --tests` passes (199 tests: 121 pre-existing + 78 new for Phase 2)
- [ ] `cargo check --target wasm32-unknown-unknown --no-default-features --features jsbindings` clean
- [ ] `cargo check --no-default-features --features pybindings` clean
- [ ] `cargo clippy --features native-cli --all-targets` has no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)