### PR TITLE
docs(cadecon): align tutorials with convergence / palette / fit-mode changes

### DIFF
--- a/apps/cadecon/src/lib/tutorial/content/01-basics.ts
+++ b/apps/cadecon/src/lib/tutorial/content/01-basics.ts
@@ -67,7 +67,7 @@ export const basicsTutorial: Tutorial = {
       element: '[data-tutorial="kernel-convergence"]',
       title: 'Watching It Converge',
       description:
-        'As the run increases in iterations, these tabbed charts track the learning process: <b>Kernel</b> shape over iterations, plus <b>Alpha</b>, <b>Threshold</b>, <b>PVE</b>, <b>Event Rate</b>, and <b>Spike Eff.</b> trends. A good run shows these settling toward stable values. Don\u2019t judge a fit until the run has converged.',
+        'As the run iterates, these tabbed charts track the learning process. <b>Asymptote</b> (shown first) is the at-a-glance health check \u2014 small charts of the four things that should <b>flatten out</b> as the run settles: kernel shape (peak time &amp; FWHM), kernel-fit quality (R\u00b2), reconstruction quality (PVE), and activity stability. <b>Kernel</b> shows the kernel shape evolving over iterations with the per-subset spread; <b>Distributions</b> shows per-cell histograms once the run finishes. A good run shows the Asymptote curves leveling off \u2014 don\u2019t judge a fit until the run has converged.',
       side: 'bottom',
       popoverClass: 'driver-popover--wide',
     },

--- a/apps/cadecon/src/lib/tutorial/content/03-theory.ts
+++ b/apps/cadecon/src/lib/tutorial/content/03-theory.ts
@@ -96,16 +96,11 @@ export const theoryTutorial: Tutorial = {
         'Both parts of the loop improve each other over each iteration until they converge on a consistent answer. To handle large recordings, many <b>subsets</b> of cells and time are solved in parallel and their kernels combined. This back-and-forth is exactly what you see happening in the convergence panel.',
     },
     // Step 11: Stopping + final inference.
-    // NOTE: The exact stop criterion \u2014 and whether the reported kernel comes from
-    // the stopping iteration or a potentially better earlier iteration \u2014 is still
-    // being finalized (see iteration-manager.ts: best-residual tracking + the
-    // currently-disabled patience early-stop). Keep this description general until
-    // the approach is locked in, then tighten the wording here.
     {
       title: 'How does CaDecon know when to stop?',
       description:
-        'More iterations aren\u2019t always better. Once the kernel and spikes stop changing much from one pass to the next, extra iterations add little \u2014 and the fit can even drift after it has peaked. CaDecon watches how much the kernel changes between iterations and <b>settles once it stabilizes</b>. In practice a good solution usually emerges within just a handful of iterations.<br><br>' +
-        'There is also a maximum-iteration limit, but that is only a <b>safety cap</b> to stop a run that never settles \u2014 it is not how a healthy run should normally end. With a stable kernel in hand, CaDecon runs one <b>final inference across every cell</b>, which is why results appear for all your cells, not just the subsets it learned from.',
+        'More iterations aren\u2019t always better. Once the kernel stops changing much from one pass to the next, extra iterations add little \u2014 and the fit can even drift after it has peaked. Rather than watch the raw time constants (which can trade off against each other), CaDecon judges convergence by the kernel\u2019s <b>shape</b> \u2014 its <b>rise-to-peak time</b> and its <b>width (FWHM)</b>. An iteration counts as <b>stable</b> when both change by less than a small tolerance, and CaDecon declares convergence only after <b>several consecutive stable iterations</b>, so one lucky pass can\u2019t stop it early. In practice a good solution usually emerges within just a handful of iterations.<br><br>' +
+        'To guard against any late drift, the <b>reported kernel is the consensus</b> (the median shape) of the last few iterations, not whatever the final pass happened to produce. You can make the run stop sooner or keep refining with the <b>Convergence Tolerance</b> setting. There is also a maximum-iteration limit, but that is only a <b>safety cap</b> for a run that never settles \u2014 not how a healthy run should normally end. With a stable kernel in hand, CaDecon runs one <b>final inference across every cell</b>, which is why results appear for all your cells, not just the subsets it learned from.',
     },
     // Step 12: Completion
     {

--- a/apps/cadecon/src/lib/tutorial/content/04-interpreting.ts
+++ b/apps/cadecon/src/lib/tutorial/content/04-interpreting.ts
@@ -22,7 +22,7 @@ export const interpretingTutorial: Tutorial = {
       element: '[data-tutorial="kernel-convergence"]',
       title: 'Signs of Healthy Convergence',
       description:
-        'Click through the tabs. <b>Kernel</b> and <b>PVE</b> are your first checks: the kernel shape should stop changing and PVE should plateau. <b>Threshold</b> and <b>Alpha</b> should settle rather than drift. <b>Warning signs:</b> values still moving when the run ends (the kernel never stabilized — usually low SNR or an unlucky subset draw; try higher coverage or re-tiling), or a sharp reset mid-run followed by divergence.',
+        'Start on the <b>Asymptote</b> tab — its four small charts are your first check. Kernel shape (peak time &amp; FWHM), kernel-fit R², reconstruction PVE, and activity stability should all <b>flatten toward a plateau</b> as the run settles; the green marker shows the iteration where CaDecon declared convergence. The <b>Kernel</b> tab shows the shape itself over iterations, and <b>Distributions</b> shows the per-cell alpha, PVE, and event-rate spread. <b>Warning signs:</b> curves still moving when the run ends (the kernel never stabilized — usually low SNR or an unlucky subset draw; try higher coverage or re-tiling), or a sharp reset mid-run followed by divergence.',
       side: 'bottom',
       popoverClass: 'driver-popover--wide',
     },
@@ -31,7 +31,7 @@ export const interpretingTutorial: Tutorial = {
       element: '[data-tutorial="kernel-display"]',
       title: 'Judging Kernel Quality',
       description:
-        'The learned kernel should look like a real calcium transient: a fast rise to a single peak, then a smooth decay. The per-subset free-kernel curves should <b>cluster tightly</b> around the fitted model. Bumpy, multi-peaked, or widely scattered curves mean the subsets disagreed which makes the kernel uncertain. If this is the case, don\u2019t over-trust the deconvolved output. If ground truth is available (like in demo data), it overlays here for comparison.',
+        'The learned kernel should look like a real calcium transient: a fast rise to a single peak, then a smooth decay. The per-subset free-kernel curves should <b>cluster tightly</b> around the fitted model. Bumpy, multi-peaked, or widely scattered curves mean the subsets disagreed which makes the kernel uncertain. If this is the case, don\u2019t over-trust the deconvolved output. Watch for a <b>degenerate-fit warning</b> here (e.g. \u201c\u26a0 2/8 fits degenerate\u201d): it means some subsets produced no usable calcium shape \u2014 typically the subsets that caught mostly noise \u2014 which is a cue to raise coverage or re-tile. If ground truth is available (like in demo data), it overlays here for comparison.',
       side: 'left',
     },
     // Step 4: Iteration selector

--- a/apps/cadecon/src/lib/tutorial/theory-figures.ts
+++ b/apps/cadecon/src/lib/tutorial/theory-figures.ts
@@ -11,6 +11,7 @@
  */
 
 import { computeKernel, computeKernelAnnotations } from '@calab/compute';
+import { OKABE_ITO, NEUTRAL } from '@calab/ui/chart';
 
 // --- Illustrative kernel for the figure (a generic GCaMP-like shape; these are
 //     display-only constants, not algorithm parameters). ---
@@ -18,14 +19,14 @@ const FIG_TAU_RISE = 0.1; // s
 const FIG_TAU_DECAY = 0.6; // s
 const FIG_FS = 30; // Hz
 
-// --- Colors (match the dashboard palette) ---
-const KERNEL_COLOR = 'hsl(280,70%,60%)';
+// --- Colors (shared colorblind-safe Okabe-Ito palette, matching the dashboard) ---
+const KERNEL_COLOR = OKABE_ITO.reddishPurple; // kernel / slow component
 const LABEL_COLOR = '#ccc';
 const AXIS_COLOR = 'rgba(255,255,255,0.15)';
-const KEEP_COLOR = 'hsl(280,70%,60%)'; // graded values above the cutoff
-const DROP_COLOR = '#6f6f7a'; // graded values below the cutoff (muted grey)
-const SPIKE_COLOR = '#2ca02c'; // recovered spikes
-const THRESH_COLOR = '#ff7f0e'; // cutoff line
+const KEEP_COLOR = OKABE_ITO.reddishPurple; // graded values above the cutoff
+const DROP_COLOR = NEUTRAL; // graded values below the cutoff (muted grey)
+const SPIKE_COLOR = OKABE_ITO.bluishGreen; // recovered spikes (matches deconv activity)
+const THRESH_COLOR = OKABE_ITO.orange; // cutoff line
 
 // --- Dimensions ---
 const SINGLE_W = 400;


### PR DESCRIPTION
Final item of the pre-publication review series: bring the in-app CaDecon tutorials in line with the behavior shipped in #153–163. Content + figure-color changes only — verified with `tsc -b apps/cadecon`, eslint, and prettier.

## What changed

**Theory — "How does CaDecon know when to stop?" (`03-theory.ts` step 11)**
The step carried an explicit `NOTE` that the stop criterion was "still being finalized." It's now finalized, so I removed the note and rewrote the description to match: convergence is judged in kernel **shape space** — stability of the **rise-to-peak time** and **FWHM** — declared after **several consecutive stable iterations**, with the **reported kernel = the median (consensus) of the last few iterates** (which is also what guards against late drift). Mentions the Convergence Tolerance control.

**Convergence panel tabs (`01-basics.ts` step 7, `04-interpreting.ts` step 2)**
Both described tabs that no longer exist ("Threshold", "Spike Eff."). Rewrote them against the real `ConvergencePanel` tabs — **Asymptote / Kernel / Distributions**:
- Basics leads with the **Asymptote** dashboard (the four signals that should flatten: kernel shape, kernel-fit R², PVE, activity stability).
- Interpreting uses Asymptote as the first health check and notes the convergence marker; per-cell alpha/PVE/event-rate now correctly attributed to the **Distributions** tab.

**Kernel quality (`04-interpreting.ts` step 3)**
Documents the new **degenerate-fit warning** (`⚠ n/N fits degenerate`, from the #162 `FitMode` work) as a cue to raise coverage or re-tile.

**Theory figures (`theory-figures.ts`)**
Now draw with the shared colorblind-safe **Okabe-Ito** palette imported from `@calab/ui/chart` (spikes → bluish-green, cutoff → orange, kernel → reddish-purple, dropped → neutral grey) instead of the old D3 category10 green/orange — making the "match the dashboard palette" comment actually true.

## Verification
- `tsc -b apps/cadecon` clean (confirms the new `@calab/ui/chart` import resolves).
- eslint + prettier clean.
- Static-only; I did not spin up the browser for this one — happy to Playwright-verify the theory figure render on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)