### PR TITLE
docs(changelog): backfill the #60–155 gap from git history

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,43 +5,123 @@ Versions correspond to git tags (`v*`) and apply to the entire monorepo.
 
 ## [Unreleased]
 
-> Note: entries between PR #59 and #156 were not recorded here as they merged;
-> the list below resumes changelog coverage from the CaDecon pre-publication
-> review series (PRs #156–163).
+> This section accumulates every monorepo change since `v2.0.6` (PRs #58–#165);
+> there has been no version tag in this window. Entries for PRs #60–#155 were
+> reconstructed from git history (the changelog had lapsed) and consolidate
+> closely-related PRs into single bullets for readability.
 
 ### Added
 
+- **CaDecon** — a new app for automated calcium deconvolution (the InDeCa
+  algorithm) that estimates the kernel and deconvolution parameters directly
+  from the data, no manual tuning required: app scaffold + data loading +
+  subset UI, the InDeCa compute engine with warm-start, visualization / QC
+  distributions / drill-down, community-database integration, ground-truth
+  overlay, and reaching functional parity with the reference InDeCa
+  implementation (PRs #85, #86, #87, #88, #90, #91, #94)
+- CaDecon convergence redesign — converge in kernel **shape space** (peak time +
+  FWHM asymptote) with median-tail kernel selection (PR #154), plus an
+  **asymptote dashboard** charting the four convergence signals (PR #155);
+  earlier migrated the kernel parameterization from (tau_rise, tau_decay) to
+  (t_peak, FWHM) (PR #104)
 - **CaDecon** bi-exponential fit outcome surfaced as `FitMode`
   (`TwoComponent` / `SlowOnly` / `Degenerate` / `Empty`) on the kernel result;
   Python `fit_biexponential` now returns an 8-tuple (trailing `fit_mode` string)
   and `BiexpFitResult` gained a `fit_mode` field; KernelDisplay warns when
   subset fits are degenerate (PR #162)
+- **`calab` Python package** greatly expanded — PyO3 bindings, CaImAn/Minian
+  loaders, browser bridge, and a CLI (PR #66); CaDecon Python bridge with
+  config, autorun, progress, and auto-export (PRs #108, #109); headless-browser
+  batch mode + InDeCa PyO3 bindings (PR #110)
+- Shared Rust **simulation module** producing synthetic ground-truth traces,
+  exposed to both Python and WASM (PR #113)
+- **Usage-analytics pipeline + admin dashboard** with breakdowns and bulk
+  moderation (PRs #62, #69), extended to track CaDecon submissions (PR #93)
+- Shared **auth menu** in the header across all CaLab apps (PR #61)
+- Community: highlight your own submissions in the scatter plot (PR #63);
+  DataSource tracking + bridge export button & heartbeat detection (PR #67)
+- Solver: banded AR(2) O(T) convolution + box constraint (PR #78); peak-seeded
+  initial-kernel auto-estimation (PR #103); an independent fast component in the
+  bi-exponential fit (PR #105); a `skip` parameter for bi-exponential fitting
+  (PR #99)
+- Dynamic worker-pool scaling with a URL override (PR #77)
 - Shared uPlot chart primitives in `@calab/ui/chart` — colorblind-safe
   Okabe-Ito palette (`TRACE_COLORS`, `GROUND_TRUTH_COLORS`, `KERNEL_FIT_COLORS`,
   `METRIC_COLORS`, `subsetColor`), viridis colormap (`VIRIDIS_LUT`,
   `viridisRGB`/`viridisCss`), tick math (`niceTicks`), and axis/cursor/range
   helpers (`chartAxis`, `labeledAxis`, `syncCursor`, `safeRange`) (PRs #158, #159, #160)
+- Chart/UX: transient-zone visual indicator (PR #81); draggable minimap edges on
+  the trace overview (PR #145)
+- Tutorials: CaDecon tutorial set (PR #151); Python Package tutorial (PR #68);
+  Python syntax highlighting in code blocks (PR #75)
+- Sphinx + ReadTheDocs documentation site for the Python package (PR #115)
 - Comprehensive README files across all packages and apps (PR #58)
 
 ### Changed
 
+- Moved the Rust solver to `crates/solver/` with dual WASM (`jsbindings`) /
+  PyO3 (`pybindings`) Cargo features (PR #65)
+- Made `@calab/community` app-agnostic (PR #60)
 - **CaDecon** raster overview uses the shared viridis colormap and drops the
   intensity colorbar (activity is assumed to span 0→full; absolute values are
   not meaningful) (PR #159)
+- Replaced the export-to-Python page with a dismissible modal (PR #79)
+- CaDecon left-sidebar layout/UX (PR #89); convergence-UI improvements and
+  kernel-estimation groundwork (PR #94)
+- CaTune: log-scale DualRangeSlider, card-grid fix, tutorial baseline docs (PR #96)
+- Performance: FISTA pipeline (SIMD, loop fusion, Fenwick baseline) (PR #92);
+  CaDecon iteration hot paths (PR #107); solver cleanup/dedup/optimize (PR #106);
+  snappier Peak/FWHM slider drag (PR #134)
 - `calab-solver` tuning-constant hygiene: introduced `SeedConfig`, shared
   `baseline::DEFAULT_BASELINE_QUANTILE`, and a named `BASELINE_EMA_WEIGHT`;
   deduplicated the bi-exponential fast-component grid bounds so the grid search
   and golden-section refinement cannot drift (no behavior change) (PR #163)
-- Repo hygiene: ignore local Python virtualenvs (`.venv*/`) (PR #156)
-- Improved tutorial terminology and scientific accuracy (PR #59)
+- Tooling: ESLint/Prettier/lint-surface cleanup (PR #120); prune unused exports
+  and internalize test-only surface (PR #125); bump GHA for Node 24 and clear
+  reactivity lint (PR #133); gitignore the whole `.claude/` directory (PR #135);
+  ignore local Python virtualenvs `.venv*/` (PR #156)
+- CI: Rust + Python lint/type jobs, a build matrix, and SHA-pinned actions
+  (PR #124)
+- Tests: smoke / export-roundtrip / sub-frame-timing / warm-start quick-wins
+  (PR #127); CaDecon iteration-manager state transitions (PR #128); iteration-
+  store & multi-cell-store reactivity (PR #129); geo-session edge function +
+  RLS policy matrix (PR #130); bridge timeout & mid-run crash detection (PR #131)
+- Documentation: separated CaTune and CaDecon into dedicated guides (PR #117);
+  promoted CaDecon to stable + root README update (PR #118); reviewed/improved
+  all Python docs (PR #116); improved tutorial terminology and scientific
+  accuracy (PR #59); reconciled repo docs with the review series (PR #164) and
+  aligned the CaDecon tutorials with it (PR #165)
 
 ### Fixed
 
+- Codebase-wide quality sweep — 26 fixes (PR #64)
+- Address pre-merge audit findings — WASM drift, RLS PII, FFI panics, config,
+  tests (PR #150)
 - `calab-solver` FFI boundaries (WASM and PyO3) reject non-finite (NaN/Inf)
   input traces with an explicit error instead of returning garbage results
   (PR #161)
-- Banded AR(2) forward model aligned via a one-sample source delay so the
-  reconvolution matches the double-exponential kernel (PR #157)
+- Solver: corrected a binning-induced time offset in iterative kernel fitting
+  (PR #102); golden-section refinement bug fix (PR #147); banded AR(2) forward
+  model aligned via a one-sample source delay so the reconvolution matches the
+  double-exponential kernel (PR #157)
+- CaDecon: correct per-subset kernel attribution + init/variance robustness
+  (PR #153)
+- CaTune: minimap no longer pushes the zoom window off-screen (PRs #70, #82);
+  clamp rise/decay sliders to prevent a negative kernel (PR #83); GT marker
+  alignment + spectrum/zoom-window perf sweep (PR #142); repair tutorial
+  highlighting after the Peak/FWHM migration (PR #143)
+- Analytics: reliable session-duration tracking via heartbeat (PR #84)
+- Headless: prevent resource leaks on browser start/close failures (PR #121)
+- Logic + UX polish — tau constraints, bridge errors, reactivity (PR #126)
+- Community: show bridge/training submissions and hide demo presets under
+  User data (PR #152)
+- CI deploy: bump the install-action pin to fix a wasm-pack 404 (PR #148)
+
+### Security
+
+- Hardened the bridge URL, added localhost bridge auth, and secured the
+  geo-session edge function (PR #122)
+- Locked down analytics row-level security (PR #123)
 
 ## [2.0.6] - 2026-02-19
 


### PR DESCRIPTION
The repo `CHANGELOG.md` had lapsed after PR #59 — PRs **#60–#155** (and my two docs PRs #164/#165) were never recorded. This reconstructs the full `[Unreleased]` section from git merge history so it accounts for **every monorepo change since the `v2.0.6` tag** (PRs #58–#165), grouped Keep-a-Changelog style.

## Method
- Recovered the merged-PR set by parsing merge-commit subjects/bodies (`Merge pull request #N … :: <title>`), 70 PRs in the #60–#155 range; cross-checked squash-merges for the numeric gaps (the missing numbers are closed-unmerged PRs).
- Consolidated closely-related PRs into single readable bullets (e.g. the CaDecon app spans #85–#91,#94) while **citing all 70 recovered PR numbers** — verified by set-diff that none were dropped.
- Folded in the already-curated review-series entries (#156–163) and added #164/#165.

## What's now recorded (highlights)
- **CaDecon** app + convergence redesign (#85–#91, #94, #104, #154, #155, #162)
- **`calab` Python package** expansion — PyO3, loaders, bridge, CLI, headless (#66, #108–#110)
- Shared Rust **simulation module** (#113); dual-target `crates/solver/` move (#65)
- **Analytics + admin dashboard** (#62, #69, #93); shared **auth menu** (#61)
- **Security** hardening — bridge/localhost auth, geo-session, analytics RLS (#122, #123)
- **CI + test** build-out (#124, #127–#131) and tooling cleanup (#120, #125, #133, #135)
- Solver features/fixes — banded AR(2) (#78), peak-seed (#103), fast component (#105), time-offset (#102), golden refinement (#147)

Categories: **Added / Changed / Fixed / Security**. A note at the top explains the reconstruction and that there's been no version tag in this window.

Prettier-clean. Docs-only; the Python Sphinx changelog `{include}` picks these up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)