### PR TITLE
fix(solver): use isolate_lowest_one in the Fenwick tree update

### DIFF
--- a/crates/solver/src/baseline.rs
+++ b/crates/solver/src/baseline.rs
@@ -73,7 +73,7 @@ impl FenwickTree {
         i += 1; // convert to 1-indexed
         while i < self.tree.len() {
             self.tree[i] += delta;
-            i += i & i.wrapping_neg(); // i += lowbit(i)
+            i += i.isolate_lowest_one(); // i += lowbit(i)
         }
     }
 


### PR DESCRIPTION
## What

One-line change in `crates/solver/src/baseline.rs`: the Fenwick tree's `update` now advances with `i.isolate_lowest_one()` instead of `i & i.wrapping_neg()`. Same value, clippy's own suggested spelling.

## Why

The `rust` CI job started failing on unchanged code:

```
error: manual implementation of `isolate_lowest_one`
  --> src/baseline.rs:76:18
   |
76 |             i += i & i.wrapping_neg(); // i += lowbit(i)
   |                  ^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `i.isolate_lowest_one()`
   |
   = note: `-D clippy::manual-isolate-lowest-one` implied by `-D warnings`
```

`manual_isolate_lowest_one` is new in clippy 1.98. `.github/workflows/ci.yml` pins `dtolnay/rust-toolchain` by SHA, but that action resolves *latest stable* at run time, so the toolchain moved under us between 2026-08-20 (rust job green) and 2026-08-21 (rust job red) with no commits in between. `-D warnings` turns the new lint into a hard error, so this blocks `main` and every open PR — #172 hit it first.

This was the only occurrence in the repo (`grep -rn wrapping_neg crates/`).

## Verification

CI on this PR is the check that matters — I have no Rust toolchain locally, so I have not compiled it here. `cargo clippy --no-default-features --features jsbindings -- -D warnings` and `cargo test --no-default-features --features jsbindings` are what the `rust` job runs.

If the toolchain drift is worth preventing rather than chasing, a follow-up could pin an explicit version in `rust-toolchain.toml` (currently `channel = "stable"`) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)