### PR TITLE
fix(community): show bridge submissions & hide demo presets under User data

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,10 @@
     "./chart/chart-theme.css": "./src/chart/chart-theme.css",
     "./styles/*": "./src/styles/*"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@calab/community": "*",
     "@calab/compute": "*",

--- a/packages/ui/src/CommunityBrowserShell.tsx
+++ b/packages/ui/src/CommunityBrowserShell.tsx
@@ -18,6 +18,7 @@ import { createSignal, createEffect, createMemo, Show, on } from 'solid-js';
 import type { JSX, Accessor } from 'solid-js';
 import type { BaseSubmission, BaseFilterState, DataSource } from '@calab/community';
 import { supabaseEnabled, user, fieldOptions, loadFieldOptions } from '@calab/community';
+import { matchesSourceBucket } from './source-bucket.ts';
 import './styles/community.css';
 
 /** Stale-while-revalidate threshold: 5 minutes in milliseconds. */
@@ -110,7 +111,7 @@ export function CommunityBrowserShell<
     const f = props.filters();
     const ds = dataSource();
     return subs.filter((s) => {
-      if (s.data_source !== ds) return false;
+      if (!matchesSourceBucket(s.data_source, ds)) return false;
       if (f.indicator && s.indicator !== f.indicator) return false;
       if (f.species && s.species !== f.species) return false;
       if (f.brainRegion && s.brain_region !== f.brainRegion) return false;
@@ -127,7 +128,7 @@ export function CommunityBrowserShell<
   /** Submissions matching the current data source (before dropdown filters). */
   const sourceSubmissions = createMemo(() => {
     const ds = dataSource();
-    return submissions().filter((s) => s.data_source === ds);
+    return submissions().filter((s) => matchesSourceBucket(s.data_source, ds));
   });
 
   /** User params for "Compare my params" overlay. */

--- a/packages/ui/src/FilterBar.tsx
+++ b/packages/ui/src/FilterBar.tsx
@@ -117,20 +117,6 @@ export function FilterBar<F extends BaseFilterState>(props: FilterBarProps<F>) {
               <option value={br}>{br}</option>
             ))}
           </select>
-
-          {/* Render extra filters alongside base filters when not in extra-only mode */}
-          {(props.extraFilters ?? []).map((ef) => (
-            <select
-              class="filter-bar__select"
-              value={((props.filters as Record<string, unknown>)[ef.id] as string) ?? ''}
-              onChange={(e) => handleFilterChange(ef.id, e.currentTarget.value)}
-            >
-              <option value="">{ef.label}</option>
-              {ef.options.map((opt) => (
-                <option value={opt.id}>{opt.label}</option>
-              ))}
-            </select>
-          ))}
         </>
       )}
 

--- a/packages/ui/src/__tests__/source-bucket.test.ts
+++ b/packages/ui/src/__tests__/source-bucket.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { matchesSourceBucket } from '../source-bucket.ts';
+
+describe('matchesSourceBucket', () => {
+  // Regression: the browser source toggle only ever selects 'demo' or 'user'.
+  // Submissions are stored with their exact source, so bridge/training rows
+  // (e.g. real data loaded via the Python calab.tune bridge) were silently
+  // filtered out of the 'user' bucket and never appeared in the community
+  // browser. The 'user' bucket must include every non-demo source.
+
+  it('matches user submissions to the user bucket', () => {
+    expect(matchesSourceBucket('user', 'user')).toBe(true);
+  });
+
+  it('matches bridge submissions to the user bucket', () => {
+    expect(matchesSourceBucket('bridge', 'user')).toBe(true);
+  });
+
+  it('matches training submissions to the user bucket', () => {
+    expect(matchesSourceBucket('training', 'user')).toBe(true);
+  });
+
+  it('matches demo submissions to the demo bucket', () => {
+    expect(matchesSourceBucket('demo', 'demo')).toBe(true);
+  });
+
+  it('does not show demo submissions in the user bucket', () => {
+    expect(matchesSourceBucket('demo', 'user')).toBe(false);
+  });
+
+  it('does not show non-demo submissions in the demo bucket', () => {
+    expect(matchesSourceBucket('user', 'demo')).toBe(false);
+    expect(matchesSourceBucket('bridge', 'demo')).toBe(false);
+    expect(matchesSourceBucket('training', 'demo')).toBe(false);
+  });
+});

--- a/packages/ui/src/source-bucket.ts
+++ b/packages/ui/src/source-bucket.ts
@@ -1,0 +1,16 @@
+// Data-source bucket matching for the community browser.
+
+import type { DataSource } from '@calab/community';
+
+/**
+ * Does a submission's stored `data_source` belong in the currently selected
+ * browser bucket? The browser's source toggle only ever selects 'demo' or
+ * 'user' (bridge/training collapse to 'user' — see the appDataSource effect in
+ * CommunityBrowserShell), but submissions are stored with their exact source
+ * ('bridge', 'training', ...). So the 'user' bucket must match every non-demo
+ * source, otherwise bridge/training submissions are silently filtered out and
+ * never appear in the browser.
+ */
+export function matchesSourceBucket(rowSource: DataSource, bucket: DataSource): boolean {
+  return bucket === 'demo' ? rowSource === 'demo' : rowSource !== 'demo';
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Problem

Ran CaTune on real data (loaded via the Python `calab.tune` bridge), submitted to the community database — the submission saved correctly but never appeared in the **Community** sidebar.

Root cause: two read-side filtering bugs in the shared community browser (`@calab/ui`). Both affect **CaTune and CaDecon**, since they share `CommunityBrowserShell` and `FilterBar`.

### 1. Bridge / training submissions were invisible

The source toggle only ever selects `'demo'` or `'user'`, but submissions are stored with their exact `data_source` — `'bridge'` for Python-bridge real-data runs, plus `'training'`. The row filter did an exact `===`/`!==` match, so a `'bridge'` row matched neither toggle state and was silently filtered out, despite being saved fine.

The `appDataSource` effect already collapses `bridge`→`user` for the *toggle*, so the read side was inconsistent with its own intent. Fix: the `'user'` bucket now matches every non-demo source, extracted as a pure `matchesSourceBucket()` helper with a regression test.

### 2. Demo Presets dropdown showed under User data

The preset options are simulation presets, and the shell only applies the `demoPreset` filter to `data_source === 'demo'` rows — so under User data the dropdown was a dead control. `FilterBar` rendered extra filters in *both* the demo-only and base branches; removed the stray base-branch render so extra filters are strictly demo-only, matching `showExtraFiltersOnly`'s intent.

## Changes
- `CommunityBrowserShell.tsx` — use `matchesSourceBucket()` in both filter memos
- `source-bucket.ts` — new pure helper (extracted for testability)
- `FilterBar.tsx` — drop the duplicate extra-filter render in the base branch
- `__tests__/source-bucket.test.ts` + `vitest.config.ts` + `test` scripts — `@calab/ui` was previously skipped by the workspace-wide test run for having no test script

## Testing
- `npm run test -w @calab/ui` — 6/6 pass
- `npx tsc --noEmit -p packages/ui` — clean
- Verified locally against the live database: the affected `bridge` submission (GCaMP6f / mouse / CA1, 708 cells) now appears under User data; Presets dropdown shows only in Demo mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)