### PR TITLE
ci(python): build abi3 wheels, repair the publish matrix, smoke-test the result

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'   # abi3 floor; the wheel it emits runs on 3.11+
+          python-version: '3.11' # abi3 floor; the wheel it emits runs on 3.11+
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -163,9 +163,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install from the wheel only
+      - name: Install the built wheel (never from PyPI)
         shell: bash
-        run: "python -m pip install --only-binary=:all: --find-links dist calab"
+        run: |
+          # Runtime deps come from PyPI...
+          python -m pip install --only-binary=:all: numpy pydantic
+          # ...but calab itself MUST be the wheel we just built. --no-index is
+          # load-bearing: dispatch runs carry the 0.0.0 placeholder version, so
+          # without it pip resolves calab from PyPI (a higher version always
+          # wins) and this job silently green-lights an already-released build
+          # instead of the one under test.
+          python -m pip install --no-index --no-deps --find-links dist calab
 
       - name: Exercise the Rust extension
         shell: bash
@@ -174,10 +182,18 @@ jobs:
           import sys
           import numpy as np
           import calab
-          from calab import build_kernel, run_deconvolution
+          from calab import _solver, build_kernel, run_deconvolution
 
           print(f"python  {sys.version.split()[0]}")
           print(f"calab   {calab.__version__}")
+
+          # Prove we loaded the compiled abi3 extension and not a pure-Python
+          # build. calab 0.1.0 on PyPI is py3-none-any with no _solver at all,
+          # so this is the assertion that catches a resolver falling back to
+          # the index.
+          ext = _solver.__file__ or ""
+          assert ext.endswith((".so", ".pyd", ".dylib")), f"not a compiled extension: {ext!r}"
+          print(f"solver  {ext.rsplit('/', 1)[-1].rsplit(chr(92), 1)[-1]}")
 
           k = build_kernel(0.1, 0.5, 30.0)
           assert k.ndim == 1 and k.size > 0, f"bad kernel shape: {k.shape}"

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -57,12 +57,20 @@ jobs:
         run: .venv/bin/pytest -m "not integration"
         working-directory: python
 
+  # One abi3 wheel per platform: `abi3-py311` (crates/solver/Cargo.toml) targets
+  # CPython's stable ABI, so a single cp311-abi3 wheel covers 3.11 and every
+  # later interpreter. That's why there is no python-version axis here.
+  #
+  # The `include` entries are deliberately the ONLY matrix keys. Adding a base
+  # axis alongside them does NOT create a cross product: each include applies to
+  # every combination and the last one wins, silently collapsing the whole job
+  # to windows-latest/x64. See "Expanding or adding matrix configurations" in
+  # the GitHub Actions matrix docs.
   build-wheels:
     needs: test
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
         include:
           - os: ubuntu-latest
             target: x86_64
@@ -87,20 +95,20 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'   # abi3 floor; the wheel it emits runs on 3.11+
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features pybindings -i python${{ matrix.python-version }}
+          args: --release --out dist --features pybindings
           sccache: 'true'
           manylinux: auto
           working-directory: python
 
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: python/dist
 
   build-sdist:
@@ -127,8 +135,14 @@ jobs:
           name: wheels-sdist
           path: python/dist
 
+  # Tag-gated. `Set version from tag` above is itself tag-gated, so on a
+  # workflow_dispatch run the version stays at the 0.0.0 placeholder — without
+  # this guard a manual dry run would publish `calab 0.0.0` to PyPI, which can
+  # never be re-uploaded or reused. Dispatch builds the wheels and uploads them
+  # as artifacts; only a `py/v*` tag actually publishes.
   publish:
     needs: [build-wheels, build-sdist]
+    if: startsWith(github.ref, 'refs/tags/py/v')
     runs-on: ubuntu-latest
     environment: pypi
     steps:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -135,13 +135,80 @@ jobs:
           name: wheels-sdist
           path: python/dist
 
+  # Installs the built wheel on every interpreter the abi3 tag claims to cover
+  # and runs a real computation through the Rust extension.
+  #
+  # This is the check whose absence let calab ship cp312-only wheels for four
+  # releases: the `test` job compiles from source, so it proves the code works
+  # on 3.11-3.13 — not that a *published wheel* is installable. `--only-binary`
+  # is load-bearing: without it pip would quietly fall back to the sdist and
+  # build from source, which is the exact failure this job exists to catch.
+  smoke-test-wheels:
+    needs: build-wheels
+    name: smoke py${{ matrix.python-version }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install from the wheel only
+        shell: bash
+        run: "python -m pip install --only-binary=:all: --find-links dist calab"
+
+      - name: Exercise the Rust extension
+        shell: bash
+        run: |
+          python - <<'PY'
+          import sys
+          import numpy as np
+          import calab
+          from calab import build_kernel, run_deconvolution
+
+          print(f"python  {sys.version.split()[0]}")
+          print(f"calab   {calab.__version__}")
+
+          k = build_kernel(0.1, 0.5, 30.0)
+          assert k.ndim == 1 and k.size > 0, f"bad kernel shape: {k.shape}"
+          assert np.all(np.isfinite(k)), "kernel has non-finite values"
+
+          # A clean synthetic trace: two well-separated spikes convolved with
+          # the kernel. Deconvolution must recover non-negative activity that
+          # is sparser than the input.
+          rng = np.random.default_rng(0)
+          spikes = np.zeros(600, dtype=np.float32)
+          spikes[[150, 400]] = 1.0
+          trace = np.convolve(spikes, k, mode="full")[:600].astype(np.float32)
+          trace += rng.normal(0, 0.01, trace.size).astype(np.float32)
+
+          act = run_deconvolution(trace, 30.0, 0.1, 0.5, 0.1)
+          act = np.asarray(act).ravel()
+          assert act.size == trace.size, f"size mismatch: {act.size} vs {trace.size}"
+          assert np.all(np.isfinite(act)), "solver returned non-finite values"
+          assert act.min() >= -1e-6, f"nonneg constraint violated: min={act.min()}"
+          assert act.max() > 0, "solver returned an all-zero solution"
+          print(f"kernel  {k.size} taps, activity peak {act.max():.4f}")
+          print("OK")
+          PY
+
   # Tag-gated. `Set version from tag` above is itself tag-gated, so on a
   # workflow_dispatch run the version stays at the 0.0.0 placeholder — without
   # this guard a manual dry run would publish `calab 0.0.0` to PyPI, which can
   # never be re-uploaded or reused. Dispatch builds the wheels and uploads them
   # as artifacts; only a `py/v*` tag actually publishes.
   publish:
-    needs: [build-wheels, build-sdist]
+    needs: [build-wheels, build-sdist, smoke-test-wheels]
     if: startsWith(github.ref, 'refs/tags/py/v')
     runs-on: ubuntu-latest
     environment: pypi

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -22,7 +22,12 @@ serde-wasm-bindgen = { version = "0.6", optional = true }
 serde_json = { version = "1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+# `abi3-py311` builds against CPython's stable ABI, so one wheel per platform
+# serves 3.11 and every later interpreter. Without it, each new CPython release
+# has no matching wheel and pip falls back to this sdist — which forces a Rust
+# toolchain download on the user's machine. Keep in sync with
+# `requires-python` in python/pyproject.toml.
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py311"], optional = true }
 numpy = { version = "0.23", optional = true }
 
 [dev-dependencies]

--- a/python/docs/installation.md
+++ b/python/docs/installation.md
@@ -8,7 +8,9 @@ pip install calab
 
 This installs the core package with numpy, pydantic, and the compiled Rust solver extension. You get deconvolution, simulation, and the interactive `tune()` bridge out of the box.
 
-Requires **Python 3.10+**.
+Requires **Python 3.11+**. Wheels are built against CPython's stable ABI
+(`cp311-abi3`), so a single wheel per platform covers 3.11 and every later
+release — including ones published after this version of CaLab.
 
 ## Optional dependencies
 


### PR DESCRIPTION
## Why

`calab` has only ever shipped **cp312** wheels. Every other interpreter falls back to the sdist — which is a maturin/PyO3 extension, so pip pulls a Rust toolchain onto the user's machine at install time.

A workshop participant on Python 3.13 hit this last week. Their endpoint security quarantined LLVM's `ld.lld.exe` mid-extraction and rustup died with `os error 2`. The visible symptom was an Artemis/Trojan alert, so it read as an antivirus problem rather than a packaging one.

## What this changes

### abi3 wheels

Build against CPython's stable ABI (`abi3-py311`). One `cp311-abi3` wheel per platform covers 3.11 and every later interpreter, including ones released after this version of calab. **Five wheel jobs instead of fifteen**, and new CPython releases stop triggering source builds for users.

The binding surface is well inside the limited API: one bare `#[pyclass]` (no `dict`, `weakref`, or `subclass`), plain `#[pyfunction]`s, `PyValueError`, and `PyArray1`/`PyReadonlyArray` I/O.

### The 3.11/3.12/3.13 matrix never worked

Added in 3e0fa94, never executed — the last publish run was `py/v0.2.3`, three weeks earlier. It would not have done what it looks like it does:

```yaml
matrix:
  python-version: ['3.11', '3.12', '3.13']
  include:
    - {os: ubuntu-latest,  target: x86_64}
    # ... 4 more
    - {os: windows-latest, target: x64}   # ← last one wins
```

`os` and `target` aren't base-matrix keys, so per GitHub's documented rule each `include` applies to *every* combination and later entries overwrite earlier ones. That expands to **3 windows-latest/x64 jobs, not 15** — silently dropping macOS and Linux wheels, a regression from 0.2.3. The `include` entries are now the only matrix keys, with a comment explaining why an axis must not be re-added.

### The publish job had no ref guard

`Set version from tag` is tag-gated, so a `workflow_dispatch` run would have published **`calab 0.0.0`** to PyPI — unrecoverable, since PyPI forbids re-uploading a version. Publishing now requires a `py/v*` tag; dispatch builds wheels as artifacts only.

### Wheel smoke test

`test` builds from source, so it proves the code *compiles* on 3.11–3.13 — not that a published wheel is *installable*. That gap is exactly how cp312-only wheels shipped for four releases with green CI.

New `smoke-test-wheels` job installs the built wheel on 3.11/3.12/3.13/3.14 × Linux/macOS/Windows and runs a real deconvolution through the Rust extension. `publish` now depends on it.

Two details are load-bearing, and the first version of this job got one of them wrong:

- `--no-index` — the local wheel is version `0.0.0` on dispatch runs, so without it pip resolved `calab` from PyPI and installed **0.1.0** (the old py3-none-any release with no Rust extension). It imported fine and all twelve jobs passed green while never touching the wheel under test. Fixed in 3289431.
- `assert calab._solver.__file__` ends in `.so`/`.pyd`/`.dylib` — fails on any pure-Python build, which is precisely the substitution that slipped through.

## Verification

Dispatch run [32808988305](https://github.com/miniscope/CaLab/actions/runs/32808988305) on this branch:

- `test` green on 3.11 / 3.12 / 3.13 — abi3 compiles and imports on all three
- All 5 wheel jobs green, emitting `calab-*-cp311-abi3-{win_amd64,macosx_11_0_arm64,macosx_10_12_x86_64,manylinux_2_17_x86_64,manylinux_2_17_aarch64}.whl`
- `smoke-test-wheels` green across 3.11–3.14 on all three OSes, **including Windows × 3.13** — the participant's exact configuration
- `publish` correctly skipped (dispatch is not a tag)

## Not included

`requirements.lock` in the workshop repo stays on `calab==0.2.3` for this week's workshop. That stack is 3.12-only for unrelated reasons (`scipy==1.18.0` needs `>=3.12`; `ecos==2.0.14` has no wheel past cp312), so this change widens nothing there. It's additive on PyPI and affects no existing pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)