### PR TITLE
fix(cadecon): correct per-subset kernel attribution + init/variance robustness

### DIFF
--- a/apps/cadecon/src/lib/__tests__/iteration-store.test.ts
+++ b/apps/cadecon/src/lib/__tests__/iteration-store.test.ts
@@ -184,8 +184,12 @@ describe('iteration-store: derived memos', () => {
         tauDecayFast: 0.4,
         betaFast: 1,
         fs: 30,
+        // subsetIdx deliberately does not match array position — kernel results
+        // arrive in worker-completion order, so subsetVarianceData must read the
+        // subsetIdx field, not the array index.
         subsets: [
           {
+            subsetIdx: 2,
             tauRise: 0.05,
             tauDecay: 0.4,
             beta: 1,
@@ -196,6 +200,7 @@ describe('iteration-store: derived memos', () => {
             hFree: new Float32Array(),
           },
           {
+            subsetIdx: 0,
             tauRise: 0.06,
             tauDecay: 0.5,
             beta: 1,
@@ -209,6 +214,8 @@ describe('iteration-store: derived memos', () => {
       });
       const variance = subsetVarianceData();
       expect(variance).toHaveLength(2);
+      expect(variance[0].subsetIdx).toBe(2);
+      expect(variance[1].subsetIdx).toBe(0);
       expect(variance[0].tauRise).toBeCloseTo(50); // ms
       expect(variance[0].tauDecay).toBeCloseTo(400);
       expect(variance[1].tauRise).toBeCloseTo(60);

--- a/apps/cadecon/src/lib/iteration-manager.ts
+++ b/apps/cadecon/src/lib/iteration-manager.ts
@@ -65,6 +65,15 @@ import { reconvolveAR2 } from './reconvolve.ts';
 /** Number of early free-kernel samples to skip in bi-exponential fitting. */
 export const BIEXP_FIT_SKIP = 0;
 
+/**
+ * A kernel-estimation result tagged with the subset it came from.
+ * Kernel jobs complete in worker-completion order (not dispatch order), so the
+ * subset index must travel with each result rather than being inferred from
+ * array position — otherwise per-subset kernels, warm-starts, and snapshots get
+ * bound to the wrong subset when jobs finish out of order.
+ */
+type KernelJobResult = KernelResult & { subsetIdx: number };
+
 let pool: WorkerPool<CaDeconPoolJob> | null = null;
 let nextJobId = 0;
 let pauseResolver: (() => void) | null = null;
@@ -87,14 +96,6 @@ function extractCellTrace(
     trace[t] = Number(data.data[idx]);
   }
   return trace;
-}
-
-/** Check whether a subset's trace results contain at least one usable cell (non-zero alpha and spikes). */
-function hasValidTraceResults(subsetResults: Map<number, TraceResult>): boolean {
-  for (const [, r] of subsetResults) {
-    if (r.alpha !== 0 && !r.sCounts.every((v) => v === 0)) return true;
-  }
-  return false;
 }
 
 // --- Dispatch helpers ---
@@ -195,9 +196,9 @@ function dispatchKernelJobs(
   kernelLength: number,
   prevKernels?: Float32Array[],
   prevBiexpResults?: WarmBiexp[],
-): Promise<KernelResult[]> {
+): Promise<KernelJobResult[]> {
   return new Promise((resolve) => {
-    const kernelResults: KernelResult[] = [];
+    const kernelResults: KernelJobResult[] = [];
     let completed = 0;
     let totalKernelJobs = 0;
 
@@ -276,7 +277,7 @@ function dispatchKernelJobs(
         warmKernel,
         warmBiexp,
         onComplete(result: KernelResult) {
-          kernelResults.push(result);
+          kernelResults.push({ ...result, subsetIdx: si });
           completed++;
           if (completed === totalKernelJobs) resolve(kernelResults);
         },
@@ -650,21 +651,15 @@ export async function startRun(): Promise<void> {
     }
 
     // Store kernels and biexp results for warm-starting next iteration.
-    // dispatchKernelJobs skips subsets with no valid traces, so kernelResults
-    // may have fewer entries than rects. Map them back by replaying the skip logic.
+    // dispatchKernelJobs skips subsets with no valid traces and results arrive in
+    // worker-completion order, so index each result by its own subsetIdx rather
+    // than by array position.
     prevKernels = new Array(rects.length);
     prevBiexpResults = new Array(rects.length);
-    {
-      let ki = 0;
-      for (let si = 0; si < rects.length; si++) {
-        if (hasValidTraceResults(traceResults[si]) && ki < kernelResults.length) {
-          const kr = kernelResults[ki];
-          prevKernels[si] = new Float32Array(kr.hFree);
-          const { hFree: _, ...warmFields } = kr;
-          prevBiexpResults[si] = warmFields;
-          ki++;
-        }
-      }
+    for (const kr of kernelResults) {
+      const { hFree, subsetIdx, ...warmFields } = kr;
+      prevKernels[subsetIdx] = new Float32Array(hFree);
+      prevBiexpResults[subsetIdx] = warmFields;
     }
 
     // Step 3: Merge — median tauRise/tauDecay across subsets
@@ -711,6 +706,7 @@ export async function startRun(): Promise<void> {
         betaFast: medBetaFast,
         fs,
         subsets: kernelResults.map((r) => ({
+          subsetIdx: r.subsetIdx,
           tauRise: r.tauRise,
           tauDecay: r.tauDecay,
           beta: r.beta,

--- a/apps/cadecon/src/lib/iteration-store.ts
+++ b/apps/cadecon/src/lib/iteration-store.ts
@@ -6,6 +6,8 @@ export type RunState = 'idle' | 'running' | 'paused' | 'stopping' | 'complete';
 export type RunPhase = 'idle' | 'inference' | 'kernel-update' | 'merge' | 'finalization';
 
 export interface SubsetKernelSnapshot {
+  /** Index of the subset rectangle this kernel came from. */
+  subsetIdx: number;
   tauRise: number;
   tauDecay: number;
   beta: number;
@@ -116,8 +118,8 @@ const subsetVarianceData = createMemo(() => {
   const history = convergenceHistory();
   if (history.length === 0) return [];
   const latest = history[history.length - 1];
-  return latest.subsets.map((s, idx) => ({
-    subsetIdx: idx,
+  return latest.subsets.map((s) => ({
+    subsetIdx: s.subsetIdx,
     tauRise: s.tauRise * 1000,
     tauDecay: s.tauDecay * 1000,
   }));

--- a/packages/core/src/__tests__/snr.test.ts
+++ b/packages/core/src/__tests__/snr.test.ts
@@ -26,6 +26,22 @@ describe('computePeakSNR', () => {
     const trace = new Float64Array(100).fill(0);
     expect(computePeakSNR(trace)).toBe(Infinity);
   });
+
+  it('computes a finite SNR when the baseline sits on a large DC offset', () => {
+    // Regression for catastrophic cancellation: with a large offset the one-pass
+    // variance (E[x^2] - E[x]^2) collapses to ~0 (std 0 → SNR Infinity). The
+    // two-pass form recovers the true baseline spread.
+    const OFFSET = 1e8;
+    const trace = new Float64Array(200);
+    for (let i = 0; i < 200; i++) {
+      // Baseline with a small, non-degenerate spread; a chunk of clear peaks so
+      // the 95th percentile lands on signal, not baseline.
+      trace[i] = i < 180 ? OFFSET + ((i % 7) - 3) : OFFSET + 100;
+    }
+    const snr = computePeakSNR(trace);
+    expect(Number.isFinite(snr)).toBe(true);
+    expect(snr).toBeGreaterThan(10);
+  });
 });
 
 describe('snrToQuality', () => {

--- a/packages/core/src/metrics/snr.ts
+++ b/packages/core/src/metrics/snr.ts
@@ -35,14 +35,19 @@ export function computePeakSNR(trace: Float64Array): number {
   // Baseline: lower 25th percentile
   const q25Idx = Math.floor(n * 0.25);
   let baselineSum = 0;
-  let baselineSumSq = 0;
   for (let i = 0; i < q25Idx; i++) {
     baselineSum += sorted[i];
-    baselineSumSq += sorted[i] * sorted[i];
   }
   const baselineMean = baselineSum / q25Idx;
-  const baselineVar = baselineSumSq / q25Idx - baselineMean * baselineMean;
-  const baselineStd = Math.sqrt(Math.max(0, baselineVar));
+  // Two-pass variance: the one-pass form (E[x^2] - E[x]^2) suffers
+  // catastrophic cancellation when the baseline sits on a large DC offset.
+  let baselineSqDiff = 0;
+  for (let i = 0; i < q25Idx; i++) {
+    const d = sorted[i] - baselineMean;
+    baselineSqDiff += d * d;
+  }
+  const baselineVar = baselineSqDiff / q25Idx;
+  const baselineStd = Math.sqrt(baselineVar);
 
   if (baselineStd === 0) {
     snrCache.set(trace, Infinity);

--- a/packages/core/src/wasm-adapter.ts
+++ b/packages/core/src/wasm-adapter.ts
@@ -34,6 +34,15 @@ let wasmReady: Promise<void> | null = null;
  * multiple sites; only the first call triggers actual initialization.
  */
 export function initWasm(): Promise<void> {
-  if (!wasmReady) wasmReady = init().then(() => {});
+  if (!wasmReady) {
+    wasmReady = init()
+      .then(() => {})
+      .catch((err) => {
+        // Clear the cached promise so a later call can retry instead of
+        // being permanently stuck on a rejected init.
+        wasmReady = null;
+        throw err;
+      });
+  }
   return wasmReady;
 }


### PR DESCRIPTION
First PR in the pre-publication review series. Three independent, tightly-scoped correctness fixes; no behavior change to the happy path, but each removes a real latent bug.

## 1. Per-subset kernel mis-attribution (the main one)
Kernel-estimation jobs run in parallel and their results are collected in **worker-completion order**, but `KernelResult` carried no subset identity — the manager remapped results to subsets by *replaying the skip predicate against array position* (`iteration-manager.ts`). When kernel jobs finished out of dispatch order, per-subset `hFree`, warm-start kernels, and the per-subset convergence snapshots were bound to the **wrong subset**. (Merged medians are order-independent, so `tauRise`/`tauDecay` outputs were unaffected — which is why it went unnoticed.)

Fix: tag each result with its `subsetIdx` (mirroring how trace/seed jobs already work) and index warm-starts and snapshots by it. Added `subsetIdx` to `SubsetKernelSnapshot`. Trace jobs already did this; kernel jobs were the inconsistent path.

## 2. `initWasm` caches rejected promise
A first-time WASM init failure was cached forever, so every subsequent call re-returned the rejected promise and could never recover. Clear the cache on rejection so a later call retries.

## 3. `computePeakSNR` one-pass variance
Used `E[x^2] - E[x]^2`, which suffers catastrophic cancellation when the baseline sits on a large DC offset (variance collapses to ~0 → std 0 → SNR `Infinity`). Switched to two-pass.

## Tests
- New assertion in `iteration-store.test.ts` using **out-of-order** `subsetIdx` values so `subsetVarianceData` must read the field, not the array index.
- New `snr.test.ts` regression: large-offset trace returns a finite SNR (one-pass would return `Infinity`).
- Full suites pass: 33 CaDecon, 58 core; typecheck + lint clean.

## Notes
- Worker init/job-error **surfacing** (silent failures on the worker path) was deliberately split into its own follow-up PR, since it touches the shared generic `worker-pool` (also used by CaTune) and needs a user-facing-surface decision.
- The untracked `drift-trajectory.harness.test.ts` (already broken on `main` — references reverted `reconResid`/`frontFrac` fields) is not part of this diff; it'll be relocated in the repo-hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)