### PR TITLE
chore: gitignore python virtualenvs (.venv*/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ test/
 .env
 .env.local
 .claude/
+# Python virtualenvs (any variant: .venv, .venv-headless, ...) — never committed.
+.venv*/
 python/src/calab/*.so
 python/docs/_build/
 python/docs/autoapi/


### PR DESCRIPTION
## What

Adds `.venv*/` to the root `.gitignore` so Python virtualenvs can never be accidentally committed.

The headless-bridge dev workflow creates a `.venv-headless/` directory in the repo root; the existing `python/.gitignore` only covers `.venv/`, so this variant was showing up as untracked. `.venv*/` covers `.venv`, `.venv-headless`, and any future variant.

## Also

Relocated a batch of ad-hoc Python probe scripts (`python/run_*.py`, `python/drift_lib.py`, `python/drift_probe.py`) out of the tracked working tree. These were throwaway scripts from the convergence-drift / spike-overcount investigation — a headless replica of the CaDecon iteration loop plus one-off experiments. They were never committed; their findings are recorded in project memory. Moving them keeps `git status` clean without losing the analysis.

## Risk

Minimal — one `.gitignore` line. No tracked file references any of the relocated scripts or the venv path (verified with `git grep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)