### PR TITLE
fix(catune): repair tutorial highlighting after Peak/FWHM migration

### DIFF
--- a/apps/catune/src/lib/tutorial/content/01-basics.ts
+++ b/apps/catune/src/lib/tutorial/content/01-basics.ts
@@ -64,21 +64,21 @@ export const basicsTutorial: Tutorial = {
         'Use the +/\u2212 buttons to adjust the number of grid columns (1\u20136). Fewer columns means larger cards for detailed inspection; more columns lets you compare many cells at once.',
       side: 'bottom',
     },
-    // Step 7: Decay slider (+ kernel shape info absorbed from former kernel display step)
+    // Step 7: FWHM slider (+ kernel shape info absorbed from former kernel display step)
     {
-      element: '[data-tutorial="slider-decay"]',
-      title: 'Decay Time (tau_decay)',
+      element: '[data-tutorial="slider-fwhm"]',
+      title: 'FWHM (Event Width)',
       description:
-        'The most important parameter \u2014 start here. Controls how quickly calcium decays after a neural event. Too short: the solver places extra activity during the decay phase to explain lingering signal (overfitting). Too long: fit is sluggish and misses fast events. <b>Deconvolved activity should primarily appear during the rise, not spread across the whole decay.</b><br><br>' +
-        'The kernel display shows the resulting template \u2014 it should match what a real calcium transient looks like for your indicator. Its peak time and half-decay time are annotated.',
+        'The most important parameter \u2014 start here. FWHM (full width at half-max) controls the overall duration of each calcium event. Too narrow: the solver places extra activity to explain lingering signal (overfitting). Too wide: fit is sluggish and misses fast events. <b>Deconvolved activity should primarily appear during the rise, not spread across the whole event.</b><br><br>' +
+        'The kernel display shows the resulting template \u2014 it should match what a real calcium transient looks like for your indicator. Its peak time and FWHM are annotated.',
       side: 'right',
     },
-    // Step 8: Rise slider
+    // Step 8: Peak slider
     {
-      element: '[data-tutorial="slider-rise"]',
-      title: 'Rise Time (tau_rise)',
+      element: '[data-tutorial="slider-peak"]',
+      title: 'Peak Time',
       description:
-        'Controls how quickly calcium rises at event onset. Usually much shorter than decay. Fine-tune after decay is set. Note: <b>changing rise slightly changes optimal decay</b> \u2014 they\u2019re coupled, so re-check decay after adjusting rise.',
+        'Controls how quickly calcium rises to its peak after event onset. Usually much shorter than FWHM. Fine-tune after FWHM is set. Note: <b>changing Peak slightly changes optimal FWHM</b> \u2014 they\u2019re coupled, so re-check FWHM after adjusting Peak.',
       side: 'right',
     },
     // Step 9: Lambda slider
@@ -86,7 +86,7 @@ export const basicsTutorial: Tutorial = {
       element: '[data-tutorial="slider-lambda"]',
       title: 'Sparsity Penalty (lambda)',
       description:
-        'Controls event count. Start low and increase until noise artifacts disappear from the green trace without losing real events. A value of 1 is a good starting point. The green deconvolved trace should show clean, sharp peaks at real events with a quiet baseline between them. If the reconvolved fit peak starts decreasing away from the raw trace as you increase lambda, your sparsity is too high. <b>Prefer adjusting decay time over relying on high sparsity</b> to control overfitting. Increasing decay can help reduce dense deconvolved activity under big fluorescence events. Most cells will respond well to small sparsity values, but a small percentage of cells may be too noisy for reliable deconvolution \u2014 don\u2019t overfit noisy cells, focus on the average-looking cell.',
+        'Controls event count. Start low and increase until noise artifacts disappear from the green trace without losing real events. A value of 1 is a good starting point. The green deconvolved trace should show clean, sharp peaks at real events with a quiet baseline between them. If the reconvolved fit peak starts decreasing away from the raw trace as you increase lambda, your sparsity is too high. <b>Prefer adjusting FWHM over relying on high sparsity</b> to control overfitting. Increasing FWHM can help reduce dense deconvolved activity under big fluorescence events. Most cells will respond well to small sparsity values, but a small percentage of cells may be too noisy for reliable deconvolution \u2014 don\u2019t overfit noisy cells, focus on the average-looking cell.',
       side: 'right',
     },
     // Step 10: Good vs bad fit

--- a/apps/catune/src/lib/tutorial/content/02-workflow.ts
+++ b/apps/catune/src/lib/tutorial/content/02-workflow.ts
@@ -26,12 +26,12 @@ export const workflowTutorial: Tutorial = {
         'Use \u201CTop Active\u201D mode to find cells with strong activity. Look for a cell with clear, well-separated peaks in the raw trace. Avoid cells dominated by noise or slow baseline drift \u2014 a cell with a few clean events is ideal for initial tuning. Click a card below to switch cells.',
       side: 'top',
     },
-    // Step 3: Tune decay time (interactive)
+    // Step 3: Tune FWHM (interactive)
     {
-      element: '[data-tutorial="slider-decay"]',
-      title: 'Step 2: Tune Decay Time',
+      element: '[data-tutorial="slider-fwhm"]',
+      title: 'Step 2: Tune FWHM',
       description:
-        'Decay has the biggest visual impact. Find clean, small-amplitude calcium events first. Drag the slider until the fit\u2019s falling edge matches the filtered trace\u2019s falling edge after each peak. Try it now.',
+        'FWHM has the biggest visual impact. Find clean, small-amplitude calcium events first. Drag the slider until the fit\u2019s falling edge matches the filtered trace\u2019s falling edge after each peak. Try it now.',
       side: 'right',
       waitForAction: 'slider-change',
       disableActiveInteraction: false,
@@ -41,7 +41,7 @@ export const workflowTutorial: Tutorial = {
       element: '[data-tutorial="card-grid"]',
       title: 'Step 3: Check Fit & Residuals',
       description:
-        'Look at how the orange fit line follows the blue raw trace after peaks. The tails should line up. If the fit drops too fast, increase decay. If it lingers too long, decrease decay.<br><br>' +
+        'Look at how the orange fit line follows the blue raw trace after peaks. The tails should line up. If the fit drops too fast, increase FWHM. If it lingers too long, decrease FWHM.<br><br>' +
         'Then look at the red residual trace at the bottom. Residuals should resemble the noise characteristics of your recording. <b>Near-zero residuals = overfitting.</b> Visible transient shapes in residuals = underfitting. Good residuals are flat noise with no structure.',
       side: 'bottom',
       popoverClass: 'driver-popover--wide',
@@ -51,7 +51,7 @@ export const workflowTutorial: Tutorial = {
       element: '[data-tutorial="noise-filter"]',
       title: 'Step 3b: Consider Noise Filtering',
       description:
-        'Noise leads to deconvolution artifacts. Enable the <b>Noise Filter</b> to apply a bandpass filter derived from your kernel parameters. Filtering is conservative \u2014 it removes high-frequency noise without changing rise time dynamics. <b>Toggle it on to try.</b>',
+        'Noise leads to deconvolution artifacts. Enable the <b>Noise Filter</b> to apply a bandpass filter derived from your kernel parameters. Filtering is conservative \u2014 it removes high-frequency noise without changing onset kinetics. <b>Toggle it on to try.</b>',
       side: 'right',
       waitForAction: 'filter-toggle',
       disableActiveInteraction: false,
@@ -72,12 +72,12 @@ export const workflowTutorial: Tutorial = {
         'The power spectral density shows your data\u2019s frequency content. When Noise Filter is on, dashed lines mark the bandpass cutoffs (HP and LP). The passband should preserve your calcium signal frequencies while rejecting noise.',
       side: 'left',
     },
-    // Step 8: Fine-tune rise time (interactive)
+    // Step 8: Fine-tune Peak time (interactive)
     {
-      element: '[data-tutorial="slider-rise"]',
-      title: 'Step 4: Fine-Tune Rise Time',
+      element: '[data-tutorial="slider-peak"]',
+      title: 'Step 4: Fine-Tune Peak Time',
       description:
-        'Now adjust the rise time. This is subtle \u2014 it affects the onset of each event. Watch the leading edge of peaks in the fit. Drag to adjust.',
+        'Now adjust the Peak time. This is subtle \u2014 it affects how quickly each event reaches its peak. Watch the leading edge of peaks in the fit. Drag to adjust.',
       side: 'right',
       waitForAction: 'slider-change',
       disableActiveInteraction: false,
@@ -87,7 +87,7 @@ export const workflowTutorial: Tutorial = {
       element: '[data-tutorial="card-grid"]',
       title: 'Check Rise Slopes',
       description:
-        'Zoom into a peak onset. The orange fit should match the blue trace\u2019s upward slope. If the fit rises too slowly, decrease rise time. If it overshoots, increase it slightly. Note: changing rise time may slightly affect the optimal decay \u2014 re-check.',
+        'Zoom into a peak onset. The orange fit should match the blue trace\u2019s upward slope. If the fit rises too slowly, decrease Peak time. If it overshoots, increase it slightly. Note: changing Peak time may slightly affect the optimal FWHM \u2014 re-check.',
       side: 'bottom',
     },
     // Step 10: Add sparsity (interactive)

--- a/apps/catune/src/lib/tutorial/content/03-advanced.ts
+++ b/apps/catune/src/lib/tutorial/content/03-advanced.ts
@@ -23,7 +23,7 @@ export const advancedTutorial: Tutorial = {
       element: '[data-tutorial="card-grid"]',
       title: 'Residual Pattern Analysis',
       description:
-        'The red residual trace reveals model mismatches. Systematic positive bumps after peaks: decay too short. Negative dips before peaks: rise too long. Low-frequency waves: residual baseline drift (the automatic baseline subtraction handles most drift, but very slow trends may remain). <b>Residuals should resemble noise. Near-zero residuals = overfitting. Visible transient shapes = underfitting.</b>',
+        'The red residual trace reveals model mismatches. Systematic positive bumps after peaks: FWHM too narrow. Negative dips before peaks: Peak time too long. Low-frequency waves: residual baseline drift (the automatic baseline subtraction handles most drift, but very slow trends may remain). <b>Residuals should resemble noise. Near-zero residuals = overfitting. Visible transient shapes = underfitting.</b>',
       side: 'bottom',
     },
     // Step 3: Parameter coupling
@@ -31,7 +31,7 @@ export const advancedTutorial: Tutorial = {
       element: '[data-tutorial="param-panel"]',
       title: 'Parameter Coupling',
       description:
-        'Rise and decay times interact. <b>After adjusting decay, always re-check rise.</b> With longer decay, the model explains more variance, so you may need less sparsity. <b>Tune in order: decay \u2192 rise \u2192 lambda.</b>',
+        'Peak and FWHM interact. <b>After adjusting FWHM, always re-check Peak.</b> With a larger FWHM, the model explains more variance, so you may need less sparsity. <b>Tune in order: FWHM \u2192 Peak \u2192 lambda.</b>',
       side: 'left',
     },
     // Step 4: Indicator-specific guidance
@@ -48,7 +48,7 @@ export const advancedTutorial: Tutorial = {
       title: 'Artifacts & Challenging Signals',
       description:
         'Common artifacts that affect fitting: <b>Motion artifacts:</b> sharp, symmetric deflections (not calcium-shaped). <b>Photobleaching:</b> slow downward baseline trend (largely handled by the automatic rolling-percentile baseline subtraction, but extreme cases may still affect results). <b>Neuropil contamination:</b> broad, slow signals mixed with sharp events. Motion artifacts cannot be fixed by parameter tuning \u2014 they require preprocessing. Photobleaching and neuropil contamination are largely handled by CaTune\u2019s automatic baseline subtraction.<br><br>' +
-        'When neurons fire rapidly, calcium events overlap. The model handles this via superposition, but dense firing can make individual events hard to resolve. <b>Under big fluorescence events, try increasing decay time to reduce dense deconvolved activity</b> \u2014 increase as much as possible without making the fit too poor.',
+        'When neurons fire rapidly, calcium events overlap. The model handles this via superposition, but dense firing can make individual events hard to resolve. <b>Under big fluorescence events, try increasing FWHM to reduce dense deconvolved activity</b> \u2014 increase as much as possible without making the fit too poor.',
       side: 'bottom',
       popoverClass: 'driver-popover--wide',
     },
@@ -78,7 +78,7 @@ export const advancedTutorial: Tutorial = {
     },
     // Step 9: Sampling rate matters
     {
-      element: '[data-tutorial="slider-decay"]',
+      element: '[data-tutorial="slider-fwhm"]',
       title: 'When Sampling Rate Matters',
       description:
         'If your sampling rate is low (e.g., 10 Hz), fast dynamics are undersampled and parameters may need to be wider to compensate. If your data was recorded at a different rate than entered, all parameter values will be off. Double-check your sampling rate setting.',
@@ -89,7 +89,7 @@ export const advancedTutorial: Tutorial = {
       element: '[data-tutorial="export-panel"]',
       title: 'Publication-Quality Parameters',
       description:
-        'For publications, report: rise time, decay time, lambda, sampling rate, and calcium indicator. Include the AR2 coefficients from the export JSON \u2014 these are the mathematically equivalent autoregressive representation used by most analysis pipelines. Always note the CaTune version.',
+        'For publications, report: Peak time, FWHM, lambda, sampling rate, and calcium indicator. The export JSON also includes the equivalent tau_rise/tau_decay pair and AR2 coefficients used by most analysis pipelines. Always note the CaTune version.',
       side: 'top',
     },
     // Step 11: Completion (centered modal, no element)

--- a/packages/tutorials/src/types.ts
+++ b/packages/tutorials/src/types.ts
@@ -3,7 +3,7 @@
 
 /** A single step in a tutorial tour. */
 export interface TutorialStep {
-  /** CSS selector for the target element (e.g., '[data-tutorial="slider-decay"]'). Omit for centered modal. */
+  /** CSS selector for the target element (e.g., '[data-tutorial="slider-fwhm"]'). Omit for centered modal. */
   element?: string;
   /** Popover title text. */
   title: string;

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -52,7 +52,13 @@ export function Card(props: CardProps) {
       {...spreadDataAttrs(props)}
     >
       {props.children}
-      {props.resizable && <div class="calab-card__resize-handle" onMouseDown={handleResizeStart} />}
+      {props.resizable && (
+        <div
+          class="calab-card__resize-handle"
+          data-tutorial="resize-handle"
+          onMouseDown={handleResizeStart}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The tutorial overlay was misbehaving in CaTune because several of its driver.js step selectors no longer pointed at real DOM elements after the kernel parameter migration from `tau_rise`/`tau_decay` to Peak/FWHM.

Broken selectors:

- `[data-tutorial="slider-decay"]` — renamed to `slider-fwhm` in `ParameterPanel`, never updated in the tutorial content (3 references across 3 tutorials).
- `[data-tutorial="slider-rise"]` — renamed to `slider-peak`, same story (2 references across 2 tutorials).
- `[data-tutorial="resize-handle"]` — never existed; the Card component's resize-handle div was unlabeled.

So the tutorial would highlight nothing (or fall back to a sibling/parent, depending on driver.js's behaviour for missing targets) on any step touching a kernel-param slider or the "Card Height" step.

Fixes in this PR:

- Selector renames in tutorial content (`slider-decay` → `slider-fwhm`, `slider-rise` → `slider-peak`).
- Added `data-tutorial="resize-handle"` to the Card resize handle in `@calab/ui`.
- Rewrote step titles, body text, and comments that still described τ_rise / τ_decay so the popover narrative matches the slider it highlights. Mapping used: Decay Time → FWHM (event width); Rise Time → Peak Time. Tuning order / parameter coupling / artifact causes updated accordingly.
- The `05-theory` tutorial and `04-features` (community scatter plot axes) continue to reference τ values directly because the underlying kernel math and the community submission schema still use them — left untouched.
- Stale JSDoc example in `packages/tutorials/src/types.ts`.

Cross-checked every selector referenced in tutorial content against live `data-tutorial=` attributes across `apps/catune/src` and `packages/*/src`: no unmatched selectors remain.

## Test plan

- [x] `npx tsc -b apps/catune` — clean
- [x] `npx prettier --check` on touched files — clean
- [x] `npm test --workspaces` — 62/62 pass (catune + io, no regressions)
- [ ] **Needs human UI verification:** launch each of the three tutorials (basics, workflow, advanced), step through to completion, and confirm the highlight box lands on the right slider / resize handle at each step and the popover text matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)