### PR TITLE
ci(deploy): bump install-action pin to fix wasm-pack 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           workspaces: 'crates/solver -> target'
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         with:
           tool: wasm-pack@0.13.1
 


### PR DESCRIPTION
## Problem

The `v2.4.7` "Deploy to GitHub Pages" run failed at the **Install wasm-pack** step with a repeated 404:

```
downloading https://github.com/drager/wasm-pack/releases/download/v0.13.1/wasm-pack-v0.13.1-x86_64-unknown-linux-musl.tar.gz
curl: (22) The requested URL returned error: 404
```

## Root cause

The wasm-pack repo changed ownership. The old `taiki-e/install-action` pin (`a2352fc`, ~v2) froze a manifest that pointed wasm-pack downloads at `drager/wasm-pack` — a repo that hosts **no releases**. Nothing in our repo changed; the upstream metadata our pin captured went stale. The action has since corrected its manifest to the now-canonical `wasm-bindgen/wasm-pack`.

## Fix

Bump the pin to `v2.81.1` (`e49978b`), whose manifest uses `wasm-bindgen/wasm-pack`.

Verified before applying:
- `wasm-bindgen/wasm-pack` serves our pinned `v0.13.1` (302 → asset)
- The new manifest still contains a `0.13.1` entry with checksums, so `checksum: true` still validates
- `deploy.yml` is the only workflow using this action — `ci.yml` and `publish-python.yml` don't install wasm-pack

After merge, the `v2.4.7` tag will be moved onto the merge commit to re-trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)